### PR TITLE
Add manual invoice adjustments and gig expense editing

### DIFF
--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -174,6 +174,90 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task UpdateGig_WithExpenses_ReplacesExpenseCollectionAndReturnsUpdatedGig()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            invoiceId = TestData.FoxInvoiceId,
+            title = "Expense refresh test",
+            date = "2026-06-08",
+            venue = "Assembly Rooms",
+            fee = 180.00m,
+            travelMiles = 0.00m,
+            notes = "Initial expense set",
+            wasDriving = true,
+            status = 1,
+            expenses = new[]
+            {
+                new
+                {
+                    description = "Parking",
+                    amount = 12.00m,
+                },
+            },
+            invoicedAt = (string?)null,
+        });
+
+        createResponse.EnsureSuccessStatusCode();
+
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var gigId = createdGig.GetProperty("id").GetGuid();
+
+        var updateResponse = await _client.PutAsJsonAsync($"/gigs/{gigId}", new
+        {
+            id = gigId,
+            clientId = TestData.FoxAndFinchId,
+            invoiceId = TestData.FoxInvoiceId,
+            title = "Expense refresh test",
+            date = "2026-06-08",
+            venue = "Assembly Rooms",
+            fee = 180.00m,
+            travelMiles = 0.00m,
+            passengerCount = (int?)null,
+            notes = "Updated expense set",
+            wasDriving = true,
+            status = 1,
+            expenses = new[]
+            {
+                new
+                {
+                    description = "Tolls",
+                    amount = 8.50m,
+                },
+                new
+                {
+                    description = "Parking",
+                    amount = 14.00m,
+                },
+            },
+            invoicedAt = createdGig.GetProperty("invoicedAt").GetString(),
+        });
+
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+
+        var updatedGig = await updateResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var updatedExpenses = updatedGig.GetProperty("expenses").EnumerateArray().OrderBy(expense => expense.GetProperty("sortOrder").GetInt32()).ToArray();
+
+        Assert.Equal(2, updatedExpenses.Length);
+        Assert.Equal("Tolls", updatedExpenses[0].GetProperty("description").GetString());
+        Assert.Equal(8.50m, updatedExpenses[0].GetProperty("amount").GetDecimal());
+        Assert.Equal("Parking", updatedExpenses[1].GetProperty("description").GetString());
+        Assert.Equal(14.00m, updatedExpenses[1].GetProperty("amount").GetDecimal());
+
+        var invoiceResponse = await _client.GetAsync($"/invoices/{TestData.FoxInvoiceId}");
+        invoiceResponse.EnsureSuccessStatusCode();
+
+        var invoice = await invoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var lines = invoice.GetProperty("lines").EnumerateArray().Where(line => line.GetProperty("gigId").GetGuid() == gigId).ToArray();
+
+        Assert.Equal(3, lines.Length);
+        Assert.Contains(lines, line => line.GetProperty("description").GetString() == "Performance fee for Expense refresh test (2026-06-08)");
+        Assert.Contains(lines, line => line.GetProperty("description").GetString() == "Tolls");
+        Assert.Contains(lines, line => line.GetProperty("description").GetString() == "Parking");
+    }
+
+    [Fact]
     public async Task CreateGig_WithInvoice_GeneratesMileagePassengerAndExpenseLines()
     {
         var response = await _client.PostAsJsonAsync("/gigs", new

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -13,6 +13,7 @@ namespace Glovelly.Api.Tests.Infrastructure;
 public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
 {
     private readonly string _databaseName = $"glovelly-tests-{Guid.NewGuid()}";
+    private readonly object _databaseResetLock = new();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -31,12 +32,28 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
             });
 
             using var scope = services.BuildServiceProvider().CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-
-            dbContext.Database.EnsureDeleted();
-            dbContext.Database.EnsureCreated();
-            SeedTestData(dbContext);
+            ResetDatabase(scope.ServiceProvider.GetRequiredService<AppDbContext>());
         });
+    }
+
+    public new HttpClient CreateClient()
+    {
+        var client = base.CreateClient();
+
+        lock (_databaseResetLock)
+        {
+            using var scope = Services.CreateScope();
+            ResetDatabase(scope.ServiceProvider.GetRequiredService<AppDbContext>());
+        }
+
+        return client;
+    }
+
+    private static void ResetDatabase(AppDbContext dbContext)
+    {
+        dbContext.Database.EnsureDeleted();
+        dbContext.Database.EnsureCreated();
+        SeedTestData(dbContext);
     }
 
     private static void SeedTestData(AppDbContext dbContext)

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -121,4 +121,57 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("pdfBlob").ValueKind);
         Assert.Single(updatedInvoice.GetProperty("lines").EnumerateArray());
     }
+
+    [Fact]
+    public async Task AddAdjustment_WhenRequestValid_AddsManualAdjustmentLineAndUpdatesInvoiceTotal()
+    {
+        var createLineResponse = await _client.PostAsJsonAsync("/invoice-lines", new
+        {
+            invoiceId = TestData.RiversideInvoiceId,
+            sortOrder = 1,
+            type = InvoiceLineType.PerformanceFee,
+            description = "Headline performance",
+            quantity = 1m,
+            unitPrice = 200m,
+        });
+        createLineResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.PostAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/adjustments", new
+        {
+            amount = -25m,
+            reason = "Goodwill discount",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(175m, updatedInvoice.GetProperty("total").GetDecimal());
+
+        var manualAdjustment = updatedInvoice.GetProperty("lines")
+            .EnumerateArray()
+            .Single(line => line.GetProperty("type").GetString() == "ManualAdjustment");
+
+        Assert.Equal("Manual adjustment: Goodwill discount", manualAdjustment.GetProperty("description").GetString());
+        Assert.Equal(-25m, manualAdjustment.GetProperty("lineTotal").GetDecimal());
+        Assert.Equal(TestAuthContext.UserId, manualAdjustment.GetProperty("createdByUserId").GetGuid());
+        Assert.Equal(JsonValueKind.String, manualAdjustment.GetProperty("createdUtc").ValueKind);
+        Assert.Equal(
+            JsonValueKind.String,
+            manualAdjustment.GetProperty("calculationNotes").ValueKind);
+    }
+
+    [Fact]
+    public async Task AddAdjustment_WhenReasonMissing_ReturnsValidationProblem()
+    {
+        var response = await _client.PostAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/adjustments", new
+        {
+            amount = 25m,
+            reason = "   ",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Adjustment reason is required.", problem.GetProperty("errors").GetProperty("reason")[0].GetString());
+    }
 }

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -149,6 +149,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
         modelBuilder.Entity<InvoiceLine>(entity =>
         {
             entity.HasKey(line => line.Id);
+            entity.Property(line => line.CreatedUtc)
+                .IsRequired();
             entity.Property(line => line.Type)
                 .HasConversion<string>()
                 .HasMaxLength(50);

--- a/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
@@ -316,21 +316,17 @@ public static class CrudEndpoints
                 }
             }
 
-            var normalizedExpenses = NormalizeGigExpenses(request.Expenses);
-            _ = await RemoveSystemGeneratedInvoiceLinesForGigAsync(gig.Id, db);
-
-            if (gig.Expenses.Count > 0)
+            var normalizedExpenses = NormalizeGigExpenses(request.Expenses, preserveIds: false);
+            if (await RemoveSystemGeneratedInvoiceLinesForGigAsync(gig.Id, db))
             {
-                db.GigExpenses.RemoveRange(gig.Expenses.ToList());
+                await db.SaveChangesAsync();
             }
 
-            await db.SaveChangesAsync();
-
-            gig = await db.Gigs
-                .Include(value => value.Expenses)
-                .FirstAsync(value => value.Id == id);
-
             var previousInvoiceId = gig.InvoiceId;
+            var existingExpenses = gig.Expenses
+                .OrderBy(expense => expense.SortOrder)
+                .ThenBy(expense => expense.Description)
+                .ToList();
 
             gig.ClientId = request.ClientId;
             gig.InvoiceId = request.InvoiceId;
@@ -344,12 +340,35 @@ public static class CrudEndpoints
             gig.WasDriving = request.WasDriving;
             gig.Status = request.Status;
             gig.InvoicedAt = ResolveInvoicedAt(request.InvoiceId, previousInvoiceId, gig.InvoicedAt, request.InvoicedAt);
-            gig.Expenses.Clear();
-            foreach (var expense in normalizedExpenses)
-            {
-                gig.Expenses.Add(expense);
-            }
+
             StampUpdate(gig, userId);
+            await db.SaveChangesAsync();
+
+            var sharedExpenseCount = Math.Min(existingExpenses.Count, normalizedExpenses.Count);
+            for (var i = 0; i < sharedExpenseCount; i++)
+            {
+                existingExpenses[i].SortOrder = normalizedExpenses[i].SortOrder;
+                existingExpenses[i].Description = normalizedExpenses[i].Description;
+                existingExpenses[i].Amount = normalizedExpenses[i].Amount;
+            }
+
+            if (existingExpenses.Count > normalizedExpenses.Count)
+            {
+                var expensesToRemove = existingExpenses.Skip(normalizedExpenses.Count).ToList();
+                db.GigExpenses.RemoveRange(expensesToRemove);
+            }
+
+            foreach (var expense in normalizedExpenses.Skip(sharedExpenseCount))
+            {
+                expense.GigId = gig.Id;
+                db.GigExpenses.Add(expense);
+            }
+
+            await db.SaveChangesAsync();
+
+            gig = await db.Gigs
+                .Include(value => value.Expenses)
+                .FirstAsync(value => value.Id == id);
 
             await SyncGeneratedInvoiceLinesForGigAsync(gig, userId, db);
             await db.SaveChangesAsync();
@@ -917,7 +936,7 @@ public static class CrudEndpoints
         return null;
     }
 
-    private static List<GigExpense> NormalizeGigExpenses(ICollection<GigExpense>? expenses)
+    private static List<GigExpense> NormalizeGigExpenses(ICollection<GigExpense>? expenses, bool preserveIds = true)
     {
         if (expenses is null || expenses.Count == 0)
         {
@@ -927,7 +946,7 @@ public static class CrudEndpoints
         return expenses
             .Select((expense, index) => new GigExpense
             {
-                Id = expense.Id == Guid.Empty ? Guid.NewGuid() : expense.Id,
+                Id = preserveIds && expense.Id != Guid.Empty ? expense.Id : Guid.NewGuid(),
                 SortOrder = expense.SortOrder == 0 ? index + 1 : expense.SortOrder,
                 Description = expense.Description.Trim(),
                 Amount = expense.Amount,

--- a/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
@@ -2,6 +2,7 @@ using Glovelly.Api.Auth;
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Microsoft.EntityFrameworkCore;
+using System.Globalization;
 using System.Security.Claims;
 using System.Text;
 
@@ -594,6 +595,60 @@ public static class CrudEndpoints
             return Results.Ok(invoice);
         });
 
+        group.MapPost("/{id:guid}/adjustments", async (
+            Guid id,
+            InvoiceAdjustmentCreateRequest request,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var invoice = await db.Invoices
+                .Include(value => value.Lines)
+                .FirstOrDefaultAsync(value => value.Id == id);
+            if (invoice is null)
+            {
+                return Results.NotFound();
+            }
+
+            var reason = request.Reason?.Trim();
+            if (string.IsNullOrWhiteSpace(reason))
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["reason"] = ["Adjustment reason is required."]
+                });
+            }
+
+            if (request.Amount == 0)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["amount"] = ["Adjustment amount must be non-zero."]
+                });
+            }
+
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var adjustmentLine = new InvoiceLine
+            {
+                Id = Guid.NewGuid(),
+                InvoiceId = invoice.Id,
+                SortOrder = await GetNextSortOrderAsync(invoice.Id, db),
+                Type = InvoiceLineType.ManualAdjustment,
+                Description = $"Manual adjustment: {reason}",
+                Quantity = 1m,
+                UnitPrice = request.Amount,
+                CalculationNotes = BuildAdjustmentAuditNote(userId),
+                IsSystemGenerated = false,
+            };
+            StampCreate(adjustmentLine, userId);
+
+            db.InvoiceLines.Add(adjustmentLine);
+            StampUpdate(invoice, userId);
+            await db.SaveChangesAsync();
+
+            return Results.Ok(invoice);
+        });
+
         group.MapDelete("/{id:guid}", async (Guid id, AppDbContext db) =>
         {
             var invoice = await db.Invoices.FirstOrDefaultAsync(invoice => invoice.Id == id);
@@ -655,6 +710,7 @@ public static class CrudEndpoints
             line.Id = Guid.NewGuid();
             line.Description = line.Description.Trim();
             line.CalculationNotes = line.CalculationNotes?.Trim();
+            line.CreatedUtc = DateTimeOffset.UtcNow;
             line.Invoice = null;
             line.Gig = null;
 
@@ -1233,6 +1289,19 @@ public static class CrudEndpoints
         invoice.UpdatedByUserId = userId;
     }
 
+    private static void StampCreate(InvoiceLine line, Guid? userId)
+    {
+        line.CreatedByUserId = userId;
+        line.CreatedUtc = DateTimeOffset.UtcNow;
+    }
+
+    private static string BuildAdjustmentAuditNote(Guid? userId)
+    {
+        var actor = userId?.ToString() ?? "unknown-user";
+        var timestamp = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+        return $"Created by {actor} at {timestamp}";
+    }
+
     private static IResult? ValidateInvoiceStatusTransition(InvoiceStatus currentStatus, InvoiceStatus requestedStatus)
     {
         if (currentStatus == requestedStatus)
@@ -1262,4 +1331,5 @@ public static class CrudEndpoints
     }
 
     private sealed record InvoiceStatusUpdateRequest(InvoiceStatus Status);
+    private sealed record InvoiceAdjustmentCreateRequest(decimal Amount, string Reason);
 }

--- a/backend/Glovelly.Api/Models/InvoiceLine.cs
+++ b/backend/Glovelly.Api/Models/InvoiceLine.cs
@@ -7,6 +7,8 @@ public sealed class InvoiceLine
 {
     public Guid Id { get; set; }
     public Guid InvoiceId { get; set; }
+    public Guid? CreatedByUserId { get; set; }
+    public DateTimeOffset CreatedUtc { get; set; }
     public int SortOrder { get; set; }
     public InvoiceLineType Type { get; set; }
     public string Description { get; set; } = string.Empty;

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -544,6 +544,33 @@
   margin-top: 12px;
 }
 
+.invoice-adjustment-form {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+  grid-template-columns: minmax(0, 140px) minmax(0, 1fr);
+  align-items: end;
+}
+
+.invoice-adjustment-form label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  min-width: 0;
+}
+
+.invoice-adjustment-form button {
+  grid-column: 1 / -1;
+  justify-self: start;
+}
+
+@media (max-width: 1380px) {
+  .invoice-adjustment-form {
+    grid-template-columns: 1fr;
+  }
+}
+
 .invoice-line-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -801,7 +828,8 @@ button:disabled {
   .form-grid,
   .detail-grid,
   .gig-summary-grid,
-  .draft-grid {
+  .draft-grid,
+  .invoice-adjustment-form {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -544,6 +544,38 @@
   margin-top: 12px;
 }
 
+.gig-expense-list {
+  display: grid;
+  gap: 12px;
+}
+
+.gig-expense-item {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 140px);
+  align-items: end;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: var(--surface-elevated);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
+}
+
+.gig-expense-item label {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.gig-expense-item span {
+  font-size: 0.86rem;
+  color: var(--muted-strong);
+}
+
+.gig-expense-item button {
+  grid-column: 1 / -1;
+  justify-self: start;
+}
+
 .invoice-adjustment-form {
   display: grid;
   gap: 10px;
@@ -829,7 +861,8 @@ button:disabled {
   .detail-grid,
   .gig-summary-grid,
   .draft-grid,
-  .invoice-adjustment-form {
+  .invoice-adjustment-form,
+  .gig-expense-item {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -68,6 +68,20 @@ type ClientSettingsForm = {
 
 type GigStatus = 'Draft' | 'Confirmed' | 'Completed' | 'Cancelled'
 
+type GigExpense = {
+  id: string
+  sortOrder: number
+  description: string
+  amount: number
+}
+
+type GigExpenseForm = {
+  id: string
+  sortOrder: number
+  description: string
+  amount: string
+}
+
 type Gig = {
   id: string
   clientId: string
@@ -83,6 +97,7 @@ type Gig = {
   status: GigStatus
   invoicedAt: string | null
   isInvoiced: boolean
+  expenses: GigExpense[]
 }
 
 type InvoiceLine = {
@@ -126,6 +141,7 @@ type GigForm = {
   notes: string
   wasDriving: boolean
   status: GigStatus
+  expenses: GigExpenseForm[]
 }
 
 type AppSection = 'clients' | 'admin' | 'gigs' | 'invoices'
@@ -173,6 +189,7 @@ const emptyGigForm = (): GigForm => ({
   notes: '',
   wasDriving: true,
   status: 'Confirmed',
+  expenses: [],
 })
 
 const defaultAdminStatus = 'User enrolment tools ready.'
@@ -262,6 +279,19 @@ function formatDate(value: string) {
   }).format(date)
 }
 
+function formatEditableAmount(value: number) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2)
+}
+
+function toGigExpenseForm(expense: GigExpense): GigExpenseForm {
+  return {
+    id: expense.id,
+    sortOrder: expense.sortOrder,
+    description: expense.description,
+    amount: formatEditableAmount(expense.amount),
+  }
+}
+
 function formatGigStatus(status: GigStatus) {
   return status === 'Confirmed' ? 'Planned' : status
 }
@@ -339,6 +369,8 @@ function App() {
   const [gigForm, setGigForm] = useState<GigForm>(emptyGigForm)
   const [gigStatus, setGigStatus] = useState(defaultGigStatus)
   const [isGigLoading, setIsGigLoading] = useState(false)
+  const [gigExpenseAmount, setGigExpenseAmount] = useState('')
+  const [gigExpenseDescription, setGigExpenseDescription] = useState('')
   const [invoices, setInvoices] = useState<Invoice[]>([])
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('')
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
@@ -877,6 +909,8 @@ function App() {
         ? 'Capture the essentials now and we can build invoicing on top later.'
         : 'Create a client first so the gig can be linked correctly.'
     )
+    setGigExpenseAmount('')
+    setGigExpenseDescription('')
   }
 
   const startGigEdit = () => {
@@ -894,8 +928,14 @@ function App() {
       notes: selectedGig.notes ?? '',
       wasDriving: selectedGig.wasDriving,
       status: selectedGig.status,
+      expenses: selectedGig.expenses
+        .slice()
+        .sort((left, right) => left.sortOrder - right.sortOrder)
+        .map(toGigExpenseForm),
     })
     setGigStatus('Editing the selected gig.')
+    setGigExpenseAmount('')
+    setGigExpenseDescription('')
   }
 
   const updateField = (field: keyof ClientForm, value: string | Address) => {
@@ -927,11 +967,72 @@ function App() {
 
   const updateGigField = (
     field: keyof GigForm,
-    value: string | boolean
+    value: string | boolean | GigExpenseForm[]
   ) => {
     setGigForm((current) => ({
       ...current,
       [field]: value,
+    }))
+  }
+
+  const handleAddGigExpense = () => {
+    const description = gigExpenseDescription.trim()
+    const amount = Number(gigExpenseAmount)
+
+    if (!description) {
+      setGigStatus('Add an expense description before saving it to the gig.')
+      return
+    }
+
+    if (!Number.isFinite(amount) || amount < 0) {
+      setGigStatus('Expense amount must be a valid non-negative number.')
+      return
+    }
+
+    setGigForm((current) => ({
+      ...current,
+      expenses: [
+        ...current.expenses,
+        {
+          id: '',
+          sortOrder: current.expenses.length + 1,
+          description,
+          amount: gigExpenseAmount,
+        },
+      ],
+    }))
+    setGigExpenseAmount('')
+    setGigExpenseDescription('')
+    setGigStatus('Expense added to the gig form. Save the gig to persist it.')
+  }
+
+  const updateGigExpenseField = (
+    index: number,
+    field: keyof Pick<GigExpenseForm, 'description' | 'amount'>,
+    value: string
+  ) => {
+    setGigForm((current) => ({
+      ...current,
+      expenses: current.expenses.map((expense, expenseIndex) =>
+        expenseIndex === index
+          ? {
+              ...expense,
+              [field]: value,
+            }
+          : expense
+      ),
+    }))
+  }
+
+  const removeGigExpense = (index: number) => {
+    setGigForm((current) => ({
+      ...current,
+      expenses: current.expenses
+        .filter((_, expenseIndex) => expenseIndex !== index)
+        .map((expense, expenseIndex) => ({
+          ...expense,
+          sortOrder: expenseIndex + 1,
+        })),
     }))
   }
 
@@ -1460,6 +1561,7 @@ function App() {
       notes: gigForm.notes.trim(),
       wasDriving: gigForm.wasDriving,
       status: gigForm.status,
+      expenses: gigForm.expenses,
     }
 
     if (!payload.clientId || !payload.title || !payload.date || !payload.venue) {
@@ -1471,6 +1573,28 @@ function App() {
     if (!Number.isFinite(fee) || fee < 0) {
       setGigStatus('Fee must be a valid non-negative number.')
       return
+    }
+
+    const normalizedExpenses = []
+    for (const [index, expense] of payload.expenses.entries()) {
+      const description = expense.description.trim()
+      const amount = Number(expense.amount)
+
+      if (!description) {
+        setGigStatus(`Expense ${index + 1} needs a description.`)
+        return
+      }
+
+      if (!Number.isFinite(amount) || amount < 0) {
+        setGigStatus(`Expense ${index + 1} must have a valid non-negative amount.`)
+        return
+      }
+
+      normalizedExpenses.push({
+        sortOrder: index + 1,
+        description,
+        amount,
+      })
     }
 
     setIsGigLoading(true)
@@ -1498,7 +1622,7 @@ function App() {
           wasDriving: payload.wasDriving,
           status: payload.status,
           invoiceId: null,
-          expenses: [],
+          expenses: normalizedExpenses,
           invoicedAt: null,
         }),
       })
@@ -1541,7 +1665,13 @@ function App() {
         notes: savedGig.notes ?? '',
         wasDriving: savedGig.wasDriving,
         status: savedGig.status,
+        expenses: savedGig.expenses
+          .slice()
+          .sort((left, right) => left.sortOrder - right.sortOrder)
+          .map(toGigExpenseForm),
       })
+      setGigExpenseAmount('')
+      setGigExpenseDescription('')
       setGigStatus(isEdit ? 'Gig updated.' : 'Gig created.')
     } catch (error) {
       setGigStatus(
@@ -2516,6 +2646,86 @@ function App() {
                 />
               </label>
             </div>
+
+            <div className="gig-timeline-note">
+              <p className="detail-label">Expenses</p>
+              <span>
+                Add chargeable out-of-pocket costs here and they will flow through when the gig is invoiced.
+              </span>
+            </div>
+
+            <div className="invoice-adjustment-form">
+              <label>
+                Amount
+                <input
+                  inputMode="decimal"
+                  value={gigExpenseAmount}
+                  onChange={(event) => setGigExpenseAmount(event.target.value)}
+                  placeholder="45.00"
+                  disabled={isGigLoading}
+                />
+              </label>
+              <label>
+                Description
+                <input
+                  value={gigExpenseDescription}
+                  onChange={(event) => setGigExpenseDescription(event.target.value)}
+                  placeholder="Parking, hotel, equipment hire..."
+                  disabled={isGigLoading}
+                />
+              </label>
+              <button
+                className="ghost-button"
+                onClick={handleAddGigExpense}
+                type="button"
+                disabled={isGigLoading}
+              >
+                Add expense
+              </button>
+            </div>
+
+            {gigForm.expenses.length > 0 ? (
+              <div className="gig-expense-list">
+                {gigForm.expenses.map((expense, index) => (
+                  <div className="gig-expense-item" key={`${expense.id || 'new'}-${index}`}>
+                    <label>
+                      <span>Description</span>
+                      <input
+                        value={expense.description}
+                        onChange={(event) =>
+                          updateGigExpenseField(index, 'description', event.target.value)
+                        }
+                        disabled={isGigLoading}
+                      />
+                    </label>
+                    <label>
+                      <span>Amount</span>
+                      <input
+                        inputMode="decimal"
+                        value={expense.amount}
+                        onChange={(event) =>
+                          updateGigExpenseField(index, 'amount', event.target.value)
+                        }
+                        disabled={isGigLoading}
+                      />
+                    </label>
+                    <button
+                      className="ghost-button"
+                      onClick={() => removeGigExpense(index)}
+                      type="button"
+                      disabled={isGigLoading}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="empty-state">
+                <strong>No expenses added yet.</strong>
+                <p>Use the fields above to add chargeable costs to this gig.</p>
+              </div>
+            )}
 
             <div className="form-actions">
               <button

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -87,6 +87,8 @@ type Gig = {
 
 type InvoiceLine = {
   id: string
+  createdByUserId: string | null
+  createdUtc: string
   sortOrder: number
   type: string
   description: string
@@ -342,6 +344,8 @@ function App() {
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
   const [invoiceStatus, setInvoiceStatus] = useState(defaultInvoiceStatus)
   const [isInvoiceLoading, setIsInvoiceLoading] = useState(false)
+  const [adjustmentAmount, setAdjustmentAmount] = useState('')
+  const [adjustmentReason, setAdjustmentReason] = useState('')
 
   const isAdmin = authUser?.role === 'Admin'
   const profileDisplayName = authUser?.name?.trim() || authUser?.email || 'User'
@@ -1713,6 +1717,61 @@ function App() {
     }
   }
 
+  const handleAddInvoiceAdjustment = async (invoice: Invoice) => {
+    const amount = Number.parseFloat(adjustmentAmount)
+    if (!Number.isFinite(amount) || amount === 0) {
+      setInvoiceStatus('Enter a non-zero adjustment amount.')
+      return
+    }
+
+    const reason = adjustmentReason.trim()
+    if (!reason) {
+      setInvoiceStatus('Add a reason before saving an adjustment.')
+      return
+    }
+
+    setIsInvoiceLoading(true)
+    setInvoiceStatus(`Saving adjustment on ${invoice.invoiceNumber}...`)
+
+    try {
+      const response = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}/adjustments`), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          amount,
+          reason,
+        }),
+      })
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const reasonError = problem?.errors?.reason?.[0]
+        const amountError = problem?.errors?.amount?.[0]
+        throw new Error(
+          reasonError ??
+            amountError ??
+            problem?.detail ??
+            problem?.title ??
+            'Unable to add invoice adjustment.'
+        )
+      }
+
+      const updatedInvoice = (await response.json()) as Invoice
+      setInvoices((current) =>
+        current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
+      )
+      setAdjustmentAmount('')
+      setAdjustmentReason('')
+      setInvoiceStatus(`Adjustment saved. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`)
+    } catch (error) {
+      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to add invoice adjustment.')
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
   if (isCheckingSession) {
     return (
       <main className="app-shell auth-shell">
@@ -2625,12 +2684,12 @@ function App() {
                     <span>{selectedInvoice.description?.trim() || 'No description set.'}</span>
                   </article>
                   <article>
-                    <p className="detail-label">Line items</p>
-                    <strong>{selectedInvoice.lines.length}</strong>
-                  </article>
-                  <article>
                     <p className="detail-label">Total</p>
                     <strong>{formatCurrency(selectedInvoice.total)}</strong>
+                  </article>
+                  <article>
+                    <p className="detail-label">Line items</p>
+                    <strong>{selectedInvoice.lines.length}</strong>
                   </article>
                   <article>
                     <p className="detail-label">Re-issued</p>
@@ -2643,29 +2702,94 @@ function App() {
                 </div>
 
                 <div className="gig-timeline-note">
-                  <p className="detail-label">Line items</p>
-                  <div className="invoice-line-list">
-                    {selectedInvoice.lines
-                      .slice()
-                      .sort((left, right) => left.sortOrder - right.sortOrder)
-                      .map((line) => (
-                        <div className="invoice-line-item" key={line.id}>
-                          <div>
-                            <strong>{line.description}</strong>
-                            <span>
-                              {line.type} · {line.quantity} x {formatCurrency(line.unitPrice)}
-                            </span>
-                          </div>
-                          <strong>{formatCurrency(line.lineTotal)}</strong>
-                        </div>
-                      ))}
-                  </div>
+                  <p className="detail-label">Invoice workflow</p>
+                  <span>
+                    Re-issue and PDF actions stay in the overview pane, while line-level changes now live in
+                    the docked side pane for a steadier browse flow.
+                  </span>
                 </div>
               </>
             ) : (
               <div className="empty-state roomy">
                 <strong>Select an invoice to review its details.</strong>
                 <p>The generated PDF and line items will be available here.</p>
+              </div>
+            )}
+          </div>
+
+          <div className="panel">
+            <div className="panel-heading">
+              <div>
+                <p className="section-label">Management Pane</p>
+                <h2>{selectedInvoice ? 'Line items' : 'No invoice selected'}</h2>
+              </div>
+            </div>
+
+            {selectedInvoice ? (
+              <>
+                <div className="gig-timeline-note">
+                  <p className="detail-label">Adjustments</p>
+                  <span>
+                    Manual adjustments append a separate line item so the original invoice breakdown stays intact.
+                  </span>
+                </div>
+
+                <form
+                  className="invoice-adjustment-form"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    void handleAddInvoiceAdjustment(selectedInvoice)
+                  }}
+                >
+                  <label>
+                    Amount
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={adjustmentAmount}
+                      onChange={(event) => setAdjustmentAmount(event.target.value)}
+                      placeholder="-25.00"
+                      disabled={isInvoiceLoading}
+                    />
+                  </label>
+                  <label>
+                    Reason
+                    <input
+                      value={adjustmentReason}
+                      onChange={(event) => setAdjustmentReason(event.target.value)}
+                      placeholder="Goodwill discount, surcharge, correction..."
+                      disabled={isInvoiceLoading}
+                    />
+                  </label>
+                  <button className="ghost-button" type="submit" disabled={isInvoiceLoading}>
+                    Add adjustment
+                  </button>
+                </form>
+
+                <div className="invoice-line-list">
+                  {selectedInvoice.lines
+                    .slice()
+                    .sort((left, right) => left.sortOrder - right.sortOrder)
+                    .map((line) => (
+                      <div className="invoice-line-item" key={line.id}>
+                        <div>
+                          <strong>{line.description}</strong>
+                          <span>
+                            {line.type} · {line.quantity} x {formatCurrency(line.unitPrice)}
+                          </span>
+                          {line.type === 'ManualAdjustment' ? (
+                            <span>Audit: {formatDateTime(line.createdUtc)}</span>
+                          ) : null}
+                        </div>
+                        <strong>{formatCurrency(line.lineTotal)}</strong>
+                      </div>
+                    ))}
+                </div>
+              </>
+            ) : (
+              <div className="empty-state roomy">
+                <strong>Select an invoice to inspect its line items.</strong>
+                <p>The right-hand pane is reserved for line breakdowns and manual adjustments.</p>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add manual invoice adjustment support in the backend and frontend invoices workspace
- add gig expense editing in the management pane and persist expenses through gig saves
- fix invoiced gig updates by reconciling expense rows safely before regenerating invoice lines
- add regression coverage for manual adjustments and invoiced gig expense updates

## Verification
- `npm --prefix frontend/glovelly-web run build`
- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj --filter UpdateGig_WithExpenses_ReplacesExpenseCollectionAndReturnsUpdatedGig`
- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj --filter UpdateGig_RemovingInvoice_ClearsInvoicedAt`

## Notes
- the branch already contained the manual invoice adjustment implementation; this PR also includes the follow-up gig expense editing and invoiced-gig update fix.