### PR TITLE
Validate UserSettingsRequest with DataAnnotations and centralize validation

### DIFF
--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 
 namespace Glovelly.Api.Endpoints;
@@ -74,20 +75,10 @@ internal static class AuthEndpoints
             ICurrentUserAccessor currentUserAccessor,
             AppDbContext dbContext) =>
         {
-            if (request.MileageRate.HasValue && request.MileageRate.Value < 0)
+            var validationErrors = ValidateUserSettingsRequest(request);
+            if (validationErrors is not null)
             {
-                return Results.ValidationProblem(new Dictionary<string, string[]>
-                {
-                    ["mileageRate"] = ["Mileage rate cannot be negative."]
-                });
-            }
-
-            if (request.PassengerMileageRate.HasValue && request.PassengerMileageRate.Value < 0)
-            {
-                return Results.ValidationProblem(new Dictionary<string, string[]>
-                {
-                    ["passengerMileageRate"] = ["Passenger mileage rate cannot be negative."]
-                });
+                return Results.ValidationProblem(validationErrors);
             }
 
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -158,5 +149,36 @@ internal static class AuthEndpoints
         return app;
     }
 
-    internal sealed record UserSettingsRequest(decimal? MileageRate, decimal? PassengerMileageRate);
+    private static Dictionary<string, string[]>? ValidateUserSettingsRequest(UserSettingsRequest request)
+    {
+        var validationResults = new List<ValidationResult>();
+        var validationContext = new ValidationContext(request);
+        var isValid = Validator.TryValidateObject(request, validationContext, validationResults, validateAllProperties: true);
+        if (isValid)
+        {
+            return null;
+        }
+
+        return validationResults
+            .GroupBy(result => ToCamelCase(result.MemberNames.FirstOrDefault() ?? string.Empty))
+            .ToDictionary(
+                grouping => grouping.Key,
+                grouping => grouping.Select(result => result.ErrorMessage ?? "Invalid value.").ToArray());
+    }
+
+    private static string ToCamelCase(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        return char.ToLowerInvariant(value[0]) + value[1..];
+    }
+
+    internal sealed record UserSettingsRequest(
+        [Range(0, double.MaxValue, ErrorMessage = "Mileage rate cannot be negative.")]
+        decimal? MileageRate,
+        [Range(0, double.MaxValue, ErrorMessage = "Passenger mileage rate cannot be negative.")]
+        decimal? PassengerMileageRate);
 }


### PR DESCRIPTION
### Motivation

- Replace ad-hoc negative-value checks for user settings with declarative validation to unify error handling and support future rules. 
- Ensure API returns well-formed validation problems with camelCase field names to match frontend expectations.

### Description

- Added `System.ComponentModel.DataAnnotations` attributes to `UserSettingsRequest` to enforce non-negative `MileageRate` and `PassengerMileageRate` values.
- Introduced `ValidateUserSettingsRequest` helper that runs `Validator.TryValidateObject`, converts `ValidationResult`s into a `Dictionary<string,string[]>` and maps member names to camelCase.
- Replaced manual checks in the `/me/settings` `PUT` endpoint with a call to `ValidateUserSettingsRequest` and return of `Results.ValidationProblem` when validation fails.
- Added `ToCamelCase` utility to normalize validation member names for the JSON error response.

### Testing

- Ensured the project builds successfully by running `dotnet build` which completed without errors. 
- No new automated tests were added for this change; existing test suite was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71bd13ce08328ad5061482fdc8dea)