### PR TITLE
Multi-tenant visibility and monthly invoice run: filter data by user and add monthly invoice UI/flow

### DIFF
--- a/backend/Glovelly.Api.Tests/Infrastructure/TestAuthContext.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/TestAuthContext.cs
@@ -4,4 +4,5 @@ internal static class TestAuthContext
 {
     public const string SchemeName = "Test";
     public static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    public static readonly Guid AlternateUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
 }

--- a/backend/Glovelly.Api.Tests/Infrastructure/TestPolicyEvaluator.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/TestPolicyEvaluator.cs
@@ -12,10 +12,11 @@ internal sealed class TestPolicyEvaluator : IPolicyEvaluator
 {
     public Task<AuthenticateResult> AuthenticateAsync(AuthorizationPolicy policy, HttpContext context)
     {
+        var userId = ResolveUserId(context);
         var claims = new[]
         {
-            new Claim(GlovellyClaimTypes.UserId, TestAuthContext.UserId.ToString()),
-            new Claim(ClaimTypes.NameIdentifier, TestAuthContext.UserId.ToString()),
+            new Claim(GlovellyClaimTypes.UserId, userId.ToString()),
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
             new Claim(ClaimTypes.Name, "Test Admin"),
             new Claim(ClaimTypes.Email, "test-admin@glovelly.local"),
             new Claim(ClaimTypes.Role, UserRole.Admin.ToString()),
@@ -37,5 +38,16 @@ internal sealed class TestPolicyEvaluator : IPolicyEvaluator
         object? resource)
     {
         return Task.FromResult(PolicyAuthorizationResult.Success());
+    }
+
+    private static Guid ResolveUserId(HttpContext context)
+    {
+        if (!context.Request.Headers.TryGetValue("X-Test-UserId", out var values))
+        {
+            return TestAuthContext.UserId;
+        }
+
+        var value = values.FirstOrDefault();
+        return Guid.TryParse(value, out var parsed) ? parsed : TestAuthContext.UserId;
     }
 }

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -210,4 +210,18 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
             "Only Draft invoices can be deleted. Issued invoices must be retained for reporting.",
             problem.GetProperty("errors").GetProperty("status")[0].GetString());
     }
+
+    [Fact]
+    public async Task GetInvoices_WhenSignedInAsDifferentUser_ReturnsOnlyVisibleInvoices()
+    {
+        _client.DefaultRequestHeaders.Remove("X-Test-UserId");
+        _client.DefaultRequestHeaders.Add("X-Test-UserId", TestAuthContext.AlternateUserId.ToString());
+
+        var response = await _client.GetAsync("/invoices");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var invoices = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(JsonValueKind.Array, invoices.ValueKind);
+        Assert.Empty(invoices.EnumerateArray());
+    }
 }

--- a/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
@@ -11,6 +11,21 @@ internal static class EndpointSupport
         return query.Where(client => client.CreatedByUserId == null || client.CreatedByUserId == userId);
     }
 
+    public static IQueryable<Gig> WhereVisibleTo(this IQueryable<Gig> query, Guid? userId)
+    {
+        return query.Where(gig => gig.CreatedByUserId == null || gig.CreatedByUserId == userId);
+    }
+
+    public static IQueryable<Invoice> WhereVisibleTo(this IQueryable<Invoice> query, Guid? userId)
+    {
+        return query.Where(invoice => invoice.CreatedByUserId == null || invoice.CreatedByUserId == userId);
+    }
+
+    public static IQueryable<InvoiceLine> WhereVisibleTo(this IQueryable<InvoiceLine> query, Guid? userId)
+    {
+        return query.Where(line => line.CreatedByUserId == null || line.CreatedByUserId == userId);
+    }
+
     public static void StampCreate(Client client, Guid? userId)
     {
         client.CreatedByUserId = userId;

--- a/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
@@ -11,9 +11,11 @@ public static class GigEndpoints
 {
     public static RouteGroupBuilder MapGigEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/", async (AppDbContext db) =>
+        group.MapGet("/", async (AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var gigs = await db.Gigs
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .Include(gig => gig.Expenses)
                 .OrderBy(gig => gig.Date)
@@ -23,9 +25,11 @@ public static class GigEndpoints
             return Results.Ok(gigs);
         });
 
-        group.MapGet("/{id:guid}", async (Guid id, AppDbContext db) =>
+        group.MapGet("/{id:guid}", async (Guid id, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .Include(value => value.Expenses)
                 .FirstOrDefaultAsync(gig => gig.Id == id);
@@ -42,6 +46,7 @@ public static class GigEndpoints
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
+                .WhereVisibleTo(userId)
                 .Include(value => value.Client)
                 .Include(value => value.Expenses)
                 .FirstOrDefaultAsync(value => value.Id == id);
@@ -102,6 +107,7 @@ public static class GigEndpoints
             if (gig.InvoiceId.HasValue)
             {
                 var invoice = await db.Invoices
+                    .WhereVisibleTo(userId)
                     .AsNoTracking()
                     .FirstOrDefaultAsync(value => value.Id == gig.InvoiceId.Value);
 
@@ -149,6 +155,7 @@ public static class GigEndpoints
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
+                .WhereVisibleTo(userId)
                 .Include(value => value.Expenses)
                 .FirstOrDefaultAsync(value => value.Id == id);
 
@@ -176,6 +183,7 @@ public static class GigEndpoints
             if (request.InvoiceId.HasValue)
             {
                 var invoice = await db.Invoices
+                    .WhereVisibleTo(userId)
                     .AsNoTracking()
                     .FirstOrDefaultAsync(value => value.Id == request.InvoiceId.Value);
 
@@ -255,9 +263,16 @@ public static class GigEndpoints
             return Results.Ok(gig);
         });
 
-        group.MapDelete("/{id:guid}", async (Guid id, AppDbContext db, IInvoiceWorkflowService invoiceWorkflowService) =>
+        group.MapDelete("/{id:guid}", async (
+            Guid id,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IInvoiceWorkflowService invoiceWorkflowService) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
+                .WhereVisibleTo(userId)
                 .Include(value => value.Expenses)
                 .FirstOrDefaultAsync(gig => gig.Id == id);
             if (gig is null)

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -11,9 +11,11 @@ public static class InvoiceEndpoints
 {
     public static RouteGroupBuilder MapInvoiceEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/", async (AppDbContext db) =>
+        group.MapGet("/", async (AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var invoices = await db.Invoices
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .Include(invoice => invoice.Lines)
                 .OrderByDescending(invoice => invoice.InvoiceDate)
@@ -23,9 +25,11 @@ public static class InvoiceEndpoints
             return Results.Ok(invoices);
         });
 
-        group.MapGet("/{id:guid}/pdf", async (Guid id, AppDbContext db) =>
+        group.MapGet("/{id:guid}/pdf", async (Guid id, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(value => value.Id == id);
 
@@ -42,9 +46,11 @@ public static class InvoiceEndpoints
             return Results.File(invoice.PdfBlob, "application/pdf", $"{invoice.InvoiceNumber}.pdf");
         });
 
-        group.MapGet("/{id:guid}", async (Guid id, AppDbContext db) =>
+        group.MapGet("/{id:guid}", async (Guid id, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .Include(value => value.Lines)
                 .FirstOrDefaultAsync(value => value.Id == id);
@@ -82,6 +88,7 @@ public static class InvoiceEndpoints
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .Include(value => value.Lines)
                 .FirstOrDefaultAsync(value => value.Id == id);
 
@@ -150,7 +157,9 @@ public static class InvoiceEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .Include(value => value.Lines)
                 .FirstOrDefaultAsync(value => value.Id == id);
             if (invoice is null)
@@ -186,6 +195,7 @@ public static class InvoiceEndpoints
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .Include(value => value.Lines)
                 .FirstOrDefaultAsync(value => value.Id == id);
 
@@ -228,7 +238,9 @@ public static class InvoiceEndpoints
             ICurrentUserAccessor currentUserAccessor,
             IInvoiceWorkflowService invoiceWorkflowService) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .Include(value => value.Lines)
                 .FirstOrDefaultAsync(value => value.Id == id);
             if (invoice is null)
@@ -253,7 +265,6 @@ public static class InvoiceEndpoints
                 });
             }
 
-            var userId = currentUserAccessor.TryGetUserId(user);
             _ = await invoiceWorkflowService.CreateManualAdjustmentAsync(invoice, request.Amount, reason, userId);
             await db.SaveChangesAsync();
 
@@ -268,7 +279,10 @@ public static class InvoiceEndpoints
             ILoggerFactory loggerFactory) =>
         {
             var logger = loggerFactory.CreateLogger("InvoiceEndpoints");
-            var invoice = await db.Invoices.FirstOrDefaultAsync(invoice => invoice.Id == id);
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
+                .FirstOrDefaultAsync(invoice => invoice.Id == id);
             if (invoice is null)
             {
                 return Results.NotFound();
@@ -282,7 +296,6 @@ public static class InvoiceEndpoints
                 });
             }
 
-            var userId = currentUserAccessor.TryGetUserId(user);
             var deletedAtUtc = DateTimeOffset.UtcNow;
             logger.LogInformation(
                 "Invoice {InvoiceId} ({InvoiceNumber}) deleted by user {UserId} at {DeletedAtUtc}.",

--- a/backend/Glovelly.Api/Endpoints/InvoiceLineEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceLineEndpoints.cs
@@ -1,6 +1,8 @@
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
+using Glovelly.Api.Auth;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 
 namespace Glovelly.Api.Endpoints;
 
@@ -8,9 +10,11 @@ public static class InvoiceLineEndpoints
 {
     public static RouteGroupBuilder MapInvoiceLineEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/", async (AppDbContext db) =>
+        group.MapGet("/", async (AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var lines = await db.InvoiceLines
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .OrderBy(line => line.InvoiceId)
                 .ThenBy(line => line.SortOrder)
@@ -20,18 +24,22 @@ public static class InvoiceLineEndpoints
             return Results.Ok(lines);
         });
 
-        group.MapGet("/{id:guid}", async (Guid id, AppDbContext db) =>
+        group.MapGet("/{id:guid}", async (Guid id, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var line = await db.InvoiceLines
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(line => line.Id == id);
 
             return line is null ? Results.NotFound() : Results.Ok(line);
         });
 
-        group.MapPost("/", async (InvoiceLine line, AppDbContext db) =>
+        group.MapPost("/", async (InvoiceLine line, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
+            var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(value => value.Id == line.InvoiceId);
 
@@ -52,9 +60,9 @@ public static class InvoiceLineEndpoints
             line.Id = Guid.NewGuid();
             line.Description = line.Description.Trim();
             line.CalculationNotes = line.CalculationNotes?.Trim();
-            line.CreatedUtc = DateTimeOffset.UtcNow;
             line.Invoice = null;
             line.Gig = null;
+            EndpointSupport.StampCreate(line, userId);
 
             db.InvoiceLines.Add(line);
             await db.SaveChangesAsync();
@@ -62,15 +70,19 @@ public static class InvoiceLineEndpoints
             return Results.Created($"/invoice-lines/{line.Id}", line);
         });
 
-        group.MapPut("/{id:guid}", async (Guid id, InvoiceLine request, AppDbContext db) =>
+        group.MapPut("/{id:guid}", async (Guid id, InvoiceLine request, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
-            var line = await db.InvoiceLines.FirstOrDefaultAsync(value => value.Id == id);
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var line = await db.InvoiceLines
+                .WhereVisibleTo(userId)
+                .FirstOrDefaultAsync(value => value.Id == id);
             if (line is null)
             {
                 return Results.NotFound();
             }
 
             var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(value => value.Id == request.InvoiceId);
 
@@ -102,9 +114,12 @@ public static class InvoiceLineEndpoints
             return Results.Ok(line);
         });
 
-        group.MapDelete("/{id:guid}", async (Guid id, AppDbContext db) =>
+        group.MapDelete("/{id:guid}", async (Guid id, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
-            var line = await db.InvoiceLines.FirstOrDefaultAsync(value => value.Id == id);
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var line = await db.InvoiceLines
+                .WhereVisibleTo(userId)
+                .FirstOrDefaultAsync(value => value.Id == id);
             if (line is null)
             {
                 return Results.NotFound();

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -48,6 +48,14 @@ import type {
 } from './appShared'
 import './App.css'
 
+function getCurrentMonthValue() {
+  return new Date().toISOString().slice(0, 7)
+}
+
+function buildMonthlyInvoiceNumber(month: string, sequence: number) {
+  return `GLV-${month.replace('-', '')}-${String(sequence).padStart(3, '0')}`
+}
+
 function App() {
   const [activeSection, setActiveSection] = useState<AppSection>('clients')
   const [clients, setClients] = useState<Client[]>([])
@@ -95,6 +103,8 @@ function App() {
   const [isGigLoading, setIsGigLoading] = useState(false)
   const [gigExpenseAmount, setGigExpenseAmount] = useState('')
   const [gigExpenseDescription, setGigExpenseDescription] = useState('')
+  const [monthlyInvoiceClientId, setMonthlyInvoiceClientId] = useState('')
+  const [monthlyInvoiceMonth, setMonthlyInvoiceMonth] = useState(getCurrentMonthValue)
   const [invoices, setInvoices] = useState<Invoice[]>([])
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('')
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
@@ -204,6 +214,8 @@ function App() {
       setGigMode('create')
       setGigForm(emptyGigForm())
       setGigStatus(defaultGigStatus)
+      setMonthlyInvoiceClientId('')
+      setMonthlyInvoiceMonth(getCurrentMonthValue())
       setInvoices([])
       setSelectedInvoiceId('')
       setInvoiceSearchQuery('')
@@ -528,6 +540,14 @@ function App() {
       clientId: clients[0]?.id ?? '',
     }))
   }, [clients, gigForm.clientId])
+
+  useEffect(() => {
+    if (monthlyInvoiceClientId || clients.length === 0) {
+      return
+    }
+
+    setMonthlyInvoiceClientId(clients[0]?.id ?? '')
+  }, [clients, monthlyInvoiceClientId])
 
   const activeCities = new Set(clients.map((client) => client.billingAddress.city)).size
   const activeUsersCount = adminUsers.filter((user) => user.isActive).length
@@ -1478,6 +1498,147 @@ function App() {
     }
   }
 
+  const handleGenerateMonthlyInvoice = async () => {
+    const clientId = monthlyInvoiceClientId.trim()
+    if (!clientId) {
+      setGigStatus('Choose a client for the monthly invoice run.')
+      return
+    }
+
+    if (!monthlyInvoiceMonth) {
+      setGigStatus('Choose a month for the monthly invoice run.')
+      return
+    }
+
+    const gigsToInvoice = gigs
+      .filter(
+        (gig) =>
+          gig.clientId === clientId &&
+          !gig.isInvoiced &&
+          gig.date.startsWith(`${monthlyInvoiceMonth}-`) &&
+          gig.status !== 'Cancelled'
+      )
+      .sort((left, right) => left.date.localeCompare(right.date))
+
+    if (gigsToInvoice.length === 0) {
+      setGigStatus('No uninvoiced gigs found for that client/month.')
+      return
+    }
+
+    setIsInvoiceLoading(true)
+    setGigStatus(`Creating monthly invoice for ${gigsToInvoice.length} gig(s)...`)
+
+    try {
+      const issueDate = `${monthlyInvoiceMonth}-01`
+      const dueDateValue = new Date(`${issueDate}T00:00:00`)
+      dueDateValue.setDate(dueDateValue.getDate() + 14)
+      const dueDate = dueDateValue.toISOString().slice(0, 10)
+
+      const createInvoiceResponse = await fetchWithSession(buildApiUrl('/invoices'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          invoiceNumber: buildMonthlyInvoiceNumber(monthlyInvoiceMonth, invoices.length + 1),
+          clientId,
+          invoiceDate: issueDate,
+          dueDate,
+          status: 'Draft',
+          description: `Monthly invoice for ${monthlyInvoiceMonth}.`,
+        }),
+      })
+
+      if (!createInvoiceResponse.ok) {
+        const problem = await parseProblemDetails(createInvoiceResponse)
+        const validationMessages = problem?.errors
+          ? Object.values(problem.errors).flat().join(' ')
+          : problem?.detail ?? problem?.title
+        throw new Error(validationMessages || 'Unable to create monthly invoice.')
+      }
+
+      const createdInvoice = (await createInvoiceResponse.json()) as Invoice
+
+      for (const gig of gigsToInvoice) {
+        const linkGigResponse = await fetchWithSession(buildApiUrl(`/gigs/${gig.id}`), {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            clientId: gig.clientId,
+            title: gig.title,
+            date: gig.date,
+            venue: gig.venue,
+            fee: gig.fee,
+            travelMiles: gig.travelMiles,
+            passengerCount: gig.passengerCount,
+            notes: gig.notes,
+            wasDriving: gig.wasDriving,
+            status: gig.status,
+            invoiceId: createdInvoice.id,
+            expenses: gig.expenses
+              .slice()
+              .sort((left, right) => left.sortOrder - right.sortOrder)
+              .map((expense, index) => ({
+                sortOrder: index + 1,
+                description: expense.description,
+                amount: expense.amount,
+              })),
+            invoicedAt: gig.invoicedAt,
+          }),
+        })
+
+        if (!linkGigResponse.ok) {
+          const problem = await parseProblemDetails(linkGigResponse)
+          const validationMessages = problem?.errors
+            ? Object.values(problem.errors).flat().join(' ')
+            : problem?.detail ?? problem?.title
+          throw new Error(
+            validationMessages || `Unable to link ${gig.title} to the monthly invoice.`
+          )
+        }
+      }
+
+      const hydratedInvoiceResponse = await fetchWithSession(
+        buildApiUrl(`/invoices/${createdInvoice.id}`)
+      )
+
+      const updatedInvoice = hydratedInvoiceResponse.ok
+        ? ((await hydratedInvoiceResponse.json()) as Invoice)
+        : createdInvoice
+
+      setInvoices((current) => [
+        updatedInvoice,
+        ...current.filter((invoice) => invoice.id !== updatedInvoice.id),
+      ])
+      setSelectedInvoiceId(updatedInvoice.id)
+      setGigs((current) =>
+        current.map((gig) =>
+          gigsToInvoice.some((value) => value.id === gig.id)
+            ? {
+                ...gig,
+                invoiceId: updatedInvoice.id,
+                isInvoiced: true,
+                invoicedAt: gig.invoicedAt ?? new Date().toISOString(),
+              }
+            : gig
+        )
+      )
+      setGigStatus(
+        `Monthly invoice ${updatedInvoice.invoiceNumber} created for ${gigsToInvoice.length} gig(s).`
+      )
+      setInvoiceStatus(`Monthly invoice ${updatedInvoice.invoiceNumber} is ready for review.`)
+      setActiveSection('invoices')
+    } catch (error) {
+      setGigStatus(
+        error instanceof Error ? error.message : 'Unable to generate monthly invoice.'
+      )
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
   const handleDownloadInvoicePdf = async (invoice: Invoice) => {
     setIsInvoiceLoading(true)
     setInvoiceStatus(`Preparing ${invoice.invoiceNumber}.pdf...`)
@@ -1744,6 +1905,11 @@ function App() {
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateInvoice={handleGenerateInvoice}
+        onGenerateMonthlyInvoice={handleGenerateMonthlyInvoice}
+        monthlyInvoiceClientId={monthlyInvoiceClientId}
+        monthlyInvoiceMonth={monthlyInvoiceMonth}
+        onMonthlyInvoiceClientChange={setMonthlyInvoiceClientId}
+        onMonthlyInvoiceMonthChange={setMonthlyInvoiceMonth}
         onRemoveGigExpense={removeGigExpense}
         onResetForm={startGigCreate}
         onSearchQueryChange={setGigSearchQuery}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -632,6 +632,7 @@ type GigsSectionProps = {
   onExpenseAmountChange: (value: string) => void
   onExpenseDescriptionChange: (value: string) => void
   onGenerateInvoice: () => void
+  onGenerateMonthlyInvoice: () => void
   onRemoveGigExpense: (index: number) => void
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
@@ -647,6 +648,10 @@ type GigsSectionProps = {
     field: keyof GigForm,
     value: string | boolean | GigExpenseForm[]
   ) => void
+  monthlyInvoiceClientId: string
+  monthlyInvoiceMonth: string
+  onMonthlyInvoiceClientChange: (value: string) => void
+  onMonthlyInvoiceMonthChange: (value: string) => void
   plannedGigCount: number
   selectedGig: Gig | null
 }
@@ -667,6 +672,7 @@ export function GigsSection({
   onExpenseAmountChange,
   onExpenseDescriptionChange,
   onGenerateInvoice,
+  onGenerateMonthlyInvoice,
   onRemoveGigExpense,
   onResetForm,
   onSearchQueryChange,
@@ -675,6 +681,10 @@ export function GigsSection({
   onSubmit,
   onUpdateGigExpenseField,
   onUpdateGigField,
+  monthlyInvoiceClientId,
+  monthlyInvoiceMonth,
+  onMonthlyInvoiceClientChange,
+  onMonthlyInvoiceMonthChange,
   plannedGigCount,
   selectedGig,
 }: GigsSectionProps) {
@@ -778,6 +788,44 @@ export function GigsSection({
                 disabled={!selectedGig}
               >
                 Edit gig
+              </button>
+            </div>
+          </div>
+
+          <div className="gig-timeline-note">
+            <p className="detail-label">Monthly invoice run</p>
+            <div className="invoice-adjustment-form">
+              <label>
+                Client
+                <select
+                  value={monthlyInvoiceClientId}
+                  onChange={(event) => onMonthlyInvoiceClientChange(event.target.value)}
+                  disabled={isInvoiceLoading}
+                >
+                  <option value="">Select client</option>
+                  {clients.map((client) => (
+                    <option key={client.id} value={client.id}>
+                      {client.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Month
+                <input
+                  type="month"
+                  value={monthlyInvoiceMonth}
+                  onChange={(event) => onMonthlyInvoiceMonthChange(event.target.value)}
+                  disabled={isInvoiceLoading}
+                />
+              </label>
+              <button
+                className="primary-button"
+                onClick={onGenerateMonthlyInvoice}
+                type="button"
+                disabled={isInvoiceLoading}
+              >
+                Generate monthly invoice
               </button>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Ensure data is scoped to the signed-in user so clients, gigs, invoices and invoice lines only surface records the current user should see. 
- Support creating a single-month consolidated invoice for a client by adding a UI and client-side flow to generate and link gigs to a monthly invoice. 

### Description
- Added per-user visibility helpers to `EndpointSupport`: `WhereVisibleTo` for `Gig`, `Invoice`, and `InvoiceLine` and used them across endpoints to filter queries by `CreatedByUserId`.
- Threaded the current user id into endpoints by using `ClaimsPrincipal` and `ICurrentUserAccessor.TryGetUserId(user)` and applied the `WhereVisibleTo` filters on read/update/delete flows in `GigEndpoints`, `InvoiceEndpoints`, and `InvoiceLineEndpoints`.
- Persisted user stamping for created `InvoiceLine` entities via `EndpointSupport.StampCreate(line, userId)` and preserved existing stamp behavior for other entities.
- Tests: updated test auth helpers to allow switching test user via header `X-Test-UserId` by adding `AlternateUserId` and header resolution in `TestPolicyEvaluator`.
- Added a new integration test `GetInvoices_WhenSignedInAsDifferentUser_ReturnsOnlyVisibleInvoices` to verify multi-user visibility behavior.
- Frontend: added a monthly invoice feature in `App.tsx` with `getCurrentMonthValue`, `buildMonthlyInvoiceNumber`, state for `monthlyInvoiceClientId` and `monthlyInvoiceMonth`, and `handleGenerateMonthlyInvoice` which creates a draft monthly invoice and links qualifying gigs; added UI controls and wiring in `GigsSection` to select client and month and trigger generation.

### Testing
- Ran backend test suite `Glovelly.Api.Tests` including `InvoiceStatusEndpointsTests` and the new `GetInvoices_WhenSignedInAsDifferentUser_ReturnsOnlyVisibleInvoices`, and all tests passed.
- Verified endpoint behavior manually via the updated frontend flow during development (no automated frontend tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e733131dc8832889ca114eff71e225)