### PR TITLE
Generate combined invoices from selected gigs (backend + frontend)

### DIFF
--- a/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
+++ b/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
@@ -196,7 +196,7 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
 
         var riversideGigResponse = await _client.PostAsJsonAsync("/gigs", new
         {
-            clientId = TestData.RiversideCateringId,
+            clientId = TestData.RiversideId,
             title = "Riverside gig",
             date = "2026-06-02",
             venue = "Venue B",

--- a/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
+++ b/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
@@ -109,4 +109,118 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
         Assert.Equal("This gig has already been invoiced.", conflict.GetProperty("message").GetString());
         Assert.Equal(JsonValueKind.String, conflict.GetProperty("invoiceId").ValueKind);
     }
+
+    [Fact]
+    public async Task GenerateInvoice_FromSelectedGigs_CreatesCombinedInvoiceOrderedByDate()
+    {
+        var firstGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Second date gig",
+            date = "2026-05-20",
+            venue = "Bridge Hall",
+            fee = 200.00m,
+            travelMiles = 0m,
+            notes = "Later in month",
+            wasDriving = false,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        firstGigResponse.EnsureSuccessStatusCode();
+        var firstGig = await firstGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var secondGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "First date gig",
+            date = "2026-05-10",
+            venue = "Park Room",
+            fee = 300.00m,
+            travelMiles = 0m,
+            notes = "Earlier in month",
+            wasDriving = false,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        secondGigResponse.EnsureSuccessStatusCode();
+        var secondGig = await secondGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/gigs/generate-invoice", new
+        {
+            gigIds = new[]
+            {
+                firstGig.GetProperty("id").GetGuid(),
+                secondGig.GetProperty("id").GetGuid(),
+            }
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var invoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var lines = invoice.GetProperty("lines").EnumerateArray().OrderBy(line => line.GetProperty("sortOrder").GetInt32()).ToArray();
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("First date gig (2026-05-10)", lines[0].GetProperty("description").GetString());
+        Assert.Contains("Second date gig (2026-05-20)", lines[1].GetProperty("description").GetString());
+
+        var invoiceId = invoice.GetProperty("id").GetGuid();
+        foreach (var gigId in new[] { firstGig.GetProperty("id").GetGuid(), secondGig.GetProperty("id").GetGuid() })
+        {
+            var gigResponse = await _client.GetAsync($"/gigs/{gigId}");
+            gigResponse.EnsureSuccessStatusCode();
+            var refreshedGig = await gigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+            Assert.Equal(invoiceId, refreshedGig.GetProperty("invoiceId").GetGuid());
+        }
+
+        var pdfResponse = await _client.GetAsync($"/invoices/{invoiceId}/pdf");
+        Assert.Equal(HttpStatusCode.OK, pdfResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task GenerateInvoice_FromSelectedGigs_WhenDifferentClients_ReturnsValidationError()
+    {
+        var foxGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Fox gig",
+            date = "2026-06-01",
+            venue = "Venue A",
+            fee = 100.00m,
+            travelMiles = 0m,
+            notes = "Fox notes",
+            wasDriving = false,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        foxGigResponse.EnsureSuccessStatusCode();
+        var foxGig = await foxGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var riversideGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.RiversideCateringId,
+            title = "Riverside gig",
+            date = "2026-06-02",
+            venue = "Venue B",
+            fee = 120.00m,
+            travelMiles = 0m,
+            notes = "Riverside notes",
+            wasDriving = false,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        riversideGigResponse.EnsureSuccessStatusCode();
+        var riversideGig = await riversideGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await _client.PostAsJsonAsync("/gigs/generate-invoice", new
+        {
+            gigIds = new[]
+            {
+                foxGig.GetProperty("id").GetGuid(),
+                riversideGig.GetProperty("id").GetGuid(),
+            }
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Selected gigs must all belong to the same client.", problem.GetProperty("errors").GetProperty("gigIds")[0].GetString());
+    }
 }

--- a/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
@@ -11,6 +11,98 @@ public static class GigEndpoints
 {
     public static RouteGroupBuilder MapGigEndpoints(this RouteGroupBuilder group)
     {
+        group.MapPost("/generate-invoice", async (
+            GenerateInvoiceFromGigSelectionRequest request,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IInvoiceWorkflowService invoiceWorkflowService) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var gigIds = request.GigIds
+                .Where(id => id != Guid.Empty)
+                .Distinct()
+                .ToList();
+
+            if (gigIds.Count == 0)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["gigIds"] = ["Select at least one gig."]
+                });
+            }
+
+            var gigs = await db.Gigs
+                .WhereVisibleTo(userId)
+                .Include(value => value.Client)
+                .Include(value => value.Expenses)
+                .Where(value => gigIds.Contains(value.Id))
+                .OrderBy(value => value.Date)
+                .ThenBy(value => value.Title)
+                .ToListAsync();
+
+            if (gigs.Count != gigIds.Count)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["gigIds"] = ["One or more selected gigs do not exist."]
+                });
+            }
+
+            if (gigs.Any(gig => gig.InvoiceId.HasValue))
+            {
+                return Results.Conflict(new
+                {
+                    message = "All selected gigs must be uninvoiced before creating a combined invoice.",
+                });
+            }
+
+            var distinctClientIds = gigs
+                .Select(gig => gig.ClientId)
+                .Distinct()
+                .ToList();
+
+            if (distinctClientIds.Count != 1)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["gigIds"] = ["Selected gigs must all belong to the same client."]
+                });
+            }
+
+            var client = gigs[0].Client;
+            if (client is null)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["clientId"] = ["Client does not exist."]
+                });
+            }
+
+            var firstGig = gigs[0];
+            var invoice = await invoiceWorkflowService.GenerateInvoiceForGigAsync(firstGig, client, userId);
+
+            foreach (var gig in gigs.Skip(1))
+            {
+                gig.InvoiceId = invoice.Id;
+                gig.InvoicedAt = DateTimeOffset.UtcNow;
+                EndpointSupport.StampUpdate(gig, userId);
+                await invoiceWorkflowService.SyncGeneratedInvoiceLinesForGigAsync(gig, userId);
+            }
+
+            await db.SaveChangesAsync();
+
+            var refreshedInvoice = await db.Invoices
+                .WhereVisibleTo(userId)
+                .Include(value => value.Lines)
+                .FirstAsync(value => value.Id == invoice.Id);
+
+            await invoiceWorkflowService.ReissueInvoiceAsync(refreshedInvoice, client, userId);
+            await db.SaveChangesAsync();
+
+            return Results.Created($"/invoices/{refreshedInvoice.Id}", refreshedInvoice);
+        });
+
         group.MapGet("/", async (AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -289,4 +381,6 @@ public static class GigEndpoints
 
         return group;
     }
+
+    private sealed record GenerateInvoiceFromGigSelectionRequest(IReadOnlyList<Guid> GigIds);
 }

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -96,6 +96,7 @@ function App() {
   const [isAdminLoading, setIsAdminLoading] = useState(false)
   const [gigs, setGigs] = useState<Gig[]>([])
   const [selectedGigId, setSelectedGigId] = useState<string>('')
+  const [selectedGigIds, setSelectedGigIds] = useState<string[]>([])
   const [gigSearchQuery, setGigSearchQuery] = useState('')
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
   const [gigForm, setGigForm] = useState<GigForm>(emptyGigForm)
@@ -500,6 +501,14 @@ function App() {
     filteredGigs[0] ??
     null
 
+  const selectedGigs = useMemo(
+    () =>
+      gigs
+        .filter((gig) => selectedGigIds.includes(gig.id))
+        .sort((left, right) => left.date.localeCompare(right.date)),
+    [gigs, selectedGigIds]
+  )
+
   const selectedInvoice =
     filteredInvoices.find((invoice) => invoice.id === selectedInvoiceId) ??
     invoices.find((invoice) => invoice.id === selectedInvoiceId) ??
@@ -523,6 +532,10 @@ function App() {
       setSelectedGigId(selectedGig.id)
     }
   }, [selectedGig])
+
+  useEffect(() => {
+    setSelectedGigIds((current) => current.filter((gigId) => gigs.some((gig) => gig.id === gigId)))
+  }, [gigs])
 
   useEffect(() => {
     if (selectedInvoice) {
@@ -662,6 +675,7 @@ function App() {
     )
     setGigExpenseAmount('')
     setGigExpenseDescription('')
+    setSelectedGigIds([])
   }
 
   const startGigEdit = () => {
@@ -1434,8 +1448,86 @@ function App() {
   }
 
   const handleGenerateInvoice = async () => {
+    if (selectedGigs.length > 0) {
+      const distinctClientIds = new Set(selectedGigs.map((gig) => gig.clientId))
+      if (distinctClientIds.size > 1) {
+        setGigStatus('Selected gigs must all belong to the same client.')
+        return
+      }
+
+      const alreadyInvoicedGig = selectedGigs.find((gig) => gig.isInvoiced)
+      if (alreadyInvoicedGig) {
+        setGigStatus(`"${alreadyInvoicedGig.title}" is already linked to an invoice.`)
+        return
+      }
+
+      setIsInvoiceLoading(true)
+      setGigStatus(`Generating invoice for ${selectedGigs.length} selected gig(s)...`)
+
+      try {
+        const response = await fetchWithSession(buildApiUrl('/gigs/generate-invoice'), {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            gigIds: selectedGigs.map((gig) => gig.id),
+          }),
+        })
+
+        if (response.status === 409) {
+          const conflict = (await response.json()) as { message?: string }
+          throw new Error(
+            conflict.message ?? 'Selected gigs must all be uninvoiced before generating.'
+          )
+        }
+
+        if (!response.ok) {
+          const problem = await parseProblemDetails(response)
+          const validationMessages = problem?.errors
+            ? Object.values(problem.errors).flat().join(' ')
+            : problem?.detail ?? problem?.title
+          throw new Error(validationMessages || 'Unable to generate invoice.')
+        }
+
+        const generatedInvoice = (await response.json()) as Invoice
+        const nowIso = new Date().toISOString()
+        const selectedIds = new Set(selectedGigs.map((gig) => gig.id))
+
+        setInvoices((current) => [
+          generatedInvoice,
+          ...current.filter((invoice) => invoice.id !== generatedInvoice.id),
+        ])
+        setSelectedInvoiceId(generatedInvoice.id)
+        setGigs((current) =>
+          current.map((gig) =>
+            selectedIds.has(gig.id)
+              ? {
+                  ...gig,
+                  invoiceId: generatedInvoice.id,
+                  invoicedAt: gig.invoicedAt ?? nowIso,
+                  isInvoiced: true,
+                }
+              : gig
+          )
+        )
+        setSelectedGigIds([])
+        setGigStatus(
+          `Invoice ${generatedInvoice.invoiceNumber} generated from ${selectedGigs.length} selected gig(s).`
+        )
+        setInvoiceStatus(`Invoice ${generatedInvoice.invoiceNumber} is ready for review.`)
+        setActiveSection('invoices')
+      } catch (error) {
+        setGigStatus(error instanceof Error ? error.message : 'Unable to generate invoice.')
+      } finally {
+        setIsInvoiceLoading(false)
+      }
+
+      return
+    }
+
     if (!selectedGig) {
-      setGigStatus('Select a gig first.')
+      setGigStatus('Select one or more gigs first.')
       return
     }
 
@@ -1496,6 +1588,14 @@ function App() {
     } finally {
       setIsInvoiceLoading(false)
     }
+  }
+
+  const handleToggleGigSelection = (gigId: string) => {
+    setSelectedGigIds((current) =>
+      current.includes(gigId)
+        ? current.filter((value) => value !== gigId)
+        : [...current, gigId]
+    )
   }
 
   const handleGenerateMonthlyInvoice = async () => {
@@ -1916,12 +2016,15 @@ function App() {
         onResetForm={startGigCreate}
         onSearchQueryChange={setGigSearchQuery}
         onSelectGig={setSelectedGigId}
+        onToggleGigSelection={handleToggleGigSelection}
         onStartEditing={startGigEdit}
         onSubmit={handleGigSubmit}
         onUpdateGigExpenseField={updateGigExpenseField}
         onUpdateGigField={updateGigField}
         plannedGigCount={plannedGigCount}
         selectedGig={selectedGig}
+        selectedGigIds={selectedGigIds}
+        selectedGigs={selectedGigs}
       />
     ) : (
       <InvoicesSection

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -694,6 +694,7 @@ type GigsSectionProps = {
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
   onSelectGig: (gigId: string) => void
+  onToggleGigSelection: (gigId: string) => void
   onStartEditing: () => void
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   onUpdateGigExpenseField: (
@@ -707,6 +708,8 @@ type GigsSectionProps = {
   ) => void
   plannedGigCount: number
   selectedGig: Gig | null
+  selectedGigIds: string[]
+  selectedGigs: Gig[]
 }
 
 export function GigsSection({
@@ -729,15 +732,19 @@ export function GigsSection({
   onResetForm,
   onSearchQueryChange,
   onSelectGig,
+  onToggleGigSelection,
   onStartEditing,
   onSubmit,
   onUpdateGigExpenseField,
   onUpdateGigField,
   plannedGigCount,
   selectedGig,
+  selectedGigIds,
+  selectedGigs,
 }: GigsSectionProps) {
   const selectedGigClient =
     clients.find((client) => client.id === selectedGig?.clientId) ?? null
+  const hasCrossClientSelection = new Set(selectedGigs.map((gig) => gig.clientId)).size > 1
 
   return (
     <section className="section-layout">
@@ -791,6 +798,15 @@ export function GigsSection({
                   onClick={() => onSelectGig(gig.id)}
                   type="button"
                 >
+                  <label onClick={(event) => event.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      checked={selectedGigIds.includes(gig.id)}
+                      disabled={gig.isInvoiced}
+                      onChange={() => onToggleGigSelection(gig.id)}
+                    />
+                    <span>{gig.isInvoiced ? 'Invoiced' : 'Select'}</span>
+                  </label>
                   <div>
                     <strong>{gig.title}</strong>
                     <span>{clientName}</span>
@@ -825,9 +841,18 @@ export function GigsSection({
                 className="primary-button"
                 onClick={onGenerateInvoice}
                 type="button"
-                disabled={!selectedGig || selectedGig.isInvoiced || isInvoiceLoading}
+                disabled={
+                  isInvoiceLoading ||
+                  (selectedGigIds.length === 0 &&
+                    (!selectedGig || selectedGig.isInvoiced)) ||
+                  hasCrossClientSelection
+                }
               >
-                {selectedGig?.isInvoiced ? 'Already invoiced' : 'Generate invoice'}
+                {selectedGigIds.length > 0
+                  ? `Generate invoice (${selectedGigIds.length})`
+                  : selectedGig?.isInvoiced
+                    ? 'Already invoiced'
+                    : 'Generate invoice'}
               </button>
               <button
                 className="ghost-button"
@@ -884,6 +909,13 @@ export function GigsSection({
                     ? 'This gig is already linked to an invoice. Open the invoices workspace to review or download it.'
                     : 'This record now carries the client, date, venue and fee needed to generate a one-off invoice.'}
                 </span>
+                {selectedGigIds.length > 0 && (
+                  <span>
+                    {hasCrossClientSelection
+                      ? 'Selected gigs must share the same client before invoice generation is allowed.'
+                      : `${selectedGigIds.length} gig(s) selected for a combined invoice.`}
+                  </span>
+                )}
               </div>
             </>
           ) : (


### PR DESCRIPTION
### Motivation
- Provide the ability to generate a single invoice from multiple selected gigs while enforcing business rules such as single-client grouping and uninvoiced gigs.
- Ensure the generated combined invoice has lines ordered by gig date and that gigs are linked to the new invoice and stamped with `InvoicedAt`.

### Description
- Added a new backend endpoint `POST /gigs/generate-invoice` with request model `GenerateInvoiceFromGigSelectionRequest` that validates input, ensures all gigs exist, belong to the same client, and are uninvoiced, then creates a combined invoice and reissues it via the `IInvoiceWorkflowService`.
- Backend ensures selected gigs are loaded ordered by `Date` and `Title`, assigns `InvoiceId`/`InvoicedAt` to each gig, calls `SyncGeneratedInvoiceLinesForGigAsync` for synced lines, and returns `201 Created` with the refreshed invoice; validation and conflict responses are returned as appropriate.
- Frontend adds multi-select support via `selectedGigIds` and derived `selectedGigs`, UI checkboxes in the gigs list, `handleToggleGigSelection`, and updates `handleGenerateInvoice` to POST multiple gig IDs to `'/gigs/generate-invoice'`, handle validation/conflict responses, update `invoices` and `gigs` state, clear selections, and adjust button text/disabled logic.
- Wire changes through the UI by passing `selectedGigIds`, `selectedGigs`, and `onToggleGigSelection` into `GigsSection` and updating the gig card rendering and status messaging.

### Testing
- Added backend integration tests in `GigInvoiceGenerationTests`: `GenerateInvoice_FromSelectedGigs_CreatesCombinedInvoiceOrderedByDate` and `GenerateInvoice_FromSelectedGigs_WhenDifferentClients_ReturnsValidationError`, which exercise success and validation scenarios respectively.
- Ran the automated test suite (`dotnet test` for the backend tests) and the test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e775b147c88328aa2e50f35cd9aa4f)