### PR TITLE
Fix stale admin user results and unify User model (remove Admin DTO)

### DIFF
--- a/backend/Glovelly.Api/Endpoints/AdminEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AdminEndpoints.cs
@@ -21,16 +21,6 @@ public static class AdminEndpoints
                 .OrderByDescending(user => user.IsActive)
                 .ThenBy(user => user.Role)
                 .ThenBy(user => user.Email)
-                .Select(user => new AdminUserDto(
-                    user.Id,
-                    user.Email,
-                    user.DisplayName,
-                    user.GoogleSubject,
-                    user.GoogleSubject != null,
-                    user.Role.ToString(),
-                    user.IsActive,
-                    user.CreatedUtc,
-                    user.LastLoginUtc))
                 .ToListAsync();
 
             return Results.Ok(result);
@@ -59,7 +49,7 @@ public static class AdminEndpoints
             db.Users.Add(user);
             await db.SaveChangesAsync();
 
-            return Results.Created($"/admin/users/{user.Id}", ToDto(user));
+            return Results.Created($"/admin/users/{user.Id}", user);
         });
 
         users.MapPut("/{id:guid}", async (
@@ -118,7 +108,7 @@ public static class AdminEndpoints
 
             await db.SaveChangesAsync();
 
-            return Results.Ok(ToDto(user));
+            return Results.Ok(user);
         });
 
         return app;
@@ -178,18 +168,6 @@ public static class AdminEndpoints
             request.IsActive);
     }
 
-    private static AdminUserDto ToDto(User user) =>
-        new(
-            user.Id,
-            user.Email,
-            user.DisplayName,
-            user.GoogleSubject,
-            user.GoogleSubject is not null,
-            user.Role.ToString(),
-            user.IsActive,
-            user.CreatedUtc,
-            user.LastLoginUtc);
-
     private sealed record AdminUserRequest(
         string Email,
         string? DisplayName,
@@ -203,15 +181,4 @@ public static class AdminEndpoints
         string? GoogleSubject,
         UserRole Role,
         bool IsActive);
-
-    private sealed record AdminUserDto(
-        Guid Id,
-        string Email,
-        string? DisplayName,
-        string? GoogleSubject,
-        bool IsEnrolled,
-        string Role,
-        bool IsActive,
-        DateTime CreatedUtc,
-        DateTime? LastLoginUtc);
 }

--- a/backend/Glovelly.Api/Models/User.cs
+++ b/backend/Glovelly.Api/Models/User.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Glovelly.Api.Models;
 
@@ -8,10 +9,13 @@ public sealed class User
     public string? GoogleSubject { get; set; }
     public string Email { get; set; } = string.Empty;
     public string? DisplayName { get; set; }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public UserRole Role { get; set; } = UserRole.User;
     public bool IsActive { get; set; } = true;
     public DateTime CreatedUtc { get; set; }
     public DateTime? LastLoginUtc { get; set; }
+    [NotMapped]
+    public bool IsEnrolled => GoogleSubject is not null;
 
     [JsonIgnore]
     public ICollection<Client> ClientsCreated { get; set; } = new List<Client>();

--- a/frontend/glovelly-web/public/sw.js
+++ b/frontend/glovelly-web/public/sw.js
@@ -29,6 +29,7 @@ self.addEventListener('fetch', (event) => {
   const requestUrl = new URL(event.request.url)
   if (
     requestUrl.pathname.startsWith('/auth') ||
+    requestUrl.pathname.startsWith('/admin') ||
     requestUrl.pathname.startsWith('/clients') ||
     requestUrl.pathname.startsWith('/gigs') ||
     requestUrl.pathname.startsWith('/invoices') ||


### PR DESCRIPTION
### Motivation
- Admin view sometimes showed stale enrollment data because `/admin` API calls were being served from the service worker cache. 
- The codebase had a dedicated `AdminUserDto` projection for admin endpoints which created an unnecessary proxy model surface. 
- The goal was to always fetch fresh admin data and prefer a single shared `User` model unless a strong reason exists for a DTO. 

### Description
- Excluded `/admin` requests from the service worker cache by adding `requestUrl.pathname.startsWith('/admin')` to `public/sw.js` so admin API calls always go to the network. 
- Replaced the `AdminUserDto` projection in `AdminEndpoints` by returning the domain `User` model directly from the GET/POST/PUT admin endpoints and removed the `ToDto` helper and `AdminUserDto` record. 
- Added a computed `User.IsEnrolled` property (annotated `[NotMapped]`) so the front-end still receives an equivalent `isEnrolled` value without a DTO. 
- Enabled string enum serialization for `User.Role` by adding `[JsonConverter(typeof(JsonStringEnumConverter))]` so the role shape matches the previous DTO contract. 

### Testing
- Ran `npm --prefix frontend/glovelly-web run build` which completed successfully. 
- Attempted `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj` but it could not be run in this environment because `dotnet` is not installed (test run failed due to missing runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cc208d18832896a8c002fdda9889)