### PR TITLE
Harden auth return URL handling against open redirects

### DIFF
--- a/backend/Glovelly.Api.Tests/ReturnUrlSanitizerTests.cs
+++ b/backend/Glovelly.Api.Tests/ReturnUrlSanitizerTests.cs
@@ -1,0 +1,34 @@
+using Glovelly.Api.Auth;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class ReturnUrlSanitizerTests
+{
+    [Theory]
+    [InlineData(null, "/")]
+    [InlineData("", "/")]
+    [InlineData(" ", "/")]
+    [InlineData("/dashboard", "/dashboard")]
+    [InlineData("/invoices?status=draft", "/invoices?status=draft")]
+    [InlineData("/gigs#current", "/gigs#current")]
+    [InlineData("https://example.com/account", "/")]
+    [InlineData("//evil.example.com", "/")]
+    [InlineData("javascript:alert('x')", "/")]
+    public void BuildSafeLocalReturnPath_SanitizesUnsafeValues(string? returnUrl, string expected)
+    {
+        var actual = ReturnUrlSanitizer.BuildSafeLocalReturnPath(returnUrl);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("/safe\r\nX-Injected: yes")]
+    [InlineData("/safe\nX-Injected: yes")]
+    public void BuildSafeLocalReturnPath_BlocksHeaderInjection(string returnUrl)
+    {
+        var actual = ReturnUrlSanitizer.BuildSafeLocalReturnPath(returnUrl);
+
+        Assert.Equal("/", actual);
+    }
+}

--- a/backend/Glovelly.Api.Tests/ReturnUrlSanitizerTests.cs
+++ b/backend/Glovelly.Api.Tests/ReturnUrlSanitizerTests.cs
@@ -15,6 +15,8 @@ public sealed class ReturnUrlSanitizerTests
     [InlineData("https://example.com/account", "/")]
     [InlineData("//evil.example.com", "/")]
     [InlineData("javascript:alert('x')", "/")]
+    [InlineData("/\\evil.example.com", "/")]
+    [InlineData("/safe\\next", "/")]
     public void BuildSafeLocalReturnPath_SanitizesUnsafeValues(string? returnUrl, string expected)
     {
         var actual = ReturnUrlSanitizer.BuildSafeLocalReturnPath(returnUrl);
@@ -25,6 +27,7 @@ public sealed class ReturnUrlSanitizerTests
     [Theory]
     [InlineData("/safe\r\nX-Injected: yes")]
     [InlineData("/safe\nX-Injected: yes")]
+    [InlineData("/safe\0X-Injected: yes")]
     public void BuildSafeLocalReturnPath_BlocksHeaderInjection(string returnUrl)
     {
         var actual = ReturnUrlSanitizer.BuildSafeLocalReturnPath(returnUrl);

--- a/backend/Glovelly.Api/Auth/ReturnUrlSanitizer.cs
+++ b/backend/Glovelly.Api/Auth/ReturnUrlSanitizer.cs
@@ -9,12 +9,14 @@ public static class ReturnUrlSanitizer
             return "/";
         }
 
-        if (returnUrl.Contains('\r') || returnUrl.Contains('\n'))
+        if (returnUrl.Contains('\r') || returnUrl.Contains('\n') || returnUrl.Contains('\0'))
         {
             return "/";
         }
 
-        if (!returnUrl.StartsWith('/') || returnUrl.StartsWith("//", StringComparison.Ordinal))
+        if (!returnUrl.StartsWith('/', StringComparison.Ordinal) ||
+            returnUrl.StartsWith("//", StringComparison.Ordinal) ||
+            returnUrl.Contains('\\'))
         {
             return "/";
         }

--- a/backend/Glovelly.Api/Auth/ReturnUrlSanitizer.cs
+++ b/backend/Glovelly.Api/Auth/ReturnUrlSanitizer.cs
@@ -1,0 +1,24 @@
+namespace Glovelly.Api.Auth;
+
+public static class ReturnUrlSanitizer
+{
+    public static string BuildSafeLocalReturnPath(string? returnUrl)
+    {
+        if (string.IsNullOrWhiteSpace(returnUrl))
+        {
+            return "/";
+        }
+
+        if (returnUrl.Contains('\r') || returnUrl.Contains('\n'))
+        {
+            return "/";
+        }
+
+        if (!returnUrl.StartsWith('/') || returnUrl.StartsWith("//", StringComparison.Ordinal))
+        {
+            return "/";
+        }
+
+        return returnUrl;
+    }
+}

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -268,8 +268,7 @@ if (!string.IsNullOrWhiteSpace(googleClientId) && !string.IsNullOrWhiteSpace(goo
                 context.HandleResponse();
 
                 var failureCode = GetAuthenticationFailureCode(context.Failure);
-                var redirectUri = BuildSafeRedirectUri(
-                    context.HttpContext,
+                var redirectUri = ReturnUrlSanitizer.BuildSafeLocalReturnPath(
                     $"/auth/denied?code={Uri.EscapeDataString(failureCode)}");
 
                 context.Response.Redirect(redirectUri);
@@ -335,7 +334,7 @@ auth.MapGet("/login", (HttpContext httpContext, string? returnUrl) =>
             statusCode: StatusCodes.Status500InternalServerError);
     }
 
-    var redirectUri = BuildSafeRedirectUri(httpContext, returnUrl);
+    var redirectUri = ReturnUrlSanitizer.BuildSafeLocalReturnPath(returnUrl);
     return Results.Challenge(
         new AuthenticationProperties { RedirectUri = redirectUri },
         authenticationSchemes: [OpenIdConnectDefaults.AuthenticationScheme]);
@@ -611,31 +610,6 @@ app.MapAdminEndpoints();
 app.MapFallbackToFile("index.html");
 
 app.Run();
-
-static string BuildSafeRedirectUri(HttpContext httpContext, string? returnUrl)
-{
-    if (string.IsNullOrWhiteSpace(returnUrl))
-    {
-        return "/";
-    }
-
-    if (Uri.TryCreate(returnUrl, UriKind.Absolute, out var absoluteUri))
-    {
-        var request = httpContext.Request;
-        var sameHost = string.Equals(absoluteUri.Host, request.Host.Host, StringComparison.OrdinalIgnoreCase);
-        var localhostRedirect =
-            absoluteUri.IsLoopback &&
-            (absoluteUri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
-             absoluteUri.Host.Equals("127.0.0.1"));
-
-        if (sameHost || localhostRedirect)
-        {
-            return absoluteUri.ToString();
-        }
-    }
-
-    return returnUrl.StartsWith('/') ? returnUrl : "/";
-}
 
 static bool IsApiRequest(HttpRequest request)
 {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -203,7 +203,7 @@ function buildApiUrl(path: string) {
 }
 
 function buildReturnUrl() {
-  return window.location.href
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
 }
 
 async function fetchWithSession(input: string, init?: RequestInit) {


### PR DESCRIPTION
### Motivation

- Close an open-redirect / header-injection vector in the authentication flow by validating return URLs more strictly.  
- Ensure only local, root-relative return paths are accepted and reject absolute/protocol-based values and CRLF payloads.  

### Description

- Add `backend/Glovelly.Api/Auth/ReturnUrlSanitizer.cs` which exposes `BuildSafeLocalReturnPath` to validate and sanitize return URLs (blocks absolute URLs, `//` host redirects, and CRLF injection).  
- Update `backend/Glovelly.Api/Program.cs` to use `ReturnUrlSanitizer.BuildSafeLocalReturnPath` for the `/auth/login` redirect and the OpenID Connect `OnRemoteFailure` redirect, and remove the previous broader `BuildSafeRedirectUri` logic.  
- Change frontend sign-in behavior in `frontend/glovelly-web/src/App.tsx` so `buildReturnUrl()` returns only `pathname + search + hash` (no absolute URL) to align with the backend policy.  
- Add unit tests `backend/Glovelly.Api.Tests/ReturnUrlSanitizerTests.cs` covering safe return paths and malicious inputs including CRLF header-injection cases.  

### Testing

- Ran frontend build with `npm --prefix frontend/glovelly-web run build`, which completed successfully.  
- Added unit tests in `backend/Glovelly.Api.Tests/ReturnUrlSanitizerTests.cs`, but `dotnet test` could not be executed in this environment because `dotnet` is not installed, so backend tests were not run here.  
- The change is limited to return URL handling and frontend return URL construction; new tests exercise expected sanitizer behavior even though they were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e694d117d88328add03a44be01152d)