### PR TITLE
Add invoice re-issue endpoint, model fields, migration and UI

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -80,4 +80,31 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         Assert.Equal(300m, updatedInvoice.GetProperty("total").GetDecimal());
         Assert.Single(updatedInvoice.GetProperty("lines").EnumerateArray());
     }
+
+    [Fact]
+    public async Task Reissue_WhenInvoiceExists_RegeneratesPdfAndLogsActionWithoutChangingFinancials()
+    {
+        var createLineResponse = await _client.PostAsJsonAsync("/invoice-lines", new
+        {
+            invoiceId = TestData.RiversideInvoiceId,
+            sortOrder = 1,
+            type = InvoiceLineType.PerformanceFee,
+            description = "Headline performance",
+            quantity = 2m,
+            unitPrice = 150m,
+        });
+        createLineResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.PostAsync($"/invoices/{TestData.RiversideInvoiceId}/reissue", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(300m, updatedInvoice.GetProperty("total").GetDecimal());
+        Assert.Equal(1, updatedInvoice.GetProperty("reissueCount").GetInt32());
+        Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("lastReissuedByUserId").GetGuid());
+        Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("lastReissuedUtc").ValueKind);
+        Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("pdfBlob").ValueKind);
+        Assert.Single(updatedInvoice.GetProperty("lines").EnumerateArray());
+    }
 }

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -127,6 +127,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
             entity.Property(invoice => invoice.Status)
                 .HasConversion<string>()
                 .HasMaxLength(50);
+            entity.Property(invoice => invoice.ReissueCount);
             entity.Property(invoice => invoice.Description)
                 .HasMaxLength(4000);
             entity.Property(invoice => invoice.PdfBlob);

--- a/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
@@ -545,6 +545,53 @@ public static class CrudEndpoints
             return Results.Ok(invoice);
         });
 
+        group.MapPost("/{id:guid}/reissue", async (
+            Guid id,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var invoice = await db.Invoices
+                .Include(value => value.Lines)
+                .FirstOrDefaultAsync(value => value.Id == id);
+
+            if (invoice is null)
+            {
+                return Results.NotFound();
+            }
+
+            var client = await db.Clients
+                .AsNoTracking()
+                .FirstOrDefaultAsync(value => value.Id == invoice.ClientId);
+
+            if (client is null)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["clientId"] = ["Client does not exist."]
+                });
+            }
+
+            if (string.IsNullOrWhiteSpace(client.Email))
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["recipient"] = ["Invoice recipient email is missing."]
+                });
+            }
+
+            invoice.PdfBlob = GenerateInvoicePdf(invoice, client, null, invoice.Lines.ToList());
+            invoice.ReissueCount += 1;
+            invoice.LastReissuedUtc = DateTimeOffset.UtcNow;
+            invoice.LastReissuedByUserId = userId;
+            StampUpdate(invoice, userId);
+
+            await db.SaveChangesAsync();
+
+            return Results.Ok(invoice);
+        });
+
         group.MapDelete("/{id:guid}", async (Guid id, AppDbContext db) =>
         {
             var invoice = await db.Invoices.FirstOrDefaultAsync(invoice => invoice.Id == id);
@@ -1027,7 +1074,7 @@ public static class CrudEndpoints
     private static byte[] GenerateInvoicePdf(
         Invoice invoice,
         Client client,
-        Gig gig,
+        Gig? gig,
         IReadOnlyCollection<InvoiceLine> lines)
     {
         var rows = new List<string>
@@ -1073,7 +1120,7 @@ public static class CrudEndpoints
         }
 
         rows.Add(string.Empty);
-        rows.Add(invoice.Description ?? BuildInvoiceDescription(gig));
+        rows.Add(invoice.Description ?? (gig is null ? "In respect of services rendered." : BuildInvoiceDescription(gig)));
         rows.Add(string.Empty);
         rows.Add("Line items:");
 

--- a/backend/Glovelly.Api/Models/Invoice.cs
+++ b/backend/Glovelly.Api/Models/Invoice.cs
@@ -14,6 +14,9 @@ public sealed class Invoice
     public DateOnly DueDate { get; set; }
     public InvoiceStatus Status { get; set; } = InvoiceStatus.Draft;
     public DateTimeOffset? StatusUpdatedUtc { get; set; }
+    public int ReissueCount { get; set; }
+    public DateTimeOffset? LastReissuedUtc { get; set; }
+    public Guid? LastReissuedByUserId { get; set; }
     public string? Description { get; set; }
     public byte[]? PdfBlob { get; set; }
 

--- a/docs/migrations/20260420_issue22_reissue_columns_postgres.sql
+++ b/docs/migrations/20260420_issue22_reissue_columns_postgres.sql
@@ -1,0 +1,16 @@
+-- One-time migration for Issue #22 (invoice re-issue metadata)
+-- Target: PostgreSQL
+-- Safe to run once in production before deploying the API changes.
+
+BEGIN;
+
+ALTER TABLE "Invoices"
+    ADD COLUMN IF NOT EXISTS "ReissueCount" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "Invoices"
+    ADD COLUMN IF NOT EXISTS "LastReissuedUtc" timestamp with time zone NULL;
+
+ALTER TABLE "Invoices"
+    ADD COLUMN IF NOT EXISTS "LastReissuedByUserId" uuid NULL;
+
+COMMIT;

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -107,6 +107,8 @@ type Invoice = {
   invoiceDate: string
   dueDate: string
   status: InvoiceStatus
+  reissueCount: number
+  lastReissuedUtc: string | null
   description: string | null
   pdfBlob: string | null
   total: number
@@ -1675,6 +1677,42 @@ function App() {
     }
   }
 
+  const handleInvoiceReissue = async (invoice: Invoice) => {
+    const shouldProceed = window.confirm(
+      `Re-issue ${invoice.invoiceNumber}? This will regenerate the document and log the action.`
+    )
+    if (!shouldProceed) {
+      return
+    }
+
+    setIsInvoiceLoading(true)
+    setInvoiceStatus(`Re-issuing ${invoice.invoiceNumber}...`)
+
+    try {
+      const response = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}/reissue`), {
+        method: 'POST',
+      })
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const fieldError = problem?.errors?.recipient?.[0]
+        throw new Error(fieldError ?? problem?.detail ?? problem?.title ?? 'Unable to re-issue invoice.')
+      }
+
+      const updatedInvoice = (await response.json()) as Invoice
+      setInvoices((current) =>
+        current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
+      )
+
+      const reissuedAt = formatDateTime(updatedInvoice.lastReissuedUtc)
+      setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} re-issued at ${reissuedAt}.`)
+    } catch (error) {
+      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to re-issue invoice.')
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
   if (isCheckingSession) {
     return (
       <main className="app-shell auth-shell">
@@ -2527,6 +2565,14 @@ function App() {
               </div>
               <div className="actions">
                 <button
+                  className="ghost-button"
+                  onClick={() => selectedInvoice && void handleInvoiceReissue(selectedInvoice)}
+                  type="button"
+                  disabled={!selectedInvoice || isInvoiceLoading}
+                >
+                  Re-issue
+                </button>
+                <button
                   className="primary-button"
                   onClick={() => selectedInvoice && void handleDownloadInvoicePdf(selectedInvoice)}
                   type="button"
@@ -2585,6 +2631,14 @@ function App() {
                   <article>
                     <p className="detail-label">Total</p>
                     <strong>{formatCurrency(selectedInvoice.total)}</strong>
+                  </article>
+                  <article>
+                    <p className="detail-label">Re-issued</p>
+                    <strong>{selectedInvoice.reissueCount} times</strong>
+                  </article>
+                  <article>
+                    <p className="detail-label">Last re-issue</p>
+                    <strong>{formatDateTime(selectedInvoice.lastReissuedUtc)}</strong>
                   </article>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Support re-issuing invoices so the PDF can be regenerated and the action logged without altering financial totals.
- Surface re-issue metadata in the API and UI so users can see how many times and when an invoice was re-issued.

### Description
- Add a new POST endpoint `POST /invoices/{id}/reissue` that validates the invoice and client, regenerates the PDF, increments `ReissueCount`, sets `LastReissuedUtc` and `LastReissuedByUserId`, stamps the update, and returns the invoice.
- Extend the `Invoice` model with `ReissueCount`, `LastReissuedUtc`, and `LastReissuedByUserId`, and register `ReissueCount` in `AppDbContext` mapping.
- Add a one-time PostgreSQL migration script `docs/migrations/20260420_issue22_reissue_columns_postgres.sql` to add the new columns to the `Invoices` table with a default of `0` for `ReissueCount`.
- Tweak `GenerateInvoicePdf` to accept a nullable `Gig` and provide a fallback invoice description when `Gig` is null.
- Update the frontend (`App.tsx`) to include invoice type updates, new invoice fields (`reissueCount`, `lastReissuedUtc`), a `Re-issue` button, and the `handleInvoiceReissue` routine to call the new endpoint and update the UI.
- Add an integration test `Reissue_WhenInvoiceExists_RegeneratesPdfAndLogsActionWithoutChangingFinancials` to `InvoiceStatusEndpointsTests` that asserts the PDF blob, reissue count, last reissued metadata, and that totals/lines remain unchanged.

### Testing
- Ran backend tests with `dotnet test backend/Glovelly.Api.Tests` and the test suite including the new reissue integration test passed.
- Verified the API changes with the added integration test `Reissue_WhenInvoiceExists_RegeneratesPdfAndLogsActionWithoutChangingFinancials` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e9580cc883288b0337226110767a)