### PR TITLE
Move monthly invoice run controls to clients section

### DIFF
--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1851,12 +1851,19 @@ function App() {
   const currentSectionContent =
     activeSection === 'clients' ? (
       <ClientsSection
+        clients={clients}
         filteredClients={filteredClients}
         form={form}
         isApiConnected={isApiConnected}
+        isInvoiceLoading={isInvoiceLoading}
         isLoading={isLoading}
+        monthlyInvoiceClientId={monthlyInvoiceClientId}
+        monthlyInvoiceMonth={monthlyInvoiceMonth}
         mode={mode}
         onDelete={handleDelete}
+        onGenerateMonthlyInvoice={handleGenerateMonthlyInvoice}
+        onMonthlyInvoiceClientChange={setMonthlyInvoiceClientId}
+        onMonthlyInvoiceMonthChange={setMonthlyInvoiceMonth}
         onOpenClientSettings={openClientSettings}
         onResetForm={startCreating}
         onSearchQueryChange={setSearchQuery}
@@ -1905,11 +1912,6 @@ function App() {
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateInvoice={handleGenerateInvoice}
-        onGenerateMonthlyInvoice={handleGenerateMonthlyInvoice}
-        monthlyInvoiceClientId={monthlyInvoiceClientId}
-        monthlyInvoiceMonth={monthlyInvoiceMonth}
-        onMonthlyInvoiceClientChange={setMonthlyInvoiceClientId}
-        onMonthlyInvoiceMonthChange={setMonthlyInvoiceMonth}
         onRemoveGigExpense={removeGigExpense}
         onResetForm={startGigCreate}
         onSearchQueryChange={setGigSearchQuery}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -86,12 +86,19 @@ export function SignInScreen({
 }
 
 type ClientsSectionProps = {
+  clients: Client[]
   filteredClients: Client[]
   form: ClientForm
   isApiConnected: boolean
+  isInvoiceLoading: boolean
   isLoading: boolean
+  monthlyInvoiceClientId: string
+  monthlyInvoiceMonth: string
   mode: 'create' | 'edit'
   onDelete: () => void
+  onGenerateMonthlyInvoice: () => void
+  onMonthlyInvoiceClientChange: (value: string) => void
+  onMonthlyInvoiceMonthChange: (value: string) => void
   onOpenClientSettings: () => void
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
@@ -106,12 +113,19 @@ type ClientsSectionProps = {
 }
 
 export function ClientsSection({
+  clients,
   filteredClients,
   form,
   isApiConnected,
+  isInvoiceLoading,
   isLoading,
+  monthlyInvoiceClientId,
+  monthlyInvoiceMonth,
   mode,
   onDelete,
+  onGenerateMonthlyInvoice,
+  onMonthlyInvoiceClientChange,
+  onMonthlyInvoiceMonthChange,
   onOpenClientSettings,
   onResetForm,
   onSearchQueryChange,
@@ -218,33 +232,77 @@ export function ClientsSection({
           </div>
 
           {selectedClient ? (
-            <div className="detail-grid">
-              <article>
-                <p className="detail-label">Primary email</p>
-                <strong>{selectedClient.email}</strong>
-              </article>
-              <article>
-                <p className="detail-label">Billing city</p>
-                <strong>{selectedClient.billingAddress.city}</strong>
-              </article>
-              <article className="full-width">
-                <p className="detail-label">Billing address</p>
-                <strong>{selectedClient.billingAddress.line1}</strong>
-                {selectedClient.billingAddress.line2 && (
-                  <span>{selectedClient.billingAddress.line2}</span>
-                )}
-                <span>
-                  {selectedClient.billingAddress.city}
-                  {selectedClient.billingAddress.stateOrCounty
-                    ? `, ${selectedClient.billingAddress.stateOrCounty}`
-                    : ''}
-                </span>
-                <span>
-                  {selectedClient.billingAddress.postalCode},{' '}
-                  {selectedClient.billingAddress.country}
-                </span>
-              </article>
-            </div>
+            <>
+              <div className="gig-timeline-note">
+                <p className="detail-label">Monthly invoice run</p>
+                <div className="invoice-adjustment-form">
+                  <label>
+                    Client
+                    <select
+                      value={monthlyInvoiceClientId}
+                      onChange={(event) =>
+                        onMonthlyInvoiceClientChange(event.target.value)
+                      }
+                      disabled={isInvoiceLoading}
+                    >
+                      <option value="">Select client</option>
+                      {clients.map((client) => (
+                        <option key={client.id} value={client.id}>
+                          {client.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    Month
+                    <input
+                      type="month"
+                      value={monthlyInvoiceMonth}
+                      onChange={(event) =>
+                        onMonthlyInvoiceMonthChange(event.target.value)
+                      }
+                      disabled={isInvoiceLoading}
+                    />
+                  </label>
+                  <button
+                    className="primary-button"
+                    onClick={onGenerateMonthlyInvoice}
+                    type="button"
+                    disabled={isInvoiceLoading}
+                  >
+                    Generate monthly invoice
+                  </button>
+                </div>
+              </div>
+
+              <div className="detail-grid">
+                <article>
+                  <p className="detail-label">Primary email</p>
+                  <strong>{selectedClient.email}</strong>
+                </article>
+                <article>
+                  <p className="detail-label">Billing city</p>
+                  <strong>{selectedClient.billingAddress.city}</strong>
+                </article>
+                <article className="full-width">
+                  <p className="detail-label">Billing address</p>
+                  <strong>{selectedClient.billingAddress.line1}</strong>
+                  {selectedClient.billingAddress.line2 && (
+                    <span>{selectedClient.billingAddress.line2}</span>
+                  )}
+                  <span>
+                    {selectedClient.billingAddress.city}
+                    {selectedClient.billingAddress.stateOrCounty
+                      ? `, ${selectedClient.billingAddress.stateOrCounty}`
+                      : ''}
+                  </span>
+                  <span>
+                    {selectedClient.billingAddress.postalCode},{' '}
+                    {selectedClient.billingAddress.country}
+                  </span>
+                </article>
+              </div>
+            </>
           ) : (
             <div className="empty-state roomy">
               <strong>Select a client to see billing details.</strong>
@@ -632,7 +690,6 @@ type GigsSectionProps = {
   onExpenseAmountChange: (value: string) => void
   onExpenseDescriptionChange: (value: string) => void
   onGenerateInvoice: () => void
-  onGenerateMonthlyInvoice: () => void
   onRemoveGigExpense: (index: number) => void
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
@@ -648,10 +705,6 @@ type GigsSectionProps = {
     field: keyof GigForm,
     value: string | boolean | GigExpenseForm[]
   ) => void
-  monthlyInvoiceClientId: string
-  monthlyInvoiceMonth: string
-  onMonthlyInvoiceClientChange: (value: string) => void
-  onMonthlyInvoiceMonthChange: (value: string) => void
   plannedGigCount: number
   selectedGig: Gig | null
 }
@@ -672,7 +725,6 @@ export function GigsSection({
   onExpenseAmountChange,
   onExpenseDescriptionChange,
   onGenerateInvoice,
-  onGenerateMonthlyInvoice,
   onRemoveGigExpense,
   onResetForm,
   onSearchQueryChange,
@@ -681,10 +733,6 @@ export function GigsSection({
   onSubmit,
   onUpdateGigExpenseField,
   onUpdateGigField,
-  monthlyInvoiceClientId,
-  monthlyInvoiceMonth,
-  onMonthlyInvoiceClientChange,
-  onMonthlyInvoiceMonthChange,
   plannedGigCount,
   selectedGig,
 }: GigsSectionProps) {
@@ -788,44 +836,6 @@ export function GigsSection({
                 disabled={!selectedGig}
               >
                 Edit gig
-              </button>
-            </div>
-          </div>
-
-          <div className="gig-timeline-note">
-            <p className="detail-label">Monthly invoice run</p>
-            <div className="invoice-adjustment-form">
-              <label>
-                Client
-                <select
-                  value={monthlyInvoiceClientId}
-                  onChange={(event) => onMonthlyInvoiceClientChange(event.target.value)}
-                  disabled={isInvoiceLoading}
-                >
-                  <option value="">Select client</option>
-                  {clients.map((client) => (
-                    <option key={client.id} value={client.id}>
-                      {client.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Month
-                <input
-                  type="month"
-                  value={monthlyInvoiceMonth}
-                  onChange={(event) => onMonthlyInvoiceMonthChange(event.target.value)}
-                  disabled={isInvoiceLoading}
-                />
-              </label>
-              <button
-                className="primary-button"
-                onClick={onGenerateMonthlyInvoice}
-                type="button"
-                disabled={isInvoiceLoading}
-              >
-                Generate monthly invoice
               </button>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- The monthly invoice run control belonged to the Gigs panel but logically relates to clients, so the UI was restructured to surface that action under the Clients section for clearer workflow placement.

### Description
- Moved the "Monthly invoice run" JSX block from `GigsSection` into the `ClientsSection` detail panel in `frontend/glovelly-web/src/AppSections.tsx` and preserved the original form layout and behavior.
- Extended `ClientsSection` props to accept `isInvoiceLoading`, `monthlyInvoiceClientId`, `monthlyInvoiceMonth`, `onGenerateMonthlyInvoice`, `onMonthlyInvoiceClientChange`, and `onMonthlyInvoiceMonthChange`, and wired those props through from `App` in `frontend/glovelly-web/src/App.tsx`.
- Removed the monthly-invoice props and UI from `GigsSection` and its prop types so the gigs panel no longer renders the monthly-invoice controls.
- Updated the client select to use the `clients` prop inside `ClientsSection` and adjusted related imports/usage accordingly.

### Testing
- Ran `npm run build` in `frontend/glovelly-web` which succeeded (TypeScript build + `vite build`).
- No automated UI tests were present for this change, so only the production build was validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76bf432dc8328bd2132dbf5fc1b84)