### PR TITLE
Reset invoice status to Draft when reissuing

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -95,11 +95,19 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         });
         createLineResponse.EnsureSuccessStatusCode();
 
+        var markPaidResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/status", new
+        {
+            status = "Paid",
+        });
+        markPaidResponse.EnsureSuccessStatusCode();
+
         var response = await _client.PostAsync($"/invoices/{TestData.RiversideInvoiceId}/reissue", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Draft", updatedInvoice.GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("statusUpdatedUtc").ValueKind);
         Assert.Equal(300m, updatedInvoice.GetProperty("total").GetDecimal());
         Assert.Equal(1, updatedInvoice.GetProperty("reissueCount").GetInt32());
         Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("lastReissuedByUserId").GetGuid());

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -95,6 +95,12 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         });
         createLineResponse.EnsureSuccessStatusCode();
 
+        var markIssuedResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/status", new
+        {
+            status = "Issued",
+        });
+        markIssuedResponse.EnsureSuccessStatusCode();
+
         var markPaidResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/status", new
         {
             status = "Paid",

--- a/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
@@ -582,6 +582,8 @@ public static class CrudEndpoints
             }
 
             invoice.PdfBlob = GenerateInvoicePdf(invoice, client, null, invoice.Lines.ToList());
+            invoice.Status = InvoiceStatus.Draft;
+            invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow;
             invoice.ReissueCount += 1;
             invoice.LastReissuedUtc = DateTimeOffset.UtcNow;
             invoice.LastReissuedByUserId = userId;


### PR DESCRIPTION
### Motivation
- Reissuing an invoice should return it to an editable draft state so users can restore and edit a document, but the previous behavior left `Status` unchanged (e.g. `Paid`) which blocked restoring drafts.

### Description
- Update `POST /invoices/{id}/reissue` to set `invoice.Status = InvoiceStatus.Draft` and `invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow` before saving, and add assertions to `InvoiceStatusEndpointsTests.Reissue_WhenInvoiceExists_RegeneratesPdfAndLogsActionWithoutChangingFinancials` that mark an invoice `Paid` first and then assert the reissue returns it to `Draft` and sets `statusUpdatedUtc`.

### Testing
- Added unit assertions in `backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs` to cover the paid->reissue->draft flow, but running `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj --filter "FullyQualifiedName~InvoiceStatusEndpointsTests"` could not be executed here because `dotnet` is not installed in this environment (run locally or in CI to verify passing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64720c64883289edfe32fb20a8bc7)