### PR TITLE
Implement invoice status transitions and invoice detail status controls (issue 21)

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _client;
+
+    public InvoiceStatusEndpointsTests(GlovellyApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task UpdateStatus_WhenTransitionAllowed_PersistsStatusAndAuditFields()
+    {
+        var response = await _client.PutAsJsonAsync($"/invoices/{TestData.FoxInvoiceId}/status", new
+        {
+            status = "Paid",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Paid", updatedInvoice.GetProperty("status").GetString());
+        Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("updatedByUserId").GetGuid());
+        Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("statusUpdatedUtc").ValueKind);
+    }
+
+    [Fact]
+    public async Task UpdateStatus_WhenTransitionNotAllowed_ReturnsValidationProblem()
+    {
+        var makePaidResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.FoxInvoiceId}/status", new
+        {
+            status = "Paid",
+        });
+        makePaidResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.PutAsJsonAsync($"/invoices/{TestData.FoxInvoiceId}/status", new
+        {
+            status = "Cancelled",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Invoice status cannot move from Paid to Cancelled.",
+            problem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
+}

--- a/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
@@ -489,11 +489,55 @@ public static class CrudEndpoints
             invoice.ClientId = request.ClientId;
             invoice.InvoiceDate = request.InvoiceDate;
             invoice.DueDate = request.DueDate;
+            var requestedStatus = request.Status;
+            var statusValidation = ValidateInvoiceStatusTransition(invoice.Status, requestedStatus);
+            if (statusValidation is not null)
+            {
+                return statusValidation;
+            }
+
+            if (invoice.Status != requestedStatus)
+            {
+                invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow;
+            }
+
             invoice.Status = request.Status;
             invoice.Description = request.Description?.Trim();
             invoice.PdfBlob = request.PdfBlob;
             StampUpdate(invoice, currentUserAccessor.TryGetUserId(user));
 
+            await db.SaveChangesAsync();
+
+            return Results.Ok(invoice);
+        });
+
+        group.MapPut("/{id:guid}/status", async (
+            Guid id,
+            InvoiceStatusUpdateRequest request,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var invoice = await db.Invoices.FirstOrDefaultAsync(value => value.Id == id);
+            if (invoice is null)
+            {
+                return Results.NotFound();
+            }
+
+            var statusValidation = ValidateInvoiceStatusTransition(invoice.Status, request.Status);
+            if (statusValidation is not null)
+            {
+                return statusValidation;
+            }
+
+            if (invoice.Status == request.Status)
+            {
+                return Results.Ok(invoice);
+            }
+
+            invoice.Status = request.Status;
+            invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow;
+            StampUpdate(invoice, currentUserAccessor.TryGetUserId(user));
             await db.SaveChangesAsync();
 
             return Results.Ok(invoice);
@@ -1137,4 +1181,34 @@ public static class CrudEndpoints
     {
         invoice.UpdatedByUserId = userId;
     }
+
+    private static IResult? ValidateInvoiceStatusTransition(InvoiceStatus currentStatus, InvoiceStatus requestedStatus)
+    {
+        if (currentStatus == requestedStatus)
+        {
+            return null;
+        }
+
+        var allowed = currentStatus switch
+        {
+            InvoiceStatus.Draft => requestedStatus is InvoiceStatus.Issued or InvoiceStatus.Cancelled,
+            InvoiceStatus.Issued => requestedStatus is InvoiceStatus.Paid or InvoiceStatus.Cancelled or InvoiceStatus.Overdue,
+            InvoiceStatus.Overdue => requestedStatus is InvoiceStatus.Paid or InvoiceStatus.Cancelled,
+            InvoiceStatus.Cancelled => requestedStatus is InvoiceStatus.Draft,
+            InvoiceStatus.Paid => false,
+            _ => false
+        };
+
+        if (allowed)
+        {
+            return null;
+        }
+
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["status"] = [$"Invoice status cannot move from {currentStatus} to {requestedStatus}."]
+        });
+    }
+
+    private sealed record InvoiceStatusUpdateRequest(InvoiceStatus Status);
 }

--- a/backend/Glovelly.Api/Models/Invoice.cs
+++ b/backend/Glovelly.Api/Models/Invoice.cs
@@ -13,6 +13,7 @@ public sealed class Invoice
     public DateOnly InvoiceDate { get; set; }
     public DateOnly DueDate { get; set; }
     public InvoiceStatus Status { get; set; } = InvoiceStatus.Draft;
+    public DateTimeOffset? StatusUpdatedUtc { get; set; }
     public string? Description { get; set; }
     public byte[]? PdfBlob { get; set; }
 

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -98,13 +98,15 @@ type InvoiceLine = {
   isSystemGenerated: boolean
 }
 
+type InvoiceStatus = 'Draft' | 'Issued' | 'Paid' | 'Overdue' | 'Cancelled'
+
 type Invoice = {
   id: string
   invoiceNumber: string
   clientId: string
   invoiceDate: string
   dueDate: string
-  status: 'Draft' | 'Issued' | 'Paid' | 'Cancelled'
+  status: InvoiceStatus
   description: string | null
   pdfBlob: string | null
   total: number
@@ -258,6 +260,21 @@ function formatDate(value: string) {
 
 function formatGigStatus(status: GigStatus) {
   return status === 'Confirmed' ? 'Planned' : status
+}
+
+function getAllowedInvoiceStatusTransitions(status: InvoiceStatus) {
+  switch (status) {
+    case 'Draft':
+      return ['Issued', 'Cancelled'] as InvoiceStatus[]
+    case 'Issued':
+      return ['Paid', 'Overdue', 'Cancelled'] as InvoiceStatus[]
+    case 'Overdue':
+      return ['Paid', 'Cancelled'] as InvoiceStatus[]
+    case 'Cancelled':
+      return ['Draft'] as InvoiceStatus[]
+    case 'Paid':
+      return [] as InvoiceStatus[]
+  }
 }
 
 function getStoredThemePreference(): ThemePreference {
@@ -1623,6 +1640,41 @@ function App() {
     }
   }
 
+  const handleInvoiceStatusChange = async (invoice: Invoice, status: InvoiceStatus) => {
+    if (invoice.status === status) {
+      return
+    }
+
+    setIsInvoiceLoading(true)
+    setInvoiceStatus(`Updating ${invoice.invoiceNumber} to ${status}...`)
+
+    try {
+      const response = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}/status`), {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ status }),
+      })
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const fieldError = problem?.errors?.status?.[0]
+        throw new Error(fieldError ?? problem?.detail ?? problem?.title ?? 'Unable to update status.')
+      }
+
+      const updatedInvoice = (await response.json()) as Invoice
+      setInvoices((current) =>
+        current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
+      )
+      setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} is now ${updatedInvoice.status}.`)
+    } catch (error) {
+      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to update invoice status.')
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
   if (isCheckingSession) {
     return (
       <main className="app-shell auth-shell">
@@ -2494,7 +2546,25 @@ function App() {
                   </article>
                   <article>
                     <p className="detail-label">Status</p>
-                    <strong>{selectedInvoice.status}</strong>
+                    <div className="field-with-inline-help">
+                      <select
+                        value={selectedInvoice.status}
+                        onChange={(event) =>
+                          void handleInvoiceStatusChange(
+                            selectedInvoice,
+                            event.target.value as InvoiceStatus
+                          )
+                        }
+                        disabled={isInvoiceLoading}
+                      >
+                        <option value={selectedInvoice.status}>{selectedInvoice.status}</option>
+                        {getAllowedInvoiceStatusTransitions(selectedInvoice.status).map((statusOption) => (
+                          <option key={statusOption} value={statusOption}>
+                            {statusOption}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
                   </article>
                   <article>
                     <p className="detail-label">Invoice date</p>


### PR DESCRIPTION
### Motivation
- Prevent invalid invoice lifecycle transitions and record when a status change occurs so invoice state is explicit and auditable.
- Provide a small targeted API surface to change invoice status and a UI control so users can move invoices through allowed states without editing the whole invoice.

### Description
- Add `StatusUpdatedUtc` to `Invoice` to record when the invoice status last changed.
- Enforce transition rules server-side via `ValidateInvoiceStatusTransition` and apply them from both full invoice `PUT /invoices/{id}` updates and a new targeted endpoint `PUT /invoices/{id}/status`.
- Create `InvoiceStatusUpdateRequest` for the new status endpoint and update the `StampUpdate` behaviour to set audit fields on status changes.
- Add `InvoiceStatusEndpointsTests` to validate allowed and disallowed transitions and to assert `updatedByUserId` and `statusUpdatedUtc` are persisted.
- Update the SPA (`frontend/glovelly-web/src/App.tsx`) to include the extended status set, show only allowed next transitions in the invoice detail view, and call the new `PUT /invoices/{id}/status` endpoint when a change is requested.

### Testing
- Frontend build succeeded with `npm --prefix frontend/glovelly-web run build` (production build completed).
- New API integration tests were added at `backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs` but `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj` could not be executed in this environment because `dotnet` is not installed.
- The change includes automated tests intended to cover allowed and rejected status transitions and audit field population, which should pass when run in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d3e32d2c8328b0d273df25ecba70)