### PR TITLE
Sanitize and restrict redirect URIs to prevent open-redirects

### DIFF
--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -11,22 +11,36 @@ internal static class AuthFlowSupport
             return "/";
         }
 
-        if (Uri.TryCreate(returnUrl, UriKind.Absolute, out var absoluteUri))
+        var sanitizedReturnUrl = returnUrl.Trim();
+
+        if (IsSafeLocalPath(sanitizedReturnUrl))
+        {
+            return sanitizedReturnUrl;
+        }
+
+        if (Uri.TryCreate(sanitizedReturnUrl, UriKind.Absolute, out var absoluteUri))
         {
             var request = httpContext.Request;
+            var sameScheme = string.Equals(absoluteUri.Scheme, request.Scheme, StringComparison.OrdinalIgnoreCase);
             var sameHost = string.Equals(absoluteUri.Host, request.Host.Host, StringComparison.OrdinalIgnoreCase);
-            var localhostRedirect =
-                absoluteUri.IsLoopback &&
-                (absoluteUri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
-                 absoluteUri.Host.Equals("127.0.0.1"));
+            var samePort = (absoluteUri.IsDefaultPort && !request.Host.Port.HasValue) ||
+                           absoluteUri.Port == request.Host.Port;
 
-            if (sameHost || localhostRedirect)
+            if (sameScheme && sameHost && samePort)
             {
-                return absoluteUri.ToString();
+                var localPath = absoluteUri.PathAndQuery + absoluteUri.Fragment;
+                return IsSafeLocalPath(localPath) ? localPath : "/";
             }
         }
 
-        return returnUrl.StartsWith('/') ? returnUrl : "/";
+        return "/";
+    }
+
+    private static bool IsSafeLocalPath(string value)
+    {
+        return value.StartsWith("/", StringComparison.Ordinal) &&
+               !value.StartsWith("//", StringComparison.Ordinal) &&
+               value.IndexOf('\\') < 0;
     }
 
     public static bool IsApiRequest(HttpRequest request)


### PR DESCRIPTION
### Motivation
- Prevent open-redirect vulnerabilities by ensuring only safe local paths or same-origin absolute URLs are accepted for return redirects.
- Normalize and sanitize incoming `returnUrl` values to avoid malformed or malicious input being used as redirects.
- Ensure redirects on localhost/loopback still work only when scheme, host, and port match the current request.

### Description
- Trim the input `returnUrl` and introduce `IsSafeLocalPath` to validate local paths that start with a single `/`, do not start with `//`, and contain no backslashes.
- Short-circuit to return the sanitized local path when `IsSafeLocalPath` passes. 
- For absolute URIs, require matching scheme, host, and port with the current request, and return only the `PathAndQuery` plus `Fragment` portion when allowed.
- Remove the previous loose localhost special-case and default to returning `/` for any unsafe or disallowed redirect.

### Testing
- Ran `dotnet build` to ensure project compiles successfully and it completed without errors.
- Ran the test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69aa3536483289d6375eac576982e)