### PR TITLE
Enforce draft-only invoice deletion and add draft delete UI

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -174,4 +174,40 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
         Assert.Equal("Adjustment reason is required.", problem.GetProperty("errors").GetProperty("reason")[0].GetString());
     }
+
+    [Fact]
+    public async Task DeleteInvoice_WhenDraft_DeletesInvoice()
+    {
+        var createInvoiceResponse = await _client.PostAsJsonAsync("/invoices", new
+        {
+            invoiceNumber = "INV-DELETE-DRAFT",
+            clientId = TestData.FoxAndFinchId,
+            invoiceDate = "2026-06-01",
+            dueDate = "2026-06-15",
+            status = "Draft",
+            description = "Draft invoice to delete",
+        });
+        createInvoiceResponse.EnsureSuccessStatusCode();
+
+        var createdInvoice = await createInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var invoiceId = createdInvoice.GetProperty("id").GetGuid();
+
+        var deleteResponse = await _client.DeleteAsync($"/invoices/{invoiceId}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var getResponse = await _client.GetAsync($"/invoices/{invoiceId}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteInvoice_WhenNotDraft_ReturnsValidationProblem()
+    {
+        var response = await _client.DeleteAsync($"/invoices/{TestData.FoxInvoiceId}");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Only Draft invoices can be deleted. Issued invoices must be retained for reporting.",
+            problem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
 }

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -260,13 +260,35 @@ public static class InvoiceEndpoints
             return Results.Ok(invoice);
         });
 
-        group.MapDelete("/{id:guid}", async (Guid id, AppDbContext db) =>
+        group.MapDelete("/{id:guid}", async (
+            Guid id,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            ILogger<InvoiceEndpoints> logger) =>
         {
             var invoice = await db.Invoices.FirstOrDefaultAsync(invoice => invoice.Id == id);
             if (invoice is null)
             {
                 return Results.NotFound();
             }
+
+            if (invoice.Status is not InvoiceStatus.Draft)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["status"] = [$"Only Draft invoices can be deleted. {invoice.Status} invoices must be retained for reporting."]
+                });
+            }
+
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var deletedAtUtc = DateTimeOffset.UtcNow;
+            logger.LogInformation(
+                "Invoice {InvoiceId} ({InvoiceNumber}) deleted by user {UserId} at {DeletedAtUtc}.",
+                invoice.Id,
+                invoice.InvoiceNumber,
+                userId,
+                deletedAtUtc);
 
             db.Invoices.Remove(invoice);
             await db.SaveChangesAsync();

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -265,8 +265,9 @@ public static class InvoiceEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
-            ILogger<InvoiceEndpoints> logger) =>
+            ILoggerFactory loggerFactory) =>
         {
+            var logger = loggerFactory.CreateLogger("InvoiceEndpoints");
             var invoice = await db.Invoices.FirstOrDefaultAsync(invoice => invoice.Id == id);
             if (invoice is null)
             {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1633,6 +1633,47 @@ function App() {
     }
   }
 
+  const handleDeleteInvoice = async (invoice: Invoice) => {
+    if (invoice.status !== 'Draft') {
+      setInvoiceStatus(
+        `Only Draft invoices can be deleted. ${invoice.invoiceNumber} is currently ${invoice.status}.`
+      )
+      return
+    }
+
+    const shouldDelete = window.confirm(
+      `Delete ${invoice.invoiceNumber}? This cannot be undone and should only be used for draft mistakes.`
+    )
+    if (!shouldDelete) {
+      return
+    }
+
+    setIsInvoiceLoading(true)
+    setInvoiceStatus(`Deleting ${invoice.invoiceNumber}...`)
+
+    try {
+      const response = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}`), {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const statusError = problem?.errors?.status?.[0]
+        throw new Error(
+          statusError ?? problem?.detail ?? problem?.title ?? 'Unable to delete invoice.'
+        )
+      }
+
+      setInvoices((current) => current.filter((value) => value.id !== invoice.id))
+      setSelectedInvoiceId((current) => (current === invoice.id ? '' : current))
+      setInvoiceStatus(`Invoice ${invoice.invoiceNumber} deleted.`)
+    } catch (error) {
+      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to delete invoice.')
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
   if (isCheckingSession) {
     return <SessionCheckingScreen status={status} />
   }
@@ -1728,6 +1769,7 @@ function App() {
         onAdjustmentAmountChange={setAdjustmentAmount}
         onAdjustmentReasonChange={setAdjustmentReason}
         onAddAdjustment={handleAddInvoiceAdjustment}
+        onDeleteInvoice={handleDeleteInvoice}
         onDownloadPdf={handleDownloadInvoicePdf}
         onInvoiceStatusChange={handleInvoiceStatusChange}
         onReissue={handleInvoiceReissue}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -1055,6 +1055,7 @@ type InvoicesSectionProps = {
   onAdjustmentAmountChange: (value: string) => void
   onAdjustmentReasonChange: (value: string) => void
   onAddAdjustment: (invoice: Invoice) => Promise<void>
+  onDeleteInvoice: (invoice: Invoice) => Promise<void>
   onDownloadPdf: (invoice: Invoice) => Promise<void>
   onInvoiceStatusChange: (invoice: Invoice, status: InvoiceStatus) => Promise<void>
   onReissue: (invoice: Invoice) => Promise<void>
@@ -1076,6 +1077,7 @@ export function InvoicesSection({
   onAdjustmentAmountChange,
   onAdjustmentReasonChange,
   onAddAdjustment,
+  onDeleteInvoice,
   onDownloadPdf,
   onInvoiceStatusChange,
   onReissue,
@@ -1171,6 +1173,19 @@ export function InvoicesSection({
                 disabled={!selectedInvoice || isInvoiceLoading}
               >
                 Re-issue
+              </button>
+              <button
+                className="danger-button"
+                onClick={() => selectedInvoice && void onDeleteInvoice(selectedInvoice)}
+                type="button"
+                disabled={!selectedInvoice || isInvoiceLoading || selectedInvoice?.status !== 'Draft'}
+                title={
+                  selectedInvoice?.status !== 'Draft'
+                    ? 'Only Draft invoices can be deleted.'
+                    : 'Delete draft invoice'
+                }
+              >
+                Delete draft
               </button>
               <button
                 className="primary-button"


### PR DESCRIPTION
### Motivation
- Prevent accidental or non-compliant removal of historical invoices by restricting deletion to Draft invoices only.
- Provide an audited delete path so deletions are logged with user and timestamp for traceability.
- Give users a safe, discoverable UI to remove only draft invoices with confirmation and clear messaging.

### Description
- Server: updated `DELETE /invoices/{id}` in `backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs` to reject deletes unless the invoice `Status` is `Draft`, returning a validation problem with an explanatory `status` error.
- Server: added deletion audit logging using `ILogger<InvoiceEndpoints>` that records invoice id, invoice number, deleting user id and UTC timestamp.
- Tests: added two endpoint tests in `backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs` to cover successful deletion of a draft invoice and the validation failure when attempting to delete a non-draft invoice.
- Frontend: added `handleDeleteInvoice` in `frontend/glovelly-web/src/App.tsx` and wired it into the app props, and updated `InvoicesSection` in `frontend/glovelly-web/src/AppSections.tsx` to expose a danger-styled "Delete draft" button that is disabled unless the selected invoice is `Draft`, shows a confirmation prompt, and surfaces server validation messages.

### Testing
- Frontend build: ran `npm -C frontend/glovelly-web run build` which completed successfully and produced the production build.
- Backend unit tests: attempted `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj --filter InvoiceStatusEndpointsTests` but the command could not run in this environment because `dotnet` is not installed, so tests were not executed here; the new tests were added and should be run in a .NET-enabled CI or local environment.
- The change set includes automated tests targeting the new delete behaviour (see `InvoiceStatusEndpointsTests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7230f4ad083288f808bc4fa772e4e)