### PR TITLE
Validate invoice status transitions, add status update endpoint, and wire up UI status picker

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Glovelly.Api.Models;
 using Glovelly.Api.Tests.Infrastructure;
 using Xunit;
 
@@ -52,5 +53,31 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         Assert.Equal(
             "Invoice status cannot move from Paid to Cancelled.",
             problem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
+
+    [Fact]
+    public async Task UpdateStatus_WhenInvoiceHasLines_ResponseKeepsLineTotals()
+    {
+        var createLineResponse = await _client.PostAsJsonAsync("/invoice-lines", new
+        {
+            invoiceId = TestData.FoxInvoiceId,
+            sortOrder = 1,
+            type = InvoiceLineType.PerformanceFee,
+            description = "Headline performance",
+            quantity = 2m,
+            unitPrice = 150m,
+        });
+        createLineResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.PutAsJsonAsync($"/invoices/{TestData.FoxInvoiceId}/status", new
+        {
+            status = "Paid",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(300m, updatedInvoice.GetProperty("total").GetDecimal());
+        Assert.Single(updatedInvoice.GetProperty("lines").EnumerateArray());
     }
 }

--- a/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
@@ -518,7 +518,9 @@ public static class CrudEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor) =>
         {
-            var invoice = await db.Invoices.FirstOrDefaultAsync(value => value.Id == id);
+            var invoice = await db.Invoices
+                .Include(value => value.Lines)
+                .FirstOrDefaultAsync(value => value.Id == id);
             if (invoice is null)
             {
                 return Results.NotFound();


### PR DESCRIPTION
### Motivation

- Enforce and centralise invoice status transition rules so invalid state changes are rejected and status change metadata is tracked.

### Description

- Add `StatusUpdatedUtc` to `Invoice` and set it whenever the status changes during updates. 
- Introduce `ValidateInvoiceStatusTransition` and apply it to both the general invoice update and a new dedicated status endpoint at `PUT /invoices/{id}/status` implemented with `InvoiceStatusUpdateRequest`.
- Add backend behaviour to stamp updates and return validation problems when transitions are not allowed, and include the invoice `Lines` when updating status so totals are preserved in responses. 
- Add frontend types and functions (`InvoiceStatus`, `getAllowedInvoiceStatusTransitions`, `handleInvoiceStatusChange`) plus a select control in the invoice detail pane to change status and call the new API route.
- Add new xUnit tests in `InvoiceStatusEndpointsTests.cs` covering allowed transitions, disallowed transitions returning validation problems, and preserving line totals after status change.

### Testing

- Ran backend unit tests with `dotnet test` for the `Glovelly.Api.Tests` project including the new `InvoiceStatusEndpointsTests`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d3e32d2c8328b0d273df25ecba70)