### PR TITLE
[codex] Polish invoice UI and improve frontend responsiveness

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -200,6 +200,59 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
     }
 
     [Fact]
+    public async Task DeleteInvoice_WhenDraft_UnlinksAssociatedGigs()
+    {
+        var createInvoiceResponse = await _client.PostAsJsonAsync("/invoices", new
+        {
+            invoiceNumber = "INV-DELETE-LINKED",
+            clientId = TestData.FoxAndFinchId,
+            invoiceDate = "2026-06-02",
+            dueDate = "2026-06-16",
+            status = "Draft",
+            description = "Draft invoice linked to a gig",
+        });
+        createInvoiceResponse.EnsureSuccessStatusCode();
+
+        var createdInvoice = await createInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var invoiceId = createdInvoice.GetProperty("id").GetGuid();
+
+        var createGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            invoiceId,
+            title = "Invoice deletion unlink test",
+            date = "2026-06-10",
+            venue = "Town Hall",
+            fee = 250.00m,
+            travelMiles = 0m,
+            passengerCount = (int?)null,
+            notes = "Should be unlinked when invoice is deleted",
+            wasDriving = false,
+            status = "Completed",
+            expenses = Array.Empty<object>(),
+            invoicedAt = (string?)null,
+        });
+        createGigResponse.EnsureSuccessStatusCode();
+
+        var createdGig = await createGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var gigId = createdGig.GetProperty("id").GetGuid();
+        Assert.Equal(invoiceId, createdGig.GetProperty("invoiceId").GetGuid());
+        Assert.True(createdGig.GetProperty("isInvoiced").GetBoolean());
+        Assert.Equal(JsonValueKind.String, createdGig.GetProperty("invoicedAt").ValueKind);
+
+        var deleteResponse = await _client.DeleteAsync($"/invoices/{invoiceId}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var gigResponse = await _client.GetAsync($"/gigs/{gigId}");
+        gigResponse.EnsureSuccessStatusCode();
+
+        var gig = await gigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(JsonValueKind.Null, gig.GetProperty("invoiceId").ValueKind);
+        Assert.False(gig.GetProperty("isInvoiced").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, gig.GetProperty("invoicedAt").ValueKind);
+    }
+
+    [Fact]
     public async Task DeleteInvoice_WhenNotDraft_ReturnsValidationProblem()
     {
         var response = await _client.DeleteAsync($"/invoices/{TestData.FoxInvoiceId}");

--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -260,35 +260,35 @@ internal static class AuthFlowSupport
         return failureCode switch
         {
             "inactive_user" => new UnauthorizedPageCopy(
-                "User Inactive",
-                "Your Glovelly user is currently inactive.",
-                "Authentication succeeded, but this Glovelly user has been disabled and cannot sign in right now.",
-                "Ask an admin to re-enable your user, then try signing in again."),
+                "Account Inactive",
+                "Your account is currently inactive.",
+                "You cannot sign in right now because this account has been turned off.",
+                "Ask an admin to re-enable your access, then try again."),
             "missing_subject" => new UnauthorizedPageCopy(
                 "Sign-In Issue",
-                "Glovelly could not verify this Google identity.",
-                "Google signed you in, but the subject identifier needed to match your Glovelly user was missing from the response.",
-                "If this happens repeatedly, it is likely a configuration issue rather than a permissions issue."),
+                "We could not complete your sign-in.",
+                "Your account could not be matched correctly this time.",
+                "Try again. If this keeps happening, ask an admin for help."),
             "missing_email" => new UnauthorizedPageCopy(
                 "Sign-In Issue",
-                "Google did not provide a usable email address.",
-                "Glovelly can only bootstrap a pre-provisioned account when Google returns an email claim.",
-                "Check the Google account and OpenID scopes, then try signing in again."),
+                "We could not read your email address.",
+                "Glovelly needs an email address to sign you in.",
+                "Check the account you used, then try again."),
             "email_not_verified" => new UnauthorizedPageCopy(
                 "Email Not Verified",
-                "This Google email address is not verified.",
-                "Glovelly only allows first-time enrolment binding when Google indicates the email address is verified.",
-                "Verify the Google account email first, then try again."),
+                "This email address is not verified.",
+                "You need a verified email address before you can sign in.",
+                "Verify the email address on your account, then try again."),
             "sign_in_failed" => new UnauthorizedPageCopy(
                 "Sign-In Issue",
-                "Google sign-in did not complete.",
-                "The authentication flow was interrupted before Glovelly could create an application session.",
-                "Try again first. If it keeps happening, check the Google OIDC configuration and callback settings."),
+                "Sign-in did not complete.",
+                "Something interrupted the sign-in process before it finished.",
+                "Try again. If it keeps happening, ask an admin for help."),
             _ => new UnauthorizedPageCopy(
-                "User Not Authorised",
-                "This Google account is not enrolled for Glovelly access.",
-                "Authentication succeeded, but Glovelly could not find an active local user linked to this Google account.",
-                "Ask an admin to enrol this user in Glovelly, then try signing in again."),
+                "Access Needed",
+                "This account does not currently have access to Glovelly.",
+                "You have signed in successfully, but this account is not set up to use Glovelly yet.",
+                "Ask an admin to grant access, then try again."),
         };
     }
 

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -297,6 +297,19 @@ public static class InvoiceEndpoints
             }
 
             var deletedAtUtc = DateTimeOffset.UtcNow;
+            var linkedGigs = await db.Gigs
+                .WhereVisibleTo(userId)
+                .Where(gig => gig.InvoiceId == invoice.Id)
+                .ToListAsync();
+
+            foreach (var gig in linkedGigs)
+            {
+                gig.InvoiceId = null;
+                gig.Invoice = null;
+                gig.InvoicedAt = null;
+                EndpointSupport.StampUpdate(gig, userId);
+            }
+
             logger.LogInformation(
                 "Invoice {InvoiceId} ({InvoiceNumber}) deleted by user {UserId} at {DeletedAtUtc}.",
                 invoice.Id,

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -27,7 +27,6 @@
   border: 1px solid var(--surface-border);
   background: var(--surface-panel);
   box-shadow: var(--surface-shadow);
-  backdrop-filter: blur(18px);
 }
 
 .hero-panel {
@@ -248,7 +247,6 @@
   border: 1px solid var(--surface-border);
   background: var(--surface-overlay);
   box-shadow: var(--surface-shadow-strong);
-  backdrop-filter: blur(18px);
   display: grid;
   gap: 14px;
   z-index: 40;
@@ -302,7 +300,6 @@
   inset: 0;
   z-index: 80;
   background: color-mix(in srgb, #1a1410 42%, transparent);
-  backdrop-filter: blur(10px);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -468,6 +465,7 @@
   transition:
     width 280ms ease,
     opacity 180ms ease;
+  contain: layout paint;
 }
 
 .editor-slot.open {
@@ -531,6 +529,8 @@
   gap: 12px;
   overflow: auto;
   padding-right: 4px;
+  content-visibility: auto;
+  contain-intrinsic-size: 500px;
 }
 
 .client-card {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -400,7 +400,7 @@
 .workspace {
   display: grid;
   gap: 24px;
-  grid-template-columns: minmax(300px, 0.95fr) minmax(320px, 1fr) minmax(360px, 1.1fr);
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1fr) auto;
 }
 
 .admin-zone {
@@ -416,13 +416,13 @@
 .admin-workspace {
   display: grid;
   gap: 24px;
-  grid-template-columns: minmax(280px, 0.9fr) minmax(320px, 1fr) minmax(360px, 1.05fr);
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1fr) auto;
 }
 
 .gig-workspace {
   display: grid;
   gap: 24px;
-  grid-template-columns: minmax(280px, 0.9fr) minmax(320px, 1fr) minmax(360px, 1.05fr);
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1fr) auto;
 }
 
 .gigs-draft {
@@ -454,6 +454,57 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.editor-panel {
+  animation: editor-panel-enter 220ms ease;
+}
+
+.editor-slot {
+  width: 0;
+  min-width: 0;
+  overflow: clip;
+  opacity: 0;
+  transition:
+    width 280ms ease,
+    opacity 180ms ease;
+}
+
+.editor-slot.open {
+  width: clamp(320px, 30vw, 480px);
+  opacity: 1;
+}
+
+.editor-slot > .panel {
+  width: clamp(320px, 30vw, 480px);
+  min-width: 320px;
+  transform: translateX(14px);
+  transition:
+    transform 280ms ease,
+    opacity 180ms ease,
+    visibility 0s linear 180ms;
+  visibility: hidden;
+}
+
+.editor-slot.open > .panel {
+  transform: translateX(0);
+  visibility: visible;
+  transition:
+    transform 280ms ease,
+    opacity 180ms ease,
+    visibility 0s linear 0s;
+}
+
+@keyframes editor-panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .panel-heading {
@@ -875,6 +926,29 @@ button:disabled {
 
   .content-header-top {
     align-items: stretch;
+  }
+
+  .editor-slot {
+    width: 100%;
+    max-height: 0;
+    min-width: 0;
+    opacity: 0;
+    transform: none;
+    visibility: hidden;
+  }
+
+  .editor-slot.open {
+    width: 100%;
+    max-height: 2000px;
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .editor-slot > .panel,
+  .editor-slot.open > .panel {
+    width: 100%;
+    min-width: 0;
+    transform: none;
   }
 }
 

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -34,12 +34,12 @@
   padding: 32px;
   display: grid;
   gap: 28px;
-  grid-template-columns: minmax(0, 2.1fr) minmax(300px, 1fr);
+  grid-template-columns: 1fr;
   align-items: end;
 }
 
 .app-frame {
-  grid-template-columns: minmax(280px, 0.7fr) minmax(0, 1.45fr);
+  grid-template-columns: 1fr;
   align-items: start;
 }
 
@@ -52,61 +52,9 @@
   gap: 16px;
 }
 
-.nav-panel {
-  display: grid;
-  gap: 18px;
-  align-self: stretch;
-}
-
 .nav-intro {
   display: grid;
   gap: 16px;
-}
-
-.nav-menu {
-  display: grid;
-  gap: 12px;
-}
-
-.nav-item {
-  text-align: left;
-  border: 1px solid var(--surface-border);
-  border-radius: 22px;
-  padding: 18px;
-  display: grid;
-  gap: 6px;
-  background: var(--surface-elevated);
-  color: inherit;
-  transition:
-    transform 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease,
-    box-shadow 180ms ease;
-}
-
-.nav-item strong {
-  color: var(--heading);
-  font-size: 1.05rem;
-}
-
-.nav-item span:last-child {
-  color: var(--muted);
-}
-
-.nav-item:hover,
-.nav-item:focus-visible,
-.nav-item.selected {
-  transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--heading) 35%, transparent);
-  background: var(--surface-accent);
-  box-shadow: var(--surface-shadow-soft);
-}
-
-.nav-meta {
-  font-size: 0.74rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--muted-strong);
 }
 
 .content-shell {
@@ -132,6 +80,67 @@
 .content-header-aside {
   display: grid;
   gap: 18px;
+}
+
+.content-header-body {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.8fr);
+  align-items: start;
+}
+
+.header-mascot {
+  align-self: stretch;
+}
+
+.charm-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.charm-item {
+  text-align: left;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 92%, transparent);
+  border-radius: 20px;
+  padding: 14px 16px;
+  display: grid;
+  gap: 4px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-elevated) 94%, white) 0%, var(--surface-elevated) 100%);
+  color: inherit;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.charm-item strong {
+  color: var(--heading);
+  font-size: 0.98rem;
+}
+
+.charm-item span:last-child {
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.charm-item:hover,
+.charm-item:focus-visible,
+.charm-item.selected {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, #f47d2a 38%, var(--surface-border));
+  background: var(--surface-accent);
+  box-shadow: var(--surface-shadow-soft);
+}
+
+.charm-meta {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
 }
 
 .auth-shell {
@@ -371,7 +380,7 @@
 
 .hero-metrics {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
 }
 
@@ -928,6 +937,11 @@ button:disabled {
     align-items: stretch;
   }
 
+  .content-header-body,
+  .charm-bar {
+    grid-template-columns: 1fr;
+  }
+
   .editor-slot {
     width: 100%;
     max-height: 0;
@@ -983,6 +997,10 @@ button:disabled {
 
   .content-header-top {
     flex-direction: column;
+  }
+
+  .charm-item span:last-child {
+    display: none;
   }
 
   .profile-menu {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -509,6 +509,25 @@
   gap: 4px;
 }
 
+.gig-select-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  color: var(--muted-strong);
+  font-size: 0.84rem;
+}
+
+.gig-select-toggle input {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+  min-height: 16px;
+  margin: 0;
+  padding: 0;
+  accent-color: color-mix(in srgb, var(--heading) 72%, white);
+}
+
 .client-card strong,
 .detail-grid strong {
   color: var(--heading);
@@ -592,7 +611,7 @@
   display: grid;
   gap: 10px;
   margin-top: 10px;
-  grid-template-columns: minmax(0, 140px) minmax(0, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: end;
 }
 
@@ -778,6 +797,7 @@ input,
 select {
   width: 100%;
   box-sizing: border-box;
+  min-width: 0;
   min-height: 48px;
   border-radius: 16px;
   border: 1px solid color-mix(in srgb, var(--surface-border) 95%, transparent);
@@ -789,6 +809,7 @@ select {
 textarea {
   width: 100%;
   box-sizing: border-box;
+  min-width: 0;
   border-radius: 16px;
   border: 1px solid color-mix(in srgb, var(--surface-border) 95%, transparent);
   background: var(--surface-elevated);

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -578,14 +578,16 @@ function App({ appMetadata }: AppProps) {
     setMonthlyInvoiceClientId(clients[0]?.id ?? '')
   }, [clients, monthlyInvoiceClientId])
 
-  const activeCities = new Set(clients.map((client) => client.billingAddress.city)).size
   const activeUsersCount = adminUsers.filter((user) => user.isActive).length
   const totalAdmins = adminUsers.filter((user) => user.role === 'Admin').length
   const plannedGigCount = gigs.filter((gig) => gig.status === 'Confirmed').length
   const completedGigCount = gigs.filter((gig) => gig.status === 'Completed').length
   const upcomingGigCount = gigs.filter((gig) => gig.date >= new Date().toISOString().slice(0, 10)).length
+  const uninvoicedGigCount = gigs.filter((gig) => !gig.isInvoiced && gig.status !== 'Cancelled').length
   const draftInvoiceCount = invoices.filter((invoice) => invoice.status === 'Draft').length
   const issuedInvoiceCount = invoices.filter((invoice) => invoice.status === 'Issued').length
+  const overdueInvoiceCount = invoices.filter((invoice) => invoice.status === 'Overdue').length
+  const outstandingInvoiceCount = issuedInvoiceCount + overdueInvoiceCount
 
   const navigationItems: Array<{
     id: AppSection
@@ -600,16 +602,6 @@ function App({ appMetadata }: AppProps) {
       eyebrow: 'Live',
       description: 'Booking contacts, billing details and client records.',
     },
-    ...(isAdmin
-      ? [
-          {
-            id: 'admin' as const,
-            label: 'Admin',
-            eyebrow: 'Restricted',
-            description: 'Manage access, roles and account status.',
-          },
-        ]
-      : []),
     {
       id: 'gigs',
       label: 'Gigs',
@@ -622,25 +614,37 @@ function App({ appMetadata }: AppProps) {
       eyebrow: 'Generated',
       description: 'One-off invoices, line items and downloadable PDFs.',
     },
+    ...(isAdmin
+      ? [
+          {
+            id: 'admin' as const,
+            label: 'Admin',
+            eyebrow: 'Restricted',
+            description: 'Manage access, roles and account status.',
+          },
+        ]
+      : []),
   ]
 
   const currentSection = navigationItems.find((item) => item.id === activeSection)
-  const secondaryMetricValue =
-    activeSection === 'admin'
-      ? activeUsersCount
-      : activeSection === 'gigs'
-        ? upcomingGigCount
-        : activeSection === 'invoices'
-          ? draftInvoiceCount
-        : activeCities
-  const secondaryMetricLabel =
-    activeSection === 'admin'
-      ? 'active accounts'
-      : activeSection === 'gigs'
-        ? 'upcoming gigs'
-        : activeSection === 'invoices'
-          ? 'draft invoices'
-        : 'active cities'
+  const headerMetrics = [
+    {
+      value: upcomingGigCount,
+      label: 'upcoming gigs',
+    },
+    {
+      value: uninvoicedGigCount,
+      label: 'uninvoiced gigs',
+    },
+    {
+      value: outstandingInvoiceCount,
+      label: 'outstanding invoices',
+    },
+    {
+      value: draftInvoiceCount,
+      label: 'draft invoices',
+    },
+  ]
 
   const startCreating = () => {
     setMode('create')
@@ -2148,52 +2152,15 @@ function App({ appMetadata }: AppProps) {
   return (
     <main className="app-shell">
       <section className="hero-panel app-frame">
-        <aside className="nav-panel">
-          <div className="nav-intro">
-            <p className="eyebrow">Workspace</p>
-            <h1>Your work, all in one place.</h1>
-            <p className="hero-text">
-              Move between clients, gigs, invoices and admin tools with everything easy to find.
-            </p>
-          </div>
-
-          <nav className="nav-menu" aria-label="Primary">
-            {navigationItems.map((item) => (
-              <button
-                key={item.id}
-                className={`nav-item ${activeSection === item.id ? 'selected' : ''}`}
-                onClick={() => setActiveSection(item.id)}
-                type="button"
-                disabled={item.disabled}
-              >
-                <span className="nav-meta">{item.eyebrow}</span>
-                <strong>{item.label}</strong>
-                <span>{item.description}</span>
-              </button>
-            ))}
-          </nav>
-
-          <div className="hero-mascot">
-            <img
-              src="/gordon-192.png"
-              alt="Gordon the Glovelly mascot"
-              decoding="async"
-              loading="lazy"
-            />
-            <div>
-              <p className="section-label">Meet Gordon</p>
-              <strong>Mozart wig. Rubber chicken. Unreasonably good taste in admin.</strong>
-            </div>
-          </div>
-        </aside>
-
         <div className="content-shell">
           <div className="content-header panel">
             <div className="content-header-top">
               <div className="content-header-copy">
-                <p className="eyebrow">{currentSection?.eyebrow ?? 'Workspace'}</p>
-                <h2>{currentSection?.label ?? 'Glovelly'}</h2>
-                <p className="hero-text">{currentSection?.description}</p>
+                <p className="eyebrow">Workspace</p>
+                <h1>Your work, all in one place.</h1>
+                <p className="hero-text">
+                  Move between clients, gigs, invoices and admin tools with everything easy to find.
+                </p>
               </div>
 
               <div className="profile-menu" ref={profileMenuRef}>
@@ -2267,20 +2234,51 @@ function App({ appMetadata }: AppProps) {
               </div>
             </div>
 
+            <div className="content-header-body">
+              <div className="content-header-copy">
+                <p className="eyebrow">{currentSection?.eyebrow ?? 'Workspace'}</p>
+                <h2>{currentSection?.label ?? 'Glovelly'}</h2>
+                <p className="hero-text">{currentSection?.description}</p>
+              </div>
+
+              <div className="hero-mascot header-mascot">
+                <img
+                  src="/gordon-192.png"
+                  alt="Gordon the Glovelly mascot"
+                  decoding="async"
+                  loading="lazy"
+                />
+                <div>
+                  <p className="section-label">Meet Gordon</p>
+                  <strong>Mozart wig. Rubber chicken. Unreasonably good taste in admin.</strong>
+                </div>
+              </div>
+            </div>
+
+            <nav className="charm-bar" aria-label="Primary">
+              {navigationItems.map((item) => (
+                <button
+                  key={item.id}
+                  className={`charm-item ${activeSection === item.id ? 'selected' : ''}`}
+                  onClick={() => setActiveSection(item.id)}
+                  type="button"
+                  disabled={item.disabled}
+                >
+                  <span className="charm-meta">{item.eyebrow}</span>
+                  <strong>{item.label}</strong>
+                  <span>{item.description}</span>
+                </button>
+              ))}
+            </nav>
+
             <div className="content-header-aside">
               <div className="hero-metrics">
-                <article>
-                  <span>{clients.length}</span>
-                  <p>clients on file</p>
-                </article>
-                <article>
-                  <span>{secondaryMetricValue}</span>
-                  <p>{secondaryMetricLabel}</p>
-                </article>
-                <article>
-                  <span>{isApiConnected ? 'Live' : 'Offline'}</span>
-                  <p>{activeSection === 'gigs' ? 'section status' : 'connection'}</p>
-                </article>
+                {headerMetrics.map((metric) => (
+                  <article key={metric.label}>
+                    <span>{metric.value}</span>
+                    <p>{metric.label}</p>
+                  </article>
+                ))}
               </div>
             </div>
           </div>

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -67,6 +67,7 @@ function App({ appMetadata }: AppProps) {
   const [clients, setClients] = useState<Client[]>([])
   const [selectedClientId, setSelectedClientId] = useState<string>('')
   const [searchQuery, setSearchQuery] = useState('')
+  const [isClientEditorOpen, setIsClientEditorOpen] = useState(false)
   const [mode, setMode] = useState<'create' | 'edit'>('create')
   const [form, setForm] = useState<ClientForm>(emptyForm)
   const [isClientSettingsOpen, setIsClientSettingsOpen] = useState(false)
@@ -96,6 +97,7 @@ function App({ appMetadata }: AppProps) {
   const [adminUsers, setAdminUsers] = useState<AdminUser[]>([])
   const [selectedAdminUserId, setSelectedAdminUserId] = useState<string>('')
   const [adminSearchQuery, setAdminSearchQuery] = useState('')
+  const [isAdminEditorOpen, setIsAdminEditorOpen] = useState(false)
   const [adminMode, setAdminMode] = useState<'create' | 'edit'>('create')
   const [adminForm, setAdminForm] = useState<AdminUserForm>(emptyAdminForm)
   const [adminStatus, setAdminStatus] = useState(defaultAdminStatus)
@@ -104,6 +106,7 @@ function App({ appMetadata }: AppProps) {
   const [selectedGigId, setSelectedGigId] = useState<string>('')
   const [selectedGigIds, setSelectedGigIds] = useState<string[]>([])
   const [gigSearchQuery, setGigSearchQuery] = useState('')
+  const [isGigEditorOpen, setIsGigEditorOpen] = useState(false)
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
   const [gigForm, setGigForm] = useState<GigForm>(emptyGigForm)
   const [gigStatus, setGigStatus] = useState(defaultGigStatus)
@@ -114,6 +117,7 @@ function App({ appMetadata }: AppProps) {
   const [monthlyInvoiceMonth, setMonthlyInvoiceMonth] = useState(getCurrentMonthValue)
   const [invoices, setInvoices] = useState<Invoice[]>([])
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('')
+  const [isInvoiceEditorOpen, setIsInvoiceEditorOpen] = useState(false)
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
   const [invoiceStatus, setInvoiceStatus] = useState(defaultInvoiceStatus)
   const [isInvoiceLoading, setIsInvoiceLoading] = useState(false)
@@ -201,6 +205,7 @@ function App({ appMetadata }: AppProps) {
     setAdminUsers([])
     setSelectedAdminUserId('')
     setAdminSearchQuery('')
+    setIsAdminEditorOpen(false)
     setAdminMode('create')
     setAdminForm(emptyAdminForm())
     setAdminStatus(defaultAdminStatus)
@@ -213,11 +218,13 @@ function App({ appMetadata }: AppProps) {
       setClients([])
       setSelectedClientId('')
       setSearchQuery('')
+      setIsClientEditorOpen(false)
       setMode('create')
       setForm(emptyForm())
       setGigs([])
       setSelectedGigId('')
       setGigSearchQuery('')
+      setIsGigEditorOpen(false)
       setGigMode('create')
       setGigForm(emptyGigForm())
       setGigStatus(defaultGigStatus)
@@ -225,6 +232,7 @@ function App({ appMetadata }: AppProps) {
       setMonthlyInvoiceMonth(getCurrentMonthValue())
       setInvoices([])
       setSelectedInvoiceId('')
+      setIsInvoiceEditorOpen(false)
       setInvoiceSearchQuery('')
       setInvoiceStatus(defaultInvoiceStatus)
       setIsClientSettingsOpen(false)
@@ -633,6 +641,7 @@ function App({ appMetadata }: AppProps) {
   const startCreating = () => {
     setMode('create')
     setForm(emptyForm())
+    setIsClientEditorOpen(true)
   }
 
   const startEditing = () => {
@@ -644,13 +653,22 @@ function App({ appMetadata }: AppProps) {
     setForm({
       name: selectedClient.name,
       email: selectedClient.email,
-      billingAddress: { ...selectedClient.billingAddress },
+      billingAddress: {
+        line1: selectedClient.billingAddress.line1 ?? '',
+        line2: selectedClient.billingAddress.line2 ?? '',
+        city: selectedClient.billingAddress.city ?? '',
+        stateOrCounty: selectedClient.billingAddress.stateOrCounty ?? '',
+        postalCode: selectedClient.billingAddress.postalCode ?? '',
+        country: selectedClient.billingAddress.country ?? '',
+      },
     })
+    setIsClientEditorOpen(true)
   }
 
   const startAdminCreate = () => {
     setAdminMode('create')
     setAdminForm(emptyAdminForm())
+    setIsAdminEditorOpen(true)
   }
 
   const startAdminEdit = () => {
@@ -666,6 +684,7 @@ function App({ appMetadata }: AppProps) {
       role: selectedAdminUser.role === 'Admin' ? 'Admin' : 'User',
       isActive: selectedAdminUser.isActive,
     })
+    setIsAdminEditorOpen(true)
   }
 
   const startGigCreate = () => {
@@ -682,6 +701,7 @@ function App({ appMetadata }: AppProps) {
     setGigExpenseAmount('')
     setGigExpenseDescription('')
     setSelectedGigIds([])
+    setIsGigEditorOpen(true)
   }
 
   const startGigEdit = () => {
@@ -707,6 +727,45 @@ function App({ appMetadata }: AppProps) {
     setGigStatus('Editing the selected gig.')
     setGigExpenseAmount('')
     setGigExpenseDescription('')
+    setIsGigEditorOpen(true)
+  }
+
+  const closeClientEditor = () => {
+    setIsClientEditorOpen(false)
+    setMode('create')
+    setForm(emptyForm())
+  }
+
+  const closeAdminEditor = () => {
+    setIsAdminEditorOpen(false)
+    setAdminMode('create')
+    setAdminForm(emptyAdminForm())
+  }
+
+  const closeGigEditor = () => {
+    setIsGigEditorOpen(false)
+    setGigMode('create')
+    setGigForm({
+      ...emptyGigForm(),
+      clientId: clients[0]?.id ?? '',
+    })
+    setGigExpenseAmount('')
+    setGigExpenseDescription('')
+    setGigStatus(defaultGigStatus)
+  }
+
+  const startInvoiceEdit = () => {
+    if (!selectedInvoice) {
+      return
+    }
+
+    setIsInvoiceEditorOpen(true)
+  }
+
+  const closeInvoiceEditor = () => {
+    setIsInvoiceEditorOpen(false)
+    setAdjustmentAmount('')
+    setAdjustmentReason('')
   }
 
   const updateField = (field: keyof ClientForm, value: string | Address) => {
@@ -833,14 +892,21 @@ function App({ appMetadata }: AppProps) {
       setClients([])
       setSelectedClientId('')
       setSearchQuery('')
+      setIsClientEditorOpen(false)
       setMode('create')
       setForm(emptyForm())
       setGigs([])
       setSelectedGigId('')
       setGigSearchQuery('')
+      setIsGigEditorOpen(false)
       setGigMode('create')
       setGigForm(emptyGigForm())
       setGigStatus(defaultGigStatus)
+      setInvoices([])
+      setSelectedInvoiceId('')
+      setIsInvoiceEditorOpen(false)
+      setInvoiceSearchQuery('')
+      setInvoiceStatus(defaultInvoiceStatus)
       resetAdminWorkspace()
       setShouldCloseBrowserNotice(true)
       setStatus('Signed out. Close your browser to fully end the Google session.')
@@ -1190,6 +1256,7 @@ function App({ appMetadata }: AppProps) {
       setSelectedClientId(savedClient.id)
       setMode('edit')
       setStatus(isEdit ? 'Client updated.' : 'Client created.')
+      setIsClientEditorOpen(false)
     } catch {
       setStatus('Unable to save right now. Check that the API is running.')
     } finally {
@@ -1237,6 +1304,7 @@ function App({ appMetadata }: AppProps) {
       setMode('create')
       setForm(emptyForm())
       setStatus('Client deleted.')
+      setIsClientEditorOpen(false)
     } catch {
       setStatus('Unable to delete right now.')
     } finally {
@@ -1311,6 +1379,7 @@ function App({ appMetadata }: AppProps) {
       setSelectedAdminUserId(savedUser.id)
       setAdminMode('edit')
       setAdminStatus(isEdit ? 'User enrolment updated.' : 'User enrolled.')
+      setIsAdminEditorOpen(false)
     } catch (error) {
       setAdminStatus(
         error instanceof Error ? error.message : 'Unable to save enrolment right now.'
@@ -1444,6 +1513,7 @@ function App({ appMetadata }: AppProps) {
       setGigExpenseAmount('')
       setGigExpenseDescription('')
       setGigStatus(isEdit ? 'Gig updated.' : 'Gig created.')
+      setIsGigEditorOpen(false)
     } catch (error) {
       setGigStatus(
         error instanceof Error ? error.message : 'Unable to save this gig right now.'
@@ -1893,6 +1963,7 @@ function App({ appMetadata }: AppProps) {
       setAdjustmentAmount('')
       setAdjustmentReason('')
       setInvoiceStatus(`Adjustment saved. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`)
+      setIsInvoiceEditorOpen(false)
     } catch (error) {
       setInvoiceStatus(error instanceof Error ? error.message : 'Unable to add invoice adjustment.')
     } finally {
@@ -1934,6 +2005,7 @@ function App({ appMetadata }: AppProps) {
       setInvoices((current) => current.filter((value) => value.id !== invoice.id))
       setSelectedInvoiceId((current) => (current === invoice.id ? '' : current))
       setInvoiceStatus(`Invoice ${invoice.invoiceNumber} deleted.`)
+      setIsInvoiceEditorOpen(false)
     } catch (error) {
       setInvoiceStatus(error instanceof Error ? error.message : 'Unable to delete invoice.')
     } finally {
@@ -1962,11 +2034,13 @@ function App({ appMetadata }: AppProps) {
         filteredClients={filteredClients}
         form={form}
         isApiConnected={isApiConnected}
+        isEditorOpen={isClientEditorOpen}
         isInvoiceLoading={isInvoiceLoading}
         isLoading={isLoading}
         monthlyInvoiceClientId={monthlyInvoiceClientId}
         monthlyInvoiceMonth={monthlyInvoiceMonth}
         mode={mode}
+        onCloseEditor={closeClientEditor}
         onDelete={handleDelete}
         onGenerateMonthlyInvoice={handleGenerateMonthlyInvoice}
         onMonthlyInvoiceClientChange={setMonthlyInvoiceClientId}
@@ -1986,6 +2060,7 @@ function App({ appMetadata }: AppProps) {
     ) : activeSection === 'admin' && isAdmin ? (
       <AdminSection
         adminForm={adminForm}
+        isEditorOpen={isAdminEditorOpen}
         adminMode={adminMode}
         adminSearchQuery={adminSearchQuery}
         adminStatus={adminStatus}
@@ -1993,6 +2068,7 @@ function App({ appMetadata }: AppProps) {
         activeUsersCount={activeUsersCount}
         filteredAdminUsers={filteredAdminUsers}
         isAdminLoading={isAdminLoading}
+        onCloseEditor={closeAdminEditor}
         onResetForm={startAdminCreate}
         onSearchQueryChange={setAdminSearchQuery}
         onSelectUser={setSelectedAdminUserId}
@@ -2009,6 +2085,7 @@ function App({ appMetadata }: AppProps) {
         gigExpenseAmount={gigExpenseAmount}
         gigExpenseDescription={gigExpenseDescription}
         gigForm={gigForm}
+        isEditorOpen={isGigEditorOpen}
         gigMode={gigMode}
         gigSearchQuery={gigSearchQuery}
         gigStatus={gigStatus}
@@ -2016,6 +2093,7 @@ function App({ appMetadata }: AppProps) {
         isGigLoading={isGigLoading}
         isInvoiceLoading={isInvoiceLoading}
         onAddGigExpense={handleAddGigExpense}
+        onCloseEditor={closeGigEditor}
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateInvoice={handleGenerateInvoice}
@@ -2040,6 +2118,7 @@ function App({ appMetadata }: AppProps) {
         clients={clients}
         draftInvoiceCount={draftInvoiceCount}
         filteredInvoices={filteredInvoices}
+        isEditorOpen={isInvoiceEditorOpen}
         invoiceSearchQuery={invoiceSearchQuery}
         invoiceStatus={invoiceStatus}
         invoices={invoices}
@@ -2047,12 +2126,14 @@ function App({ appMetadata }: AppProps) {
         onAdjustmentAmountChange={setAdjustmentAmount}
         onAdjustmentReasonChange={setAdjustmentReason}
         onAddAdjustment={handleAddInvoiceAdjustment}
+        onCloseEditor={closeInvoiceEditor}
         onDeleteInvoice={handleDeleteInvoice}
         onDownloadPdf={handleDownloadInvoicePdf}
         onInvoiceStatusChange={handleInvoiceStatusChange}
         onReissue={handleInvoiceReissue}
         onSearchQueryChange={setInvoiceSearchQuery}
         onSelectInvoice={setSelectedInvoiceId}
+        onStartEditing={startInvoiceEdit}
         selectedInvoice={selectedInvoice}
       />
     )

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -271,8 +271,8 @@ function App({ appMetadata }: AppProps) {
       setSelectedAdminUserId((current) => current || users[0]?.id || '')
       setAdminStatus(
         users.length > 0
-          ? 'Manage who can sign in to Glovelly.'
-          : 'No users enrolled yet. Add the first account below.'
+          ? 'Manage access, roles and account status.'
+          : 'No users added yet. Add the first one below.'
       )
     }
 
@@ -291,7 +291,7 @@ function App({ appMetadata }: AppProps) {
           setIsApiConnected(false)
           resetSignedInState()
           setShouldCloseBrowserNotice(false)
-          setStatus('Sign in with Google to access Glovelly.')
+          setStatus('Sign in to access Glovelly.')
           return
         }
 
@@ -386,7 +386,7 @@ function App({ appMetadata }: AppProps) {
             setAdminUsers([])
             setSelectedAdminUserId('')
             setShouldCloseBrowserNotice(false)
-            setStatus('API unavailable. Start the backend to finish sign-in.')
+            setStatus('We could not load your workspace right now. Please try again.')
           }
         }
       } finally {
@@ -606,7 +606,7 @@ function App({ appMetadata }: AppProps) {
             id: 'admin' as const,
             label: 'Admin',
             eyebrow: 'Restricted',
-            description: 'User enrolment, roles and sign-in access.',
+            description: 'Manage access, roles and account status.',
           },
         ]
       : []),
@@ -913,7 +913,7 @@ function App({ appMetadata }: AppProps) {
       setInvoiceStatus(defaultInvoiceStatus)
       resetAdminWorkspace()
       setShouldCloseBrowserNotice(true)
-      setStatus('Signed out. Close your browser to fully end the Google session.')
+      setStatus('Signed out successfully.')
     } catch {
       setStatus('Unable to sign out right now.')
     } finally {
@@ -1262,7 +1262,7 @@ function App({ appMetadata }: AppProps) {
       setStatus(isEdit ? 'Client updated.' : 'Client created.')
       setIsClientEditorOpen(false)
     } catch {
-      setStatus('Unable to save right now. Check that the API is running.')
+      setStatus('Unable to save right now. Please try again.')
     } finally {
       setIsLoading(false)
     }
@@ -1328,7 +1328,7 @@ function App({ appMetadata }: AppProps) {
     }
 
     if (!payload.email) {
-      setAdminStatus('Email is required for enrolment.')
+      setAdminStatus('Email is required.')
       return
     }
 
@@ -1352,12 +1352,12 @@ function App({ appMetadata }: AppProps) {
         setIsAuthenticated(false)
         setAuthUser(null)
         setIsApiConnected(false)
-        setStatus('Your session expired. Sign in again to keep managing enrolments.')
+        setStatus('Your session expired. Sign in again to keep managing access.')
         return
       }
 
       if (response.status === 403) {
-        setAdminStatus('Administrator access is required to manage enrolments.')
+        setAdminStatus('Administrator access is required to manage users.')
         return
       }
 
@@ -1382,11 +1382,11 @@ function App({ appMetadata }: AppProps) {
 
       setSelectedAdminUserId(savedUser.id)
       setAdminMode('edit')
-      setAdminStatus(isEdit ? 'User enrolment updated.' : 'User enrolled.')
+      setAdminStatus(isEdit ? 'User updated.' : 'User added.')
       setIsAdminEditorOpen(false)
     } catch (error) {
       setAdminStatus(
-        error instanceof Error ? error.message : 'Unable to save enrolment right now.'
+        error instanceof Error ? error.message : 'Unable to save right now.'
       )
     } finally {
       setIsAdminLoading(false)
@@ -2151,10 +2151,9 @@ function App({ appMetadata }: AppProps) {
         <aside className="nav-panel">
           <div className="nav-intro">
             <p className="eyebrow">Workspace</p>
-            <h1>Glovelly keeps each area in its own lane.</h1>
+            <h1>Your work, all in one place.</h1>
             <p className="hero-text">
-              Move between client records, admin access and the next planned gigs
-              workspace without stacking everything into one screen.
+              Move between clients, gigs, invoices and admin tools with everything easy to find.
             </p>
           </div>
 
@@ -2280,7 +2279,7 @@ function App({ appMetadata }: AppProps) {
                 </article>
                 <article>
                   <span>{isApiConnected ? 'Live' : 'Offline'}</span>
-                  <p>{activeSection === 'gigs' ? 'workspace status' : 'data source'}</p>
+                  <p>{activeSection === 'gigs' ? 'section status' : 'connection'}</p>
                 </article>
               </div>
             </div>

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -113,8 +113,8 @@ function App({ appMetadata }: AppProps) {
   const [isGigLoading, setIsGigLoading] = useState(false)
   const [gigExpenseAmount, setGigExpenseAmount] = useState('')
   const [gigExpenseDescription, setGigExpenseDescription] = useState('')
-  const [monthlyInvoiceClientId, setMonthlyInvoiceClientId] = useState('')
   const [monthlyInvoiceMonth, setMonthlyInvoiceMonth] = useState(getCurrentMonthValue)
+  const [monthlyInvoiceStatus, setMonthlyInvoiceStatus] = useState('')
   const [invoices, setInvoices] = useState<Invoice[]>([])
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('')
   const [isInvoiceEditorOpen, setIsInvoiceEditorOpen] = useState(false)
@@ -228,8 +228,8 @@ function App({ appMetadata }: AppProps) {
       setGigMode('create')
       setGigForm(emptyGigForm())
       setGigStatus(defaultGigStatus)
-      setMonthlyInvoiceClientId('')
       setMonthlyInvoiceMonth(getCurrentMonthValue())
+      setMonthlyInvoiceStatus('')
       setInvoices([])
       setSelectedInvoiceId('')
       setIsInvoiceEditorOpen(false)
@@ -531,6 +531,52 @@ function App({ appMetadata }: AppProps) {
   const selectedInvoice =
     invoicesById.get(selectedInvoiceId) ?? filteredInvoices[0] ?? null
 
+  const monthlyInvoiceEligibleGigs = useMemo(() => {
+    if (!selectedClient || !monthlyInvoiceMonth) {
+      return []
+    }
+
+    return gigs
+      .filter(
+        (gig) =>
+          gig.clientId === selectedClient.id &&
+          !gig.isInvoiced &&
+          gig.date.startsWith(`${monthlyInvoiceMonth}-`) &&
+          gig.status !== 'Cancelled'
+      )
+      .sort((left, right) => left.date.localeCompare(right.date))
+  }, [gigs, monthlyInvoiceMonth, selectedClient])
+
+  const isMonthlyInvoiceReady =
+    Boolean(selectedClient) &&
+    Boolean(monthlyInvoiceMonth) &&
+    monthlyInvoiceEligibleGigs.length > 0
+
+  const monthlyInvoiceHelperText = monthlyInvoiceStatus || (() => {
+    if (!selectedClient) {
+      return 'Select a client to review monthly invoice eligibility.'
+    }
+
+    if (!monthlyInvoiceMonth) {
+      return 'Choose a month to check which gigs are ready to invoice.'
+    }
+
+    if (monthlyInvoiceEligibleGigs.length === 0) {
+      return `No eligible gigs found for ${selectedClient.name} in ${monthlyInvoiceMonth}.`
+    }
+
+    return `${monthlyInvoiceEligibleGigs.length} eligible gig(s) ready to invoice for ${selectedClient.name} in ${monthlyInvoiceMonth}.`
+  })()
+
+  const openSelectedGigInvoice = () => {
+    if (!selectedGig?.invoiceId) {
+      return
+    }
+
+    setSelectedInvoiceId(selectedGig.invoiceId)
+    setActiveSection('invoices')
+  }
+
   useEffect(() => {
     if (selectedClient) {
       setSelectedClientId(selectedClient.id)
@@ -560,6 +606,10 @@ function App({ appMetadata }: AppProps) {
   }, [selectedInvoice])
 
   useEffect(() => {
+    setMonthlyInvoiceStatus('')
+  }, [selectedClient?.id, monthlyInvoiceMonth])
+
+  useEffect(() => {
     if (gigForm.clientId || clients.length === 0) {
       return
     }
@@ -569,14 +619,6 @@ function App({ appMetadata }: AppProps) {
       clientId: clients[0]?.id ?? '',
     }))
   }, [clients, gigForm.clientId])
-
-  useEffect(() => {
-    if (monthlyInvoiceClientId || clients.length === 0) {
-      return
-    }
-
-    setMonthlyInvoiceClientId(clients[0]?.id ?? '')
-  }, [clients, monthlyInvoiceClientId])
 
   const activeUsersCount = adminUsers.filter((user) => user.isActive).length
   const totalAdmins = adminUsers.filter((user) => user.role === 'Admin').length
@@ -1683,34 +1725,30 @@ function App({ appMetadata }: AppProps) {
   }
 
   const handleGenerateMonthlyInvoice = async () => {
-    const clientId = monthlyInvoiceClientId.trim()
-    if (!clientId) {
-      setGigStatus('Choose a client for the monthly invoice run.')
+    if (!selectedClient) {
+      setMonthlyInvoiceStatus('Choose a client before running a monthly invoice.')
       return
     }
 
     if (!monthlyInvoiceMonth) {
-      setGigStatus('Choose a month for the monthly invoice run.')
+      setMonthlyInvoiceStatus('Choose a month for the monthly invoice run.')
       return
     }
 
-    const gigsToInvoice = gigs
-      .filter(
-        (gig) =>
-          gig.clientId === clientId &&
-          !gig.isInvoiced &&
-          gig.date.startsWith(`${monthlyInvoiceMonth}-`) &&
-          gig.status !== 'Cancelled'
-      )
-      .sort((left, right) => left.date.localeCompare(right.date))
+    const clientId = selectedClient.id
+    const gigsToInvoice = monthlyInvoiceEligibleGigs
 
     if (gigsToInvoice.length === 0) {
-      setGigStatus('No uninvoiced gigs found for that client/month.')
+      setMonthlyInvoiceStatus(
+        `No eligible gigs found for ${selectedClient.name} in ${monthlyInvoiceMonth}.`
+      )
       return
     }
 
     setIsInvoiceLoading(true)
-    setGigStatus(`Creating monthly invoice for ${gigsToInvoice.length} gig(s)...`)
+    setMonthlyInvoiceStatus(
+      `Creating monthly invoice for ${gigsToInvoice.length} gig(s)...`
+    )
 
     try {
       const issueDate = `${monthlyInvoiceMonth}-01`
@@ -1812,10 +1850,13 @@ function App({ appMetadata }: AppProps) {
       setGigStatus(
         `Monthly invoice ${updatedInvoice.invoiceNumber} created for ${gigsToInvoice.length} gig(s).`
       )
+      setMonthlyInvoiceStatus(
+        `Monthly invoice ${updatedInvoice.invoiceNumber} created for ${gigsToInvoice.length} gig(s).`
+      )
       setInvoiceStatus(`Monthly invoice ${updatedInvoice.invoiceNumber} is ready for review.`)
       setActiveSection('invoices')
     } catch (error) {
-      setGigStatus(
+      setMonthlyInvoiceStatus(
         error instanceof Error ? error.message : 'Unable to generate monthly invoice.'
       )
     } finally {
@@ -2011,6 +2052,18 @@ function App({ appMetadata }: AppProps) {
       }
 
       setInvoices((current) => current.filter((value) => value.id !== invoice.id))
+      setGigs((current) =>
+        current.map((gig) =>
+          gig.invoiceId === invoice.id
+            ? {
+                ...gig,
+                invoiceId: null,
+                invoicedAt: null,
+                isInvoiced: false,
+              }
+            : gig
+        )
+      )
       setSelectedInvoiceId((current) => (current === invoice.id ? '' : current))
       setInvoiceStatus(`Invoice ${invoice.invoiceNumber} deleted.`)
       setIsInvoiceEditorOpen(false)
@@ -2038,20 +2091,19 @@ function App({ appMetadata }: AppProps) {
   const currentSectionContent =
     activeSection === 'clients' ? (
       <ClientsSection
-        clients={clients}
         filteredClients={filteredClients}
         form={form}
         isApiConnected={isApiConnected}
         isEditorOpen={isClientEditorOpen}
+        isMonthlyInvoiceReady={isMonthlyInvoiceReady}
         isInvoiceLoading={isInvoiceLoading}
         isLoading={isLoading}
-        monthlyInvoiceClientId={monthlyInvoiceClientId}
+        monthlyInvoiceHelperText={monthlyInvoiceHelperText}
         monthlyInvoiceMonth={monthlyInvoiceMonth}
         mode={mode}
         onCloseEditor={closeClientEditor}
         onDelete={handleDelete}
         onGenerateMonthlyInvoice={handleGenerateMonthlyInvoice}
-        onMonthlyInvoiceClientChange={setMonthlyInvoiceClientId}
         onMonthlyInvoiceMonthChange={setMonthlyInvoiceMonth}
         onOpenClientSettings={openClientSettings}
         onResetForm={startCreating}
@@ -2107,6 +2159,7 @@ function App({ appMetadata }: AppProps) {
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateInvoice={handleGenerateInvoice}
+        onOpenLinkedInvoice={openSelectedGigInvoice}
         onRemoveGigExpense={removeGigExpense}
         onResetForm={startGigCreate}
         onSearchQueryChange={setGigSearchQuery}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -408,6 +408,19 @@ function App({ appMetadata }: AppProps) {
     () => new Map(clients.map((client) => [client.id, client.name])),
     [clients]
   )
+  const clientsById = useMemo(
+    () => new Map(clients.map((client) => [client.id, client])),
+    [clients]
+  )
+  const adminUsersById = useMemo(
+    () => new Map(adminUsers.map((user) => [user.id, user])),
+    [adminUsers]
+  )
+  const gigsById = useMemo(() => new Map(gigs.map((gig) => [gig.id, gig])), [gigs])
+  const invoicesById = useMemo(
+    () => new Map(invoices.map((invoice) => [invoice.id, invoice])),
+    [invoices]
+  )
 
   const filteredClients = useMemo(() => {
     const query = deferredSearchQuery.trim().toLowerCase()
@@ -497,37 +510,26 @@ function App({ appMetadata }: AppProps) {
     })
   }, [clientNamesById, deferredInvoiceSearchQuery, invoices])
 
-  const selectedClient =
-    filteredClients.find((client) => client.id === selectedClientId) ??
-    clients.find((client) => client.id === selectedClientId) ??
-    filteredClients[0] ??
-    null
+  const selectedClient = clientsById.get(selectedClientId) ?? filteredClients[0] ?? null
 
   const selectedAdminUser =
-    filteredAdminUsers.find((user) => user.id === selectedAdminUserId) ??
-    adminUsers.find((user) => user.id === selectedAdminUserId) ??
-    filteredAdminUsers[0] ??
-    null
+    adminUsersById.get(selectedAdminUserId) ?? filteredAdminUsers[0] ?? null
 
-  const selectedGig =
-    filteredGigs.find((gig) => gig.id === selectedGigId) ??
-    gigs.find((gig) => gig.id === selectedGigId) ??
-    filteredGigs[0] ??
-    null
+  const selectedGig = gigsById.get(selectedGigId) ?? filteredGigs[0] ?? null
 
   const selectedGigs = useMemo(
-    () =>
-      gigs
-        .filter((gig) => selectedGigIds.includes(gig.id))
-        .sort((left, right) => left.date.localeCompare(right.date)),
+    () => {
+      const selectedGigIdSet = new Set(selectedGigIds)
+
+      return gigs
+        .filter((gig) => selectedGigIdSet.has(gig.id))
+        .sort((left, right) => left.date.localeCompare(right.date))
+    },
     [gigs, selectedGigIds]
   )
 
   const selectedInvoice =
-    filteredInvoices.find((invoice) => invoice.id === selectedInvoiceId) ??
-    invoices.find((invoice) => invoice.id === selectedInvoiceId) ??
-    filteredInvoices[0] ??
-    null
+    invoicesById.get(selectedInvoiceId) ?? filteredInvoices[0] ?? null
 
   useEffect(() => {
     if (selectedClient) {
@@ -580,8 +582,10 @@ function App({ appMetadata }: AppProps) {
   const activeUsersCount = adminUsers.filter((user) => user.isActive).length
   const totalAdmins = adminUsers.filter((user) => user.role === 'Admin').length
   const plannedGigCount = gigs.filter((gig) => gig.status === 'Confirmed').length
+  const completedGigCount = gigs.filter((gig) => gig.status === 'Completed').length
   const upcomingGigCount = gigs.filter((gig) => gig.date >= new Date().toISOString().slice(0, 10)).length
   const draftInvoiceCount = invoices.filter((invoice) => invoice.status === 'Draft').length
+  const issuedInvoiceCount = invoices.filter((invoice) => invoice.status === 'Issued').length
 
   const navigationItems: Array<{
     id: AppSection
@@ -2080,7 +2084,9 @@ function App({ appMetadata }: AppProps) {
       />
     ) : activeSection === 'gigs' ? (
       <GigsSection
+        clientNamesById={clientNamesById}
         clients={clients}
+        completedGigCount={completedGigCount}
         filteredGigs={filteredGigs}
         gigExpenseAmount={gigExpenseAmount}
         gigExpenseDescription={gigExpenseDescription}
@@ -2115,13 +2121,14 @@ function App({ appMetadata }: AppProps) {
       <InvoicesSection
         adjustmentAmount={adjustmentAmount}
         adjustmentReason={adjustmentReason}
-        clients={clients}
+        clientNamesById={clientNamesById}
         draftInvoiceCount={draftInvoiceCount}
         filteredInvoices={filteredInvoices}
         isEditorOpen={isInvoiceEditorOpen}
         invoiceSearchQuery={invoiceSearchQuery}
         invoiceStatus={invoiceStatus}
         invoices={invoices}
+        issuedInvoiceCount={issuedInvoiceCount}
         isInvoiceLoading={isInvoiceLoading}
         onAdjustmentAmountChange={setAdjustmentAmount}
         onAdjustmentReasonChange={setAdjustmentReason}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -703,7 +703,9 @@ export function AdminSection({
 }
 
 type GigsSectionProps = {
+  clientNamesById: ReadonlyMap<string, string>
   clients: Client[]
+  completedGigCount: number
   filteredGigs: Gig[]
   gigExpenseAmount: string
   gigExpenseDescription: string
@@ -743,7 +745,9 @@ type GigsSectionProps = {
 }
 
 export function GigsSection({
+  clientNamesById,
   clients,
+  completedGigCount,
   filteredGigs,
   gigExpenseAmount,
   gigExpenseDescription,
@@ -774,8 +778,8 @@ export function GigsSection({
   selectedGigIds,
   selectedGigs,
 }: GigsSectionProps) {
-  const selectedGigClient =
-    clients.find((client) => client.id === selectedGig?.clientId) ?? null
+  const selectedGigClientName =
+    (selectedGig ? clientNamesById.get(selectedGig.clientId) : null) ?? 'Unknown client'
   const hasCrossClientSelection = new Set(selectedGigs.map((gig) => gig.clientId)).size > 1
 
   return (
@@ -812,16 +816,14 @@ export function GigsSection({
               <p>planned</p>
             </article>
             <article>
-              <span>{gigs.filter((gig) => gig.status === 'Completed').length}</span>
+              <span>{completedGigCount}</span>
               <p>completed</p>
             </article>
           </div>
 
           <div className="client-list">
             {filteredGigs.map((gig) => {
-              const clientName =
-                clients.find((client) => client.id === gig.clientId)?.name ??
-                'Unknown client'
+              const clientName = clientNamesById.get(gig.clientId) ?? 'Unknown client'
 
               return (
                 <button
@@ -905,7 +907,7 @@ export function GigsSection({
               <div className="detail-grid">
                 <article>
                   <p className="detail-label">Client</p>
-                  <strong>{selectedGigClient?.name ?? 'Unknown client'}</strong>
+                  <strong>{selectedGigClientName}</strong>
                 </article>
                 <article>
                   <p className="detail-label">Status</p>
@@ -1176,13 +1178,14 @@ export function GigsSection({
 type InvoicesSectionProps = {
   adjustmentAmount: string
   adjustmentReason: string
-  clients: Client[]
+  clientNamesById: ReadonlyMap<string, string>
   draftInvoiceCount: number
   filteredInvoices: Invoice[]
   isEditorOpen: boolean
   invoiceSearchQuery: string
   invoiceStatus: string
   invoices: Invoice[]
+  issuedInvoiceCount: number
   isInvoiceLoading: boolean
   onAdjustmentAmountChange: (value: string) => void
   onAdjustmentReasonChange: (value: string) => void
@@ -1201,13 +1204,14 @@ type InvoicesSectionProps = {
 export function InvoicesSection({
   adjustmentAmount,
   adjustmentReason,
-  clients,
+  clientNamesById,
   draftInvoiceCount,
   filteredInvoices,
   isEditorOpen,
   invoiceSearchQuery,
   invoiceStatus,
   invoices,
+  issuedInvoiceCount,
   isInvoiceLoading,
   onAdjustmentAmountChange,
   onAdjustmentReasonChange,
@@ -1222,8 +1226,9 @@ export function InvoicesSection({
   onStartEditing,
   selectedInvoice,
 }: InvoicesSectionProps) {
-  const selectedInvoiceClient =
-    clients.find((client) => client.id === selectedInvoice?.clientId) ?? null
+  const selectedInvoiceClientName =
+    (selectedInvoice ? clientNamesById.get(selectedInvoice.clientId) : null) ??
+    'Unknown client'
 
   return (
     <section className="section-layout">
@@ -1257,16 +1262,14 @@ export function InvoicesSection({
               <p>draft</p>
             </article>
             <article>
-              <span>{invoices.filter((invoice) => invoice.status === 'Issued').length}</span>
+              <span>{issuedInvoiceCount}</span>
               <p>issued</p>
             </article>
           </div>
 
           <div className="client-list">
             {filteredInvoices.map((invoice) => {
-              const clientName =
-                clients.find((client) => client.id === invoice.clientId)?.name ??
-                'Unknown client'
+              const clientName = clientNamesById.get(invoice.clientId) ?? 'Unknown client'
 
               return (
                 <button
@@ -1348,7 +1351,7 @@ export function InvoicesSection({
               <div className="detail-grid">
                 <article>
                   <p className="detail-label">Client</p>
-                  <strong>{selectedInvoiceClient?.name ?? 'Unknown client'}</strong>
+                  <strong>{selectedInvoiceClientName}</strong>
                 </article>
                 <article>
                   <p className="detail-label">Status</p>

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -98,10 +98,12 @@ type ClientsSectionProps = {
   filteredClients: Client[]
   form: ClientForm
   isApiConnected: boolean
+  isEditorOpen: boolean
   isInvoiceLoading: boolean
   isLoading: boolean
   monthlyInvoiceClientId: string
   monthlyInvoiceMonth: string
+  onCloseEditor: () => void
   mode: 'create' | 'edit'
   onDelete: () => void
   onGenerateMonthlyInvoice: () => void
@@ -125,10 +127,12 @@ export function ClientsSection({
   filteredClients,
   form,
   isApiConnected,
+  isEditorOpen,
   isInvoiceLoading,
   isLoading,
   monthlyInvoiceClientId,
   monthlyInvoiceMonth,
+  onCloseEditor,
   mode,
   onDelete,
   onGenerateMonthlyInvoice,
@@ -319,105 +323,111 @@ export function ClientsSection({
           )}
         </div>
 
-        <form className="editor-panel panel" onSubmit={onSubmit}>
-          <div className="panel-heading">
-            <div>
-              <p className="section-label">Editor</p>
-              <h2>{mode === 'create' ? 'Add client' : 'Edit client'}</h2>
+        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+          <form
+            aria-hidden={!isEditorOpen}
+            className="editor-panel panel"
+            onSubmit={onSubmit}
+          >
+            <div className="panel-heading">
+              <div>
+                <p className="section-label">Editor</p>
+                <h2>{mode === 'create' ? 'Add client' : 'Edit client'}</h2>
+              </div>
+              <span className="status-pill">{status}</span>
             </div>
-            <span className="status-pill">{status}</span>
-          </div>
 
-          <div className="form-grid">
-            <label>
-              <span>Client name</span>
-              <input
-                required
-                value={form.name}
-                onChange={(event) => onUpdateField('name', event.target.value)}
-                placeholder="Fox & Finch Events"
-              />
-            </label>
+            <div className="form-grid">
+              <label>
+                <span>Client name</span>
+                <input
+                  required
+                  value={form.name}
+                  onChange={(event) => onUpdateField('name', event.target.value)}
+                  placeholder="Fox & Finch Events"
+                />
+              </label>
 
-            <label>
-              <span>Email</span>
-              <input
-                required
-                type="email"
-                value={form.email}
-                onChange={(event) => onUpdateField('email', event.target.value)}
-                placeholder="accounts@example.com"
-              />
-            </label>
+              <label>
+                <span>Email</span>
+                <input
+                  required
+                  type="email"
+                  value={form.email}
+                  onChange={(event) => onUpdateField('email', event.target.value)}
+                  placeholder="accounts@example.com"
+                />
+              </label>
 
-            <label className="full-width">
-              <span>Address line 1</span>
-              <input
-                required
-                value={form.billingAddress.line1}
-                onChange={(event) => onUpdateAddressField('line1', event.target.value)}
-                placeholder="12 Chapel Street"
-              />
-            </label>
+              <label className="full-width">
+                <span>Address line 1</span>
+                <input
+                  required
+                  value={form.billingAddress.line1}
+                  onChange={(event) => onUpdateAddressField('line1', event.target.value)}
+                  placeholder="12 Chapel Street"
+                />
+              </label>
 
-            <label className="full-width">
-              <span>Address line 2</span>
-              <input
-                value={form.billingAddress.line2}
-                onChange={(event) => onUpdateAddressField('line2', event.target.value)}
-                placeholder="Optional"
-              />
-            </label>
+              <label className="full-width">
+                <span>Address line 2</span>
+                <input
+                  value={form.billingAddress.line2 ?? ''}
+                  onChange={(event) => onUpdateAddressField('line2', event.target.value)}
+                  placeholder="Optional"
+                />
+              </label>
 
-            <label>
-              <span>City</span>
-              <input
-                required
-                value={form.billingAddress.city}
-                onChange={(event) => onUpdateAddressField('city', event.target.value)}
-                placeholder="Manchester"
-              />
-            </label>
+              <label>
+                <span>City</span>
+                <input
+                  required
+                  value={form.billingAddress.city}
+                  onChange={(event) => onUpdateAddressField('city', event.target.value)}
+                  placeholder="Manchester"
+                />
+              </label>
 
-            <label>
-              <span>County / state</span>
-              <input
-                value={form.billingAddress.stateOrCounty}
-                onChange={(event) =>
-                  onUpdateAddressField('stateOrCounty', event.target.value)
-                }
-                placeholder="Greater Manchester"
-              />
-            </label>
+              <label>
+                <span>County / state</span>
+                <input
+                  value={form.billingAddress.stateOrCounty ?? ''}
+                  onChange={(event) =>
+                    onUpdateAddressField('stateOrCounty', event.target.value)
+                  }
+                  placeholder="Greater Manchester"
+                />
+              </label>
 
-            <label>
-              <span>Postal code</span>
-              <input
-                value={form.billingAddress.postalCode}
-                onChange={(event) => onUpdateAddressField('postalCode', event.target.value)}
-                placeholder="M3 5JZ"
-              />
-            </label>
+              <label>
+                <span>Postal code</span>
+                <input
+                  value={form.billingAddress.postalCode ?? ''}
+                  onChange={(event) => onUpdateAddressField('postalCode', event.target.value)}
+                  placeholder="M3 5JZ"
+                />
+              </label>
 
-            <label>
-              <span>Country</span>
-              <input
-                value={form.billingAddress.country}
-                onChange={(event) => onUpdateAddressField('country', event.target.value)}
-                placeholder="United Kingdom"
-              />
-            </label>
-          </div>
+              <label>
+                <span>Country</span>
+                <input
+                  value={form.billingAddress.country ?? ''}
+                  onChange={(event) => onUpdateAddressField('country', event.target.value)}
+                  placeholder="United Kingdom"
+                />
+              </label>
+            </div>
 
-          <div className="form-actions">
-            <button className="primary-button" type="submit" disabled={isLoading}>
-              {mode === 'create' ? 'Save client' : 'Update client'}
-            </button>
-            <button className="ghost-button" onClick={onResetForm} type="button">
-              Reset form
-            </button>
-          </div>
-        </form>
+            <div className="form-actions">
+              <button className="primary-button" type="submit" disabled={isLoading}>
+                {mode === 'create' ? 'Save client' : 'Update client'}
+              </button>
+              <button className="ghost-button" onClick={onCloseEditor} type="button">
+                Done
+              </button>
+            </div>
+          </form>
+        </div>
       </div>
     </section>
   )
@@ -425,6 +435,7 @@ export function ClientsSection({
 
 type AdminSectionProps = {
   adminForm: AdminUserForm
+  isEditorOpen: boolean
   adminMode: 'create' | 'edit'
   adminSearchQuery: string
   adminStatus: string
@@ -432,6 +443,7 @@ type AdminSectionProps = {
   activeUsersCount: number
   filteredAdminUsers: AdminUser[]
   isAdminLoading: boolean
+  onCloseEditor: () => void
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
   onSelectUser: (userId: string) => void
@@ -444,6 +456,7 @@ type AdminSectionProps = {
 
 export function AdminSection({
   adminForm,
+  isEditorOpen,
   adminMode,
   adminSearchQuery,
   adminStatus,
@@ -451,6 +464,7 @@ export function AdminSection({
   activeUsersCount,
   filteredAdminUsers,
   isAdminLoading,
+  onCloseEditor,
   onResetForm,
   onSearchQueryChange,
   onSelectUser,
@@ -601,82 +615,88 @@ export function AdminSection({
           )}
         </div>
 
-        <form className="panel" onSubmit={onSubmit}>
-          <div className="panel-heading">
-            <div>
-              <p className="section-label">Management Pane</p>
-              <h2>{adminMode === 'create' ? 'Create enrolment' : 'Update enrolment'}</h2>
+        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+          <form
+            aria-hidden={!isEditorOpen}
+            className="editor-panel panel"
+            onSubmit={onSubmit}
+          >
+            <div className="panel-heading">
+              <div>
+                <p className="section-label">Management Pane</p>
+                <h2>{adminMode === 'create' ? 'Create enrolment' : 'Update enrolment'}</h2>
+              </div>
+              <span className="status-pill">{adminStatus}</span>
             </div>
-            <span className="status-pill">{adminStatus}</span>
-          </div>
 
-          <div className="form-grid">
-            <label>
-              <span>Email</span>
-              <input
-                required
-                type="email"
-                value={adminForm.email}
-                onChange={(event) => onUpdateField('email', event.target.value)}
-                placeholder="performer@example.com"
-              />
-            </label>
+            <div className="form-grid">
+              <label>
+                <span>Email</span>
+                <input
+                  required
+                  type="email"
+                  value={adminForm.email}
+                  onChange={(event) => onUpdateField('email', event.target.value)}
+                  placeholder="performer@example.com"
+                />
+              </label>
 
-            <label>
-              <span>Display name</span>
-              <input
-                value={adminForm.displayName}
-                onChange={(event) => onUpdateField('displayName', event.target.value)}
-                placeholder="Optional"
-              />
-            </label>
+              <label>
+                <span>Display name</span>
+                <input
+                  value={adminForm.displayName}
+                  onChange={(event) => onUpdateField('displayName', event.target.value)}
+                  placeholder="Optional"
+                />
+              </label>
 
-            <label className="full-width">
-              <span>Google subject</span>
-              <input
-                value={adminForm.googleSubject}
-                onChange={(event) => onUpdateField('googleSubject', event.target.value)}
-                placeholder="Optional until first Google sign-in"
-                disabled={adminMode === 'edit' && selectedAdminUser?.isEnrolled === true}
-              />
-            </label>
+              <label className="full-width">
+                <span>Google subject</span>
+                <input
+                  value={adminForm.googleSubject}
+                  onChange={(event) => onUpdateField('googleSubject', event.target.value)}
+                  placeholder="Optional until first Google sign-in"
+                  disabled={adminMode === 'edit' && selectedAdminUser?.isEnrolled === true}
+                />
+              </label>
 
-            <label>
-              <span>Role</span>
-              <select
-                value={adminForm.role}
-                onChange={(event) =>
-                  onUpdateField('role', event.target.value as AdminUserForm['role'])
-                }
-              >
-                <option value="User">User</option>
-                <option value="Admin">Admin</option>
-              </select>
-            </label>
+              <label>
+                <span>Role</span>
+                <select
+                  value={adminForm.role}
+                  onChange={(event) =>
+                    onUpdateField('role', event.target.value as AdminUserForm['role'])
+                  }
+                >
+                  <option value="User">User</option>
+                  <option value="Admin">Admin</option>
+                </select>
+              </label>
 
-            <label className="checkbox-field">
-              <input
-                type="checkbox"
-                checked={adminForm.isActive}
-                onChange={(event) => onUpdateField('isActive', event.target.checked)}
-              />
-              <span>Account is active and allowed to sign in</span>
-            </label>
-          </div>
+              <label className="checkbox-field">
+                <input
+                  type="checkbox"
+                  checked={adminForm.isActive}
+                  onChange={(event) => onUpdateField('isActive', event.target.checked)}
+                />
+                <span>Account is active and allowed to sign in</span>
+              </label>
+            </div>
 
-          <div className="form-actions">
-            <button className="primary-button" type="submit" disabled={isAdminLoading}>
-              {adminMode === 'create' ? 'Enrol user' : 'Save enrolment'}
-            </button>
-            <button className="ghost-button" onClick={onResetForm} type="button">
-              Reset enrolment form
-            </button>
-          </div>
-          <p className="auth-note">
-            Admins can pre-provision by email only. If Google subject is blank, Glovelly
-            will bind it on the user’s first successful Google sign-in.
-          </p>
-        </form>
+            <div className="form-actions">
+              <button className="primary-button" type="submit" disabled={isAdminLoading}>
+                {adminMode === 'create' ? 'Enrol user' : 'Save enrolment'}
+              </button>
+              <button className="ghost-button" onClick={onCloseEditor} type="button">
+                Done
+              </button>
+            </div>
+            <p className="auth-note">
+              Admins can pre-provision by email only. If Google subject is blank, Glovelly
+              will bind it on the user’s first successful Google sign-in.
+            </p>
+          </form>
+        </div>
       </div>
     </section>
   )
@@ -688,6 +708,7 @@ type GigsSectionProps = {
   gigExpenseAmount: string
   gigExpenseDescription: string
   gigForm: GigForm
+  isEditorOpen: boolean
   gigMode: 'create' | 'edit'
   gigSearchQuery: string
   gigStatus: string
@@ -695,6 +716,7 @@ type GigsSectionProps = {
   isGigLoading: boolean
   isInvoiceLoading: boolean
   onAddGigExpense: () => void
+  onCloseEditor: () => void
   onExpenseAmountChange: (value: string) => void
   onExpenseDescriptionChange: (value: string) => void
   onGenerateInvoice: () => void
@@ -726,6 +748,7 @@ export function GigsSection({
   gigExpenseAmount,
   gigExpenseDescription,
   gigForm,
+  isEditorOpen,
   gigMode,
   gigSearchQuery,
   gigStatus,
@@ -733,6 +756,7 @@ export function GigsSection({
   isGigLoading,
   isInvoiceLoading,
   onAddGigExpense,
+  onCloseEditor,
   onExpenseAmountChange,
   onExpenseDescriptionChange,
   onGenerateInvoice,
@@ -937,207 +961,213 @@ export function GigsSection({
           )}
         </div>
 
-        <form className="panel" onSubmit={onSubmit}>
-          <div className="panel-heading">
-            <div>
-              <p className="section-label">Management Pane</p>
-              <h2>{gigMode === 'create' ? 'Create gig' : 'Update gig'}</h2>
+        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+          <form
+            aria-hidden={!isEditorOpen}
+            className="editor-panel panel"
+            onSubmit={onSubmit}
+          >
+            <div className="panel-heading">
+              <div>
+                <p className="section-label">Management Pane</p>
+                <h2>{gigMode === 'create' ? 'Create gig' : 'Update gig'}</h2>
+              </div>
+              <span className="status-pill">{gigStatus}</span>
             </div>
-            <span className="status-pill">{gigStatus}</span>
-          </div>
 
-          <div className="form-grid">
-            <label>
-              <span>Client</span>
-              <select
-                required
-                value={gigForm.clientId}
-                onChange={(event) => onUpdateGigField('clientId', event.target.value)}
+            <div className="form-grid">
+              <label>
+                <span>Client</span>
+                <select
+                  required
+                  value={gigForm.clientId}
+                  onChange={(event) => onUpdateGigField('clientId', event.target.value)}
+                >
+                  <option value="">Select a client</option>
+                  {clients.map((client) => (
+                    <option key={client.id} value={client.id}>
+                      {client.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label>
+                <span>Date</span>
+                <input
+                  required
+                  type="date"
+                  value={gigForm.date}
+                  onChange={(event) => onUpdateGigField('date', event.target.value)}
+                />
+              </label>
+
+              <label className="full-width">
+                <span>Title / description</span>
+                <input
+                  required
+                  value={gigForm.title}
+                  onChange={(event) => onUpdateGigField('title', event.target.value)}
+                  placeholder="Spring product launch"
+                />
+              </label>
+
+              <label className="full-width">
+                <span>Location / venue</span>
+                <input
+                  required
+                  value={gigForm.venue}
+                  onChange={(event) => onUpdateGigField('venue', event.target.value)}
+                  placeholder="Albert Hall, Manchester"
+                />
+              </label>
+
+              <label>
+                <span>Fee</span>
+                <input
+                  required
+                  inputMode="decimal"
+                  value={gigForm.fee}
+                  onChange={(event) => onUpdateGigField('fee', event.target.value)}
+                  placeholder="650"
+                />
+              </label>
+
+              <label>
+                <span>Status</span>
+                <select
+                  value={gigForm.status}
+                  onChange={(event) =>
+                    onUpdateGigField('status', event.target.value as GigStatus)
+                  }
+                >
+                  <option value="Confirmed">Planned</option>
+                  <option value="Completed">Completed</option>
+                  <option value="Cancelled">Cancelled</option>
+                  <option value="Draft">Draft</option>
+                </select>
+              </label>
+
+              <label className="checkbox-field full-width">
+                <input
+                  type="checkbox"
+                  checked={gigForm.wasDriving}
+                  onChange={(event) => onUpdateGigField('wasDriving', event.target.checked)}
+                />
+                <span>I was driving for this gig</span>
+              </label>
+
+              <label className="full-width">
+                <span>Notes</span>
+                <textarea
+                  rows={5}
+                  value={gigForm.notes}
+                  onChange={(event) => onUpdateGigField('notes', event.target.value)}
+                  placeholder="Optional commercial or logistics notes"
+                />
+              </label>
+            </div>
+
+            <div className="gig-timeline-note">
+              <p className="detail-label">Expenses</p>
+              <span>
+                Add chargeable out-of-pocket costs here and they will flow through when the gig is invoiced.
+              </span>
+            </div>
+
+            <div className="invoice-adjustment-form">
+              <label>
+                Amount
+                <input
+                  inputMode="decimal"
+                  value={gigExpenseAmount}
+                  onChange={(event) => onExpenseAmountChange(event.target.value)}
+                  placeholder="45.00"
+                  disabled={isGigLoading}
+                />
+              </label>
+              <label>
+                Description
+                <input
+                  value={gigExpenseDescription}
+                  onChange={(event) => onExpenseDescriptionChange(event.target.value)}
+                  placeholder="Parking, hotel, equipment hire..."
+                  disabled={isGigLoading}
+                />
+              </label>
+              <button
+                className="ghost-button"
+                onClick={onAddGigExpense}
+                type="button"
+                disabled={isGigLoading}
               >
-                <option value="">Select a client</option>
-                {clients.map((client) => (
-                  <option key={client.id} value={client.id}>
-                    {client.name}
-                  </option>
+                Add expense
+              </button>
+            </div>
+
+            {gigForm.expenses.length > 0 ? (
+              <div className="gig-expense-list">
+                {gigForm.expenses.map((expense, index) => (
+                  <div className="gig-expense-item" key={`${expense.id || 'new'}-${index}`}>
+                    <label>
+                      <span>Description</span>
+                      <input
+                        value={expense.description}
+                        onChange={(event) =>
+                          onUpdateGigExpenseField(index, 'description', event.target.value)
+                        }
+                        disabled={isGigLoading}
+                      />
+                    </label>
+                    <label>
+                      <span>Amount</span>
+                      <input
+                        inputMode="decimal"
+                        value={expense.amount}
+                        onChange={(event) =>
+                          onUpdateGigExpenseField(index, 'amount', event.target.value)
+                        }
+                        disabled={isGigLoading}
+                      />
+                    </label>
+                    <button
+                      className="ghost-button"
+                      onClick={() => onRemoveGigExpense(index)}
+                      type="button"
+                      disabled={isGigLoading}
+                    >
+                      Remove
+                    </button>
+                  </div>
                 ))}
-              </select>
-            </label>
+              </div>
+            ) : (
+              <div className="empty-state">
+                <strong>No expenses added yet.</strong>
+                <p>Use the fields above to add chargeable costs to this gig.</p>
+              </div>
+            )}
 
-            <label>
-              <span>Date</span>
-              <input
-                required
-                type="date"
-                value={gigForm.date}
-                onChange={(event) => onUpdateGigField('date', event.target.value)}
-              />
-            </label>
-
-            <label className="full-width">
-              <span>Title / description</span>
-              <input
-                required
-                value={gigForm.title}
-                onChange={(event) => onUpdateGigField('title', event.target.value)}
-                placeholder="Spring product launch"
-              />
-            </label>
-
-            <label className="full-width">
-              <span>Location / venue</span>
-              <input
-                required
-                value={gigForm.venue}
-                onChange={(event) => onUpdateGigField('venue', event.target.value)}
-                placeholder="Albert Hall, Manchester"
-              />
-            </label>
-
-            <label>
-              <span>Fee</span>
-              <input
-                required
-                inputMode="decimal"
-                value={gigForm.fee}
-                onChange={(event) => onUpdateGigField('fee', event.target.value)}
-                placeholder="650"
-              />
-            </label>
-
-            <label>
-              <span>Status</span>
-              <select
-                value={gigForm.status}
-                onChange={(event) =>
-                  onUpdateGigField('status', event.target.value as GigStatus)
-                }
+            <div className="form-actions">
+              <button
+                className="primary-button"
+                type="submit"
+                disabled={isGigLoading || clients.length === 0}
               >
-                <option value="Confirmed">Planned</option>
-                <option value="Completed">Completed</option>
-                <option value="Cancelled">Cancelled</option>
-                <option value="Draft">Draft</option>
-              </select>
-            </label>
-
-            <label className="checkbox-field full-width">
-              <input
-                type="checkbox"
-                checked={gigForm.wasDriving}
-                onChange={(event) => onUpdateGigField('wasDriving', event.target.checked)}
-              />
-              <span>I was driving for this gig</span>
-            </label>
-
-            <label className="full-width">
-              <span>Notes</span>
-              <textarea
-                rows={5}
-                value={gigForm.notes}
-                onChange={(event) => onUpdateGigField('notes', event.target.value)}
-                placeholder="Optional commercial or logistics notes"
-              />
-            </label>
-          </div>
-
-          <div className="gig-timeline-note">
-            <p className="detail-label">Expenses</p>
-            <span>
-              Add chargeable out-of-pocket costs here and they will flow through when the gig is invoiced.
-            </span>
-          </div>
-
-          <div className="invoice-adjustment-form">
-            <label>
-              Amount
-              <input
-                inputMode="decimal"
-                value={gigExpenseAmount}
-                onChange={(event) => onExpenseAmountChange(event.target.value)}
-                placeholder="45.00"
-                disabled={isGigLoading}
-              />
-            </label>
-            <label>
-              Description
-              <input
-                value={gigExpenseDescription}
-                onChange={(event) => onExpenseDescriptionChange(event.target.value)}
-                placeholder="Parking, hotel, equipment hire..."
-                disabled={isGigLoading}
-              />
-            </label>
-            <button
-              className="ghost-button"
-              onClick={onAddGigExpense}
-              type="button"
-              disabled={isGigLoading}
-            >
-              Add expense
-            </button>
-          </div>
-
-          {gigForm.expenses.length > 0 ? (
-            <div className="gig-expense-list">
-              {gigForm.expenses.map((expense, index) => (
-                <div className="gig-expense-item" key={`${expense.id || 'new'}-${index}`}>
-                  <label>
-                    <span>Description</span>
-                    <input
-                      value={expense.description}
-                      onChange={(event) =>
-                        onUpdateGigExpenseField(index, 'description', event.target.value)
-                      }
-                      disabled={isGigLoading}
-                    />
-                  </label>
-                  <label>
-                    <span>Amount</span>
-                    <input
-                      inputMode="decimal"
-                      value={expense.amount}
-                      onChange={(event) =>
-                        onUpdateGigExpenseField(index, 'amount', event.target.value)
-                      }
-                      disabled={isGigLoading}
-                    />
-                  </label>
-                  <button
-                    className="ghost-button"
-                    onClick={() => onRemoveGigExpense(index)}
-                    type="button"
-                    disabled={isGigLoading}
-                  >
-                    Remove
-                  </button>
-                </div>
-              ))}
+                {gigMode === 'create' ? 'Save gig' : 'Update gig'}
+              </button>
+              <button className="ghost-button" onClick={onCloseEditor} type="button">
+                Done
+              </button>
             </div>
-          ) : (
-            <div className="empty-state">
-              <strong>No expenses added yet.</strong>
-              <p>Use the fields above to add chargeable costs to this gig.</p>
-            </div>
-          )}
 
-          <div className="form-actions">
-            <button
-              className="primary-button"
-              type="submit"
-              disabled={isGigLoading || clients.length === 0}
-            >
-              {gigMode === 'create' ? 'Save gig' : 'Update gig'}
-            </button>
-            <button className="ghost-button" onClick={onResetForm} type="button">
-              Reset form
-            </button>
-          </div>
-
-          {clients.length === 0 && (
-            <p className="auth-note">
-              Add a client first. Every gig is intentionally tied to a client record.
-            </p>
-          )}
-        </form>
+            {clients.length === 0 && (
+              <p className="auth-note">
+                Add a client first. Every gig is intentionally tied to a client record.
+              </p>
+            )}
+          </form>
+        </div>
       </div>
     </section>
   )
@@ -1149,6 +1179,7 @@ type InvoicesSectionProps = {
   clients: Client[]
   draftInvoiceCount: number
   filteredInvoices: Invoice[]
+  isEditorOpen: boolean
   invoiceSearchQuery: string
   invoiceStatus: string
   invoices: Invoice[]
@@ -1156,12 +1187,14 @@ type InvoicesSectionProps = {
   onAdjustmentAmountChange: (value: string) => void
   onAdjustmentReasonChange: (value: string) => void
   onAddAdjustment: (invoice: Invoice) => Promise<void>
+  onCloseEditor: () => void
   onDeleteInvoice: (invoice: Invoice) => Promise<void>
   onDownloadPdf: (invoice: Invoice) => Promise<void>
   onInvoiceStatusChange: (invoice: Invoice, status: InvoiceStatus) => Promise<void>
   onReissue: (invoice: Invoice) => Promise<void>
   onSearchQueryChange: (value: string) => void
   onSelectInvoice: (invoiceId: string) => void
+  onStartEditing: () => void
   selectedInvoice: Invoice | null
 }
 
@@ -1171,6 +1204,7 @@ export function InvoicesSection({
   clients,
   draftInvoiceCount,
   filteredInvoices,
+  isEditorOpen,
   invoiceSearchQuery,
   invoiceStatus,
   invoices,
@@ -1178,12 +1212,14 @@ export function InvoicesSection({
   onAdjustmentAmountChange,
   onAdjustmentReasonChange,
   onAddAdjustment,
+  onCloseEditor,
   onDeleteInvoice,
   onDownloadPdf,
   onInvoiceStatusChange,
   onReissue,
   onSearchQueryChange,
   onSelectInvoice,
+  onStartEditing,
   selectedInvoice,
 }: InvoicesSectionProps) {
   const selectedInvoiceClient =
@@ -1267,6 +1303,14 @@ export function InvoicesSection({
               <h2>{selectedInvoice?.invoiceNumber ?? 'No invoice selected'}</h2>
             </div>
             <div className="actions">
+              <button
+                className="ghost-button"
+                onClick={onStartEditing}
+                type="button"
+                disabled={!selectedInvoice}
+              >
+                Line items
+              </button>
               <button
                 className="ghost-button"
                 onClick={() => selectedInvoice && void onReissue(selectedInvoice)}
@@ -1376,81 +1420,88 @@ export function InvoicesSection({
           )}
         </div>
 
-        <div className="panel">
-          <div className="panel-heading">
-            <div>
-              <p className="section-label">Management Pane</p>
-              <h2>{selectedInvoice ? 'Line items' : 'No invoice selected'}</h2>
-            </div>
-          </div>
-
-          {selectedInvoice ? (
-            <>
-              <div className="gig-timeline-note">
-                <p className="detail-label">Adjustments</p>
-                <span>
-                  Manual adjustments append a separate line item so the original invoice breakdown stays intact.
-                </span>
+        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+          <div aria-hidden={!isEditorOpen} className="panel editor-panel">
+            <div className="panel-heading">
+              <div>
+                <p className="section-label">Management Pane</p>
+                <h2>{selectedInvoice ? 'Line items' : 'No invoice selected'}</h2>
               </div>
-
-              <form
-                className="invoice-adjustment-form"
-                onSubmit={(event) => {
-                  event.preventDefault()
-                  void onAddAdjustment(selectedInvoice)
-                }}
-              >
-                <label>
-                  Amount
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={adjustmentAmount}
-                    onChange={(event) => onAdjustmentAmountChange(event.target.value)}
-                    placeholder="-25.00"
-                    disabled={isInvoiceLoading}
-                  />
-                </label>
-                <label>
-                  Reason
-                  <input
-                    value={adjustmentReason}
-                    onChange={(event) => onAdjustmentReasonChange(event.target.value)}
-                    placeholder="Goodwill discount, surcharge, correction..."
-                    disabled={isInvoiceLoading}
-                  />
-                </label>
-                <button className="ghost-button" type="submit" disabled={isInvoiceLoading}>
-                  Add adjustment
+              <div className="actions">
+                <button className="ghost-button" onClick={onCloseEditor} type="button">
+                  Done
                 </button>
-              </form>
-
-              <div className="invoice-line-list">
-                {selectedInvoice.lines
-                  .slice()
-                  .sort((left, right) => left.sortOrder - right.sortOrder)
-                  .map((line) => (
-                    <div className="invoice-line-item" key={line.id}>
-                      <div>
-                        <strong>{line.description}</strong>
-                        <span>
-                          {line.type} · {line.quantity} x {formatCurrency(line.unitPrice)}
-                        </span>
-                        {line.type === 'ManualAdjustment' ? (
-                          <span>Audit: {formatDateTime(line.createdUtc)}</span>
-                        ) : null}
-                      </div>
-                      <strong>{formatCurrency(line.lineTotal)}</strong>
-                    </div>
-                  ))}
               </div>
-            </>
-          ) : (
-            <div className="empty-state roomy">
-              <strong>Select an invoice to inspect its line items.</strong>
-              <p>The right-hand pane is reserved for line breakdowns and manual adjustments.</p>
             </div>
-          )}
+
+            {selectedInvoice ? (
+              <>
+                <div className="gig-timeline-note">
+                  <p className="detail-label">Adjustments</p>
+                  <span>
+                    Manual adjustments append a separate line item so the original invoice breakdown stays intact.
+                  </span>
+                </div>
+
+                <form
+                  className="invoice-adjustment-form"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    void onAddAdjustment(selectedInvoice)
+                  }}
+                >
+                  <label>
+                    Amount
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={adjustmentAmount}
+                      onChange={(event) => onAdjustmentAmountChange(event.target.value)}
+                      placeholder="-25.00"
+                      disabled={isInvoiceLoading}
+                    />
+                  </label>
+                  <label>
+                    Reason
+                    <input
+                      value={adjustmentReason}
+                      onChange={(event) => onAdjustmentReasonChange(event.target.value)}
+                      placeholder="Goodwill discount, surcharge, correction..."
+                      disabled={isInvoiceLoading}
+                    />
+                  </label>
+                  <button className="ghost-button" type="submit" disabled={isInvoiceLoading}>
+                    Add adjustment
+                  </button>
+                </form>
+
+                <div className="invoice-line-list">
+                  {selectedInvoice.lines
+                    .slice()
+                    .sort((left, right) => left.sortOrder - right.sortOrder)
+                    .map((line) => (
+                      <div className="invoice-line-item" key={line.id}>
+                        <div>
+                          <strong>{line.description}</strong>
+                          <span>
+                            {line.type} · {line.quantity} x {formatCurrency(line.unitPrice)}
+                          </span>
+                          {line.type === 'ManualAdjustment' ? (
+                            <span>Audit: {formatDateTime(line.createdUtc)}</span>
+                          ) : null}
+                        </div>
+                        <strong>{formatCurrency(line.lineTotal)}</strong>
+                      </div>
+                    ))}
+                </div>
+              </>
+            ) : (
+              <div className="empty-state roomy">
+                <strong>Select an invoice to inspect its line items.</strong>
+                <p>The right-hand pane is reserved for line breakdowns and manual adjustments.</p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -91,20 +91,19 @@ export function SignInScreen({
 }
 
 type ClientsSectionProps = {
-  clients: Client[]
   filteredClients: Client[]
   form: ClientForm
   isApiConnected: boolean
   isEditorOpen: boolean
+  isMonthlyInvoiceReady: boolean
   isInvoiceLoading: boolean
   isLoading: boolean
-  monthlyInvoiceClientId: string
+  monthlyInvoiceHelperText: string
   monthlyInvoiceMonth: string
   onCloseEditor: () => void
   mode: 'create' | 'edit'
   onDelete: () => void
   onGenerateMonthlyInvoice: () => void
-  onMonthlyInvoiceClientChange: (value: string) => void
   onMonthlyInvoiceMonthChange: (value: string) => void
   onOpenClientSettings: () => void
   onResetForm: () => void
@@ -120,20 +119,19 @@ type ClientsSectionProps = {
 }
 
 export function ClientsSection({
-  clients,
   filteredClients,
   form,
   isApiConnected,
   isEditorOpen,
+  isMonthlyInvoiceReady,
   isInvoiceLoading,
   isLoading,
-  monthlyInvoiceClientId,
+  monthlyInvoiceHelperText,
   monthlyInvoiceMonth,
   onCloseEditor,
   mode,
   onDelete,
   onGenerateMonthlyInvoice,
-  onMonthlyInvoiceClientChange,
   onMonthlyInvoiceMonthChange,
   onOpenClientSettings,
   onResetForm,
@@ -246,23 +244,6 @@ export function ClientsSection({
                 <p className="detail-label">Monthly invoice run</p>
                 <div className="invoice-adjustment-form">
                   <label>
-                    Client
-                    <select
-                      value={monthlyInvoiceClientId}
-                      onChange={(event) =>
-                        onMonthlyInvoiceClientChange(event.target.value)
-                      }
-                      disabled={isInvoiceLoading}
-                    >
-                      <option value="">Select client</option>
-                      {clients.map((client) => (
-                        <option key={client.id} value={client.id}>
-                          {client.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label>
                     Month
                     <input
                       type="month"
@@ -277,11 +258,12 @@ export function ClientsSection({
                     className="primary-button"
                     onClick={onGenerateMonthlyInvoice}
                     type="button"
-                    disabled={isInvoiceLoading}
+                    disabled={isInvoiceLoading || !isMonthlyInvoiceReady}
                   >
                     Generate monthly invoice
                   </button>
                 </div>
+                <span>{monthlyInvoiceHelperText}</span>
               </div>
 
               <div className="detail-grid">
@@ -716,6 +698,7 @@ type GigsSectionProps = {
   onExpenseAmountChange: (value: string) => void
   onExpenseDescriptionChange: (value: string) => void
   onGenerateInvoice: () => void
+  onOpenLinkedInvoice: () => void
   onRemoveGigExpense: (index: number) => void
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
@@ -758,6 +741,7 @@ export function GigsSection({
   onExpenseAmountChange,
   onExpenseDescriptionChange,
   onGenerateInvoice,
+  onOpenLinkedInvoice,
   onRemoveGigExpense,
   onResetForm,
   onSearchQueryChange,
@@ -925,7 +909,13 @@ export function GigsSection({
                 </article>
                 <article>
                   <p className="detail-label">Invoice link</p>
-                  <strong>{selectedGig.isInvoiced ? 'Linked' : 'Not invoiced yet'}</strong>
+                  {selectedGig.isInvoiced ? (
+                    <button className="ghost-button" onClick={onOpenLinkedInvoice} type="button">
+                      Open invoice
+                    </button>
+                  ) : (
+                    <strong>Not invoiced yet</strong>
+                  )}
                 </article>
                 <article className="full-width">
                   <p className="detail-label">Notes</p>
@@ -943,8 +933,8 @@ export function GigsSection({
                 {selectedGigIds.length > 0 && (
                   <span>
                     {hasCrossClientSelection
-                      ? 'Selected gigs need to belong to the same client before they can be invoiced together.'
-                      : `${selectedGigIds.length} gig(s) selected for a combined invoice.`}
+                      ? ' Selected gigs need to belong to the same client before they can be invoiced together.'
+                      : ` ${selectedGigIds.length} gig(s) selected for a combined invoice.`}
                   </span>
                 )}
               </div>

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -38,10 +38,8 @@ export function SessionCheckingScreen({
       <section className="hero-panel auth-panel">
         <div className="hero-copy">
           <p className="eyebrow">Security</p>
-          <h1>Checking your Google session.</h1>
-          <p className="hero-text">
-            Glovelly now protects client and invoice data behind OpenID Connect.
-          </p>
+          <h1>Checking your sign-in.</h1>
+          <p className="hero-text">Just a moment while we open your workspace.</p>
         </div>
         <span className="status-pill">{status}</span>
       </section>
@@ -68,10 +66,9 @@ export function SignInScreen({
       <section className="hero-panel auth-panel">
         <div className="hero-copy">
           <p className="eyebrow">Secure Sign-In</p>
-          <h1>Glovelly now uses Google to verify who’s allowed in.</h1>
+          <h1>Sign in to open Glovelly.</h1>
           <p className="hero-text">
-            Sign in with the Google account attached to your deployment so the API
-            can issue a secure app session before any business data is loaded.
+            Use your usual account to access clients, gigs and invoices.
           </p>
         </div>
 
@@ -79,8 +76,8 @@ export function SignInScreen({
           <span className="status-pill">{status}</span>
           {shouldCloseBrowserNotice && (
             <p className="auth-note">
-              The Glovelly session cookie has been cleared. Close your browser if you
-              want to fully end the Google sign-in session too.
+              You have been signed out of Glovelly. Close your browser too if you are
+              using a shared device.
             </p>
           )}
           <button className="primary-button" onClick={onSignIn} type="button">
@@ -202,7 +199,7 @@ export function ClientsSection({
                 <p>
                   {isApiConnected
                     ? 'Try a different term or add a fresh client profile.'
-                    : 'Start the backend and refresh this page to complete sign-in.'}
+                    : 'We could not load client details right now. Refresh and try again.'}
                 </p>
               </div>
             )}
@@ -318,7 +315,7 @@ export function ClientsSection({
           ) : (
             <div className="empty-state roomy">
               <strong>Select a client to see billing details.</strong>
-              <p>The right-hand panel is set up for a fuller CRM-style summary later on.</p>
+              <p>Billing details and contact information will appear here.</p>
             </div>
           )}
         </div>
@@ -479,17 +476,16 @@ export function AdminSection({
       <div className="admin-banner panel">
         <div>
           <p className="section-label">Administrator Area</p>
-          <h2>User enrolment</h2>
+          <h2>User access</h2>
           <p className="hero-text">
-            Control which Google accounts can access Glovelly, whether they are
-            active, and whether they should see this administrator workspace.
+            Manage who can sign in, which role they have, and whether their account is active.
           </p>
         </div>
 
         <div className="hero-metrics admin-metrics">
           <article>
             <span>{adminUsers.length}</span>
-            <p>enrolled users</p>
+            <p>users with access</p>
           </article>
           <article>
             <span>{activeUsersCount}</span>
@@ -507,10 +503,10 @@ export function AdminSection({
           <div className="panel-heading">
             <div>
               <p className="section-label">Access Directory</p>
-              <h2>Enrolled users</h2>
+              <h2>People with access</h2>
             </div>
             <button className="ghost-button" onClick={onResetForm} type="button">
-              New enrolment
+              Add user
             </button>
           </div>
 
@@ -545,8 +541,8 @@ export function AdminSection({
 
             {filteredAdminUsers.length === 0 && (
               <div className="empty-state">
-                <strong>No enrolled users match that search.</strong>
-                <p>Try another term or start a fresh enrolment.</p>
+                <strong>No users match that search.</strong>
+                <p>Try another term or add someone new.</p>
               </div>
             )}
           </div>
@@ -555,7 +551,7 @@ export function AdminSection({
         <div className="panel">
           <div className="panel-heading">
             <div>
-              <p className="section-label">Enrolment Overview</p>
+              <p className="section-label">Access Overview</p>
               <h2>
                 {selectedAdminUser?.displayName ||
                   selectedAdminUser?.email ||
@@ -569,7 +565,7 @@ export function AdminSection({
                 type="button"
                 disabled={!selectedAdminUser}
               >
-                Edit enrolment
+                Edit access
               </button>
             </div>
           </div>
@@ -585,17 +581,15 @@ export function AdminSection({
                 <strong>{selectedAdminUser.isActive ? 'Active' : 'Inactive'}</strong>
               </article>
               <article>
-                <p className="detail-label">Enrolment</p>
+                <p className="detail-label">Sign-in status</p>
                 <strong>
-                  {selectedAdminUser.isEnrolled
-                    ? 'Bound to Google subject'
-                    : 'Invited by email'}
+                  {selectedAdminUser.isEnrolled ? 'Ready to sign in' : 'Waiting for first sign-in'}
                 </strong>
               </article>
               <article className="full-width">
-                <p className="detail-label">Google subject</p>
+                <p className="detail-label">Account reference</p>
                 <strong>
-                  {selectedAdminUser.googleSubject ?? 'Pending first Google sign-in'}
+                  {selectedAdminUser.googleSubject ?? 'Added by email only so far'}
                 </strong>
               </article>
               <article>
@@ -609,8 +603,8 @@ export function AdminSection({
             </div>
           ) : (
             <div className="empty-state roomy">
-              <strong>Select an enrolled user to review their access.</strong>
-              <p>The admin area stays hidden from standard users and only appears for admins.</p>
+              <strong>Select a user to review their access.</strong>
+              <p>You can update their role, status and sign-in details here.</p>
             </div>
           )}
         </div>
@@ -624,7 +618,7 @@ export function AdminSection({
             <div className="panel-heading">
               <div>
                 <p className="section-label">Management Pane</p>
-                <h2>{adminMode === 'create' ? 'Create enrolment' : 'Update enrolment'}</h2>
+                <h2>{adminMode === 'create' ? 'Add user' : 'Update access'}</h2>
               </div>
               <span className="status-pill">{adminStatus}</span>
             </div>
@@ -651,11 +645,11 @@ export function AdminSection({
               </label>
 
               <label className="full-width">
-                <span>Google subject</span>
+                <span>Account reference</span>
                 <input
                   value={adminForm.googleSubject}
                   onChange={(event) => onUpdateField('googleSubject', event.target.value)}
-                  placeholder="Optional until first Google sign-in"
+                  placeholder="Optional"
                   disabled={adminMode === 'edit' && selectedAdminUser?.isEnrolled === true}
                 />
               </label>
@@ -685,15 +679,15 @@ export function AdminSection({
 
             <div className="form-actions">
               <button className="primary-button" type="submit" disabled={isAdminLoading}>
-                {adminMode === 'create' ? 'Enrol user' : 'Save enrolment'}
+                {adminMode === 'create' ? 'Add user' : 'Save changes'}
               </button>
               <button className="ghost-button" onClick={onCloseEditor} type="button">
                 Done
               </button>
             </div>
             <p className="auth-note">
-              Admins can pre-provision by email only. If Google subject is blank, Glovelly
-              will bind it on the user’s first successful Google sign-in.
+              Adding an email address is enough to let someone get started. You can fill in
+              the account reference later if needed.
             </p>
           </form>
         </div>
@@ -943,13 +937,13 @@ export function GigsSection({
                 <p className="detail-label">Invoice workflow</p>
                 <span>
                   {selectedGig.isInvoiced
-                    ? 'This gig is already linked to an invoice. Open the invoices workspace to review or download it.'
-                    : 'This record now carries the client, date, venue and fee needed to generate a one-off invoice.'}
+                    ? 'This gig is already linked to an invoice. Open Invoices to review or download it.'
+                    : 'This gig has everything needed to create an invoice when you are ready.'}
                 </span>
                 {selectedGigIds.length > 0 && (
                   <span>
                     {hasCrossClientSelection
-                      ? 'Selected gigs must share the same client before invoice generation is allowed.'
+                      ? 'Selected gigs need to belong to the same client before they can be invoiced together.'
                       : `${selectedGigIds.length} gig(s) selected for a combined invoice.`}
                   </span>
                 )}
@@ -958,7 +952,7 @@ export function GigsSection({
           ) : (
             <div className="empty-state roomy">
               <strong>Select a gig to review its details.</strong>
-              <p>The browse pane shows the commercial snapshot that matters later.</p>
+              <p>Key booking and billing details will appear here.</p>
             </div>
           )}
         </div>
@@ -1165,7 +1159,7 @@ export function GigsSection({
 
             {clients.length === 0 && (
               <p className="auth-note">
-                Add a client first. Every gig is intentionally tied to a client record.
+                Add a client first so this gig can be linked to the right account.
               </p>
             )}
           </form>
@@ -1410,8 +1404,7 @@ export function InvoicesSection({
               <div className="gig-timeline-note">
                 <p className="detail-label">Invoice workflow</p>
                 <span>
-                  Re-issue and PDF actions stay in the overview pane, while line-level changes now live in
-                  the docked side pane for a steadier browse flow.
+                  Review invoice details here, then open line items when you need to make changes.
                 </span>
               </div>
             </>
@@ -1442,7 +1435,7 @@ export function InvoicesSection({
                 <div className="gig-timeline-note">
                   <p className="detail-label">Adjustments</p>
                   <span>
-                    Manual adjustments append a separate line item so the original invoice breakdown stays intact.
+                    Add adjustments as separate line items so the invoice stays clear and easy to follow.
                   </span>
                 </div>
 
@@ -1501,7 +1494,7 @@ export function InvoicesSection({
             ) : (
               <div className="empty-state roomy">
                 <strong>Select an invoice to inspect its line items.</strong>
-                <p>The right-hand pane is reserved for line breakdowns and manual adjustments.</p>
+                <p>Line items and adjustments will appear here.</p>
               </div>
             )}
           </div>

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -806,7 +806,10 @@ export function GigsSection({
                   onClick={() => onSelectGig(gig.id)}
                   type="button"
                 >
-                  <label onClick={(event) => event.stopPropagation()}>
+                  <label
+                    className="gig-select-toggle"
+                    onClick={(event) => event.stopPropagation()}
+                  >
                     <input
                       type="checkbox"
                       checked={selectedGigIds.includes(gig.id)}

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -273,10 +273,7 @@ export function formatDateTime(value: string | null) {
     return 'Unknown'
   }
 
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(date)
+  return dateTimeFormatter.format(date)
 }
 
 export function formatCommitId(value: string | null) {
@@ -310,12 +307,7 @@ export function formatRate(value: number | null) {
 }
 
 export function formatCurrency(value: number) {
-  return new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: 'GBP',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value)
+  return currencyFormatter.format(value)
 }
 
 export function formatDate(value: string) {
@@ -328,9 +320,7 @@ export function formatDate(value: string) {
     return value
   }
 
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'medium',
-  }).format(date)
+  return dateFormatter.format(date)
 }
 
 function formatEditableAmount(value: number) {
@@ -364,6 +354,22 @@ export function getAllowedInvoiceStatusTransitions(status: InvoiceStatus) {
       return [] as InvoiceStatus[]
   }
 }
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'GBP',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+})
 
 export function getStoredThemePreference(): ThemePreference {
   const rawPreference = window.localStorage.getItem(themeStorageKey)


### PR DESCRIPTION
## What changed

This PR bundles a frontend polish pass across the invoice and workspace flows.

- fixed the monthly invoice run layout so controls stay inside the panel
- reduced the per-gig selection checkbox sizing
- made the add/edit panes for clients, admin, gigs, and invoice line items collapsible to declutter the workspace
- added a sliding editor-pane interaction and tightened its layout behavior so it stays inside the viewport
- fixed controlled-input warnings in the client editor
- improved frontend responsiveness by reducing paint-heavy blur effects and trimming avoidable render work in list/detail views

## Why

The SPA was looking much better visually, but a few UI issues were still getting in the way:

- some controls were overflowing or visually oversized
- the always-visible editor panes made the screen feel busier than it needed to
- the new pane transitions needed layout fixes to behave properly on wide screens
- the frontend still felt choppy on older hardware, especially for a relatively simple app

## Root causes addressed

- form controls in the monthly invoice section were using layout rules that did not shrink cleanly inside the containing card
- checkbox inputs were inheriting oversized shared input styling
- editor panes stayed mounted and permanently visible, which added clutter and made the layout heavier
- the sliding editor slot could push outside the viewport because sibling columns were holding onto aggressive minimum widths
- nullable billing-address fields could flow into mounted controlled inputs
- paint and render cost was higher than necessary because of persistent blur effects, repeated lookups in hot render paths, and recreated date/currency formatters

## Impact

- cleaner workspace layout with less visual noise when not editing
- invoice and gig workflows feel more consistent across sections
- smoother interaction on lower-powered machines, with lower paint cost and less repeated render work
- no behavior change to backend workflows; this is a frontend-focused UX and performance pass

## Validation

- `npm run build` in `frontend/glovelly-web`
