### PR TITLE
[codex] Add seller profile setup and invoice identity flow

### DIFF
--- a/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
+++ b/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using Glovelly.Api.Tests.Infrastructure;
 using Xunit;
@@ -19,6 +20,20 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
     [Fact]
     public async Task GenerateInvoice_FromGig_CreatesInvoiceLinesPdfAndGigLink()
     {
+        var sellerProfileResponse = await _client.PutAsJsonAsync("/seller-profile", new
+        {
+            sellerName = "Glovelly Music Ltd",
+            addressLine1 = "1 Chapel Street",
+            city = "Manchester",
+            country = "United Kingdom",
+            email = "accounts@glovelly.test",
+            accountName = "Glovelly Music Ltd",
+            sortCode = "12-34-56",
+            accountNumber = "12345678",
+            paymentReferenceNote = "Use the invoice number as your reference.",
+        });
+        sellerProfileResponse.EnsureSuccessStatusCode();
+
         var createGigResponse = await _client.PostAsJsonAsync("/gigs", new
         {
             clientId = TestData.FoxAndFinchId,
@@ -50,6 +65,11 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
         Assert.Equal("In respect of One-off corporate booking at King's House on 2026-06-20.", invoice.GetProperty("description").GetString());
         Assert.False(string.IsNullOrWhiteSpace(invoice.GetProperty("invoiceNumber").GetString()));
         Assert.False(string.IsNullOrWhiteSpace(invoice.GetProperty("pdfBlob").GetString()));
+        var pdfText = Encoding.ASCII.GetString(
+            Convert.FromBase64String(invoice.GetProperty("pdfBlob").GetString()!));
+        Assert.Contains("From: Glovelly Music Ltd", pdfText);
+        Assert.Contains("Account number: 12345678", pdfText);
+        Assert.Contains("Payment note: Use the invoice number as your reference.", pdfText);
 
         var lines = invoice.GetProperty("lines").EnumerateArray().OrderBy(line => line.GetProperty("sortOrder").GetInt32()).ToArray();
         Assert.Equal(3, lines.Length);

--- a/backend/Glovelly.Api.Tests/SellerProfileEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/SellerProfileEndpointsTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class SellerProfileEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _client;
+
+    public SellerProfileEndpointsTests(GlovellyApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Get_WhenNoProfileExists_ReturnsEmptyEditableState()
+    {
+        var response = await _client.GetAsync("/seller-profile");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var profile = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(JsonValueKind.Null, profile.GetProperty("id").ValueKind);
+        Assert.False(profile.GetProperty("isConfigured").GetBoolean());
+        Assert.False(profile.GetProperty("isInvoiceReady").GetBoolean());
+        Assert.Contains(
+            profile.GetProperty("missingFields").EnumerateArray().Select(value => value.GetString()),
+            value => value == "sellerName");
+    }
+
+    [Fact]
+    public async Task Put_WhenPaymentDetailsIncomplete_ReturnsValidationProblem()
+    {
+        var response = await _client.PutAsJsonAsync("/seller-profile", new
+        {
+            sellerName = "Glovelly Music Ltd",
+            addressLine1 = "1 Chapel Street",
+            city = "Manchester",
+            country = "United Kingdom",
+            sortCode = "12-34-56",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Account name is required when payment details are provided.",
+            problem.GetProperty("errors").GetProperty("accountName")[0].GetString());
+        Assert.Equal(
+            "Account number is required when payment details are provided.",
+            problem.GetProperty("errors").GetProperty("accountNumber")[0].GetString());
+    }
+
+    [Fact]
+    public async Task Put_WhenProfileValid_PersistsAndReloads()
+    {
+        var saveResponse = await _client.PutAsJsonAsync("/seller-profile", new
+        {
+            sellerName = "Glovelly Music Ltd",
+            addressLine1 = "1 Chapel Street",
+            addressLine2 = "Suite 4",
+            city = "Manchester",
+            region = "Greater Manchester",
+            postcode = "M1 1AA",
+            country = "United Kingdom",
+            email = "hello@glovelly.test",
+            phone = "+44 7700 900123",
+            accountName = "Glovelly Music Ltd",
+            sortCode = "12-34-56",
+            accountNumber = "12345678",
+            paymentReferenceNote = "Use invoice number as the payment reference.",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, saveResponse.StatusCode);
+
+        var savedProfile = await saveResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.True(savedProfile.GetProperty("isConfigured").GetBoolean());
+        Assert.True(savedProfile.GetProperty("isInvoiceReady").GetBoolean());
+        Assert.Empty(savedProfile.GetProperty("missingFields").EnumerateArray());
+
+        var getResponse = await _client.GetAsync("/seller-profile");
+        getResponse.EnsureSuccessStatusCode();
+
+        var fetchedProfile = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Glovelly Music Ltd", fetchedProfile.GetProperty("sellerName").GetString());
+        Assert.Equal("1 Chapel Street", fetchedProfile.GetProperty("addressLine1").GetString());
+        Assert.Equal("Suite 4", fetchedProfile.GetProperty("addressLine2").GetString());
+        Assert.Equal("Manchester", fetchedProfile.GetProperty("city").GetString());
+        Assert.Equal("Greater Manchester", fetchedProfile.GetProperty("region").GetString());
+        Assert.Equal("M1 1AA", fetchedProfile.GetProperty("postcode").GetString());
+        Assert.Equal("United Kingdom", fetchedProfile.GetProperty("country").GetString());
+        Assert.Equal("Glovelly Music Ltd", fetchedProfile.GetProperty("accountName").GetString());
+        Assert.Equal("12-34-56", fetchedProfile.GetProperty("sortCode").GetString());
+        Assert.Equal("12345678", fetchedProfile.GetProperty("accountNumber").GetString());
+    }
+}

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -11,6 +11,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<GigExpense> GigExpenses => Set<GigExpense>();
     public DbSet<Invoice> Invoices => Set<Invoice>();
     public DbSet<InvoiceLine> InvoiceLines => Set<InvoiceLine>();
+    public DbSet<SellerProfile> SellerProfiles => Set<SellerProfile>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -172,6 +173,53 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
                 .WithMany()
                 .HasForeignKey(line => line.GigId)
                 .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<SellerProfile>(entity =>
+        {
+            entity.HasKey(profile => profile.Id);
+            entity.Property(profile => profile.SellerName)
+                .HasMaxLength(200);
+            entity.Property(profile => profile.Email)
+                .HasMaxLength(320);
+            entity.Property(profile => profile.Phone)
+                .HasMaxLength(50);
+            entity.Property(profile => profile.AccountName)
+                .HasMaxLength(200);
+            entity.Property(profile => profile.SortCode)
+                .HasMaxLength(20);
+            entity.Property(profile => profile.AccountNumber)
+                .HasMaxLength(20);
+            entity.Property(profile => profile.PaymentReferenceNote)
+                .HasMaxLength(500);
+            entity.Property(profile => profile.CreatedUtc)
+                .IsRequired();
+            entity.Property(profile => profile.UpdatedUtc)
+                .IsRequired();
+            entity.HasIndex(profile => profile.UserId)
+                .IsUnique();
+            entity.HasOne(profile => profile.User)
+                .WithOne(user => user.SellerProfile)
+                .HasForeignKey<SellerProfile>(profile => profile.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(profile => profile.CreatedByUser)
+                .WithMany(user => user.SellerProfilesCreated)
+                .HasForeignKey(profile => profile.CreatedByUserId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(profile => profile.UpdatedByUser)
+                .WithMany(user => user.SellerProfilesUpdated)
+                .HasForeignKey(profile => profile.UpdatedByUserId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.OwnsOne(profile => profile.Address, address =>
+            {
+                address.Property(value => value.Line1).HasMaxLength(200);
+                address.Property(value => value.Line2).HasMaxLength(200);
+                address.Property(value => value.City).HasMaxLength(100);
+                address.Property(value => value.StateOrCounty).HasMaxLength(100);
+                address.Property(value => value.PostalCode).HasMaxLength(20);
+                address.Property(value => value.Country).HasMaxLength(100);
+            });
         });
     }
 }

--- a/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/CrudEndpoints.cs
@@ -26,6 +26,11 @@ public static class CrudEndpoints
             .RequireAuthorization(GlovellyPolicies.GlovellyUser)
             .MapInvoiceLineEndpoints();
 
+        app.MapGroup("/seller-profile")
+            .WithTags("SellerProfile")
+            .RequireAuthorization(GlovellyPolicies.GlovellyUser)
+            .MapSellerProfileEndpoints();
+
         return app;
     }
 }

--- a/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
@@ -26,6 +26,11 @@ internal static class EndpointSupport
         return query.Where(line => line.CreatedByUserId == null || line.CreatedByUserId == userId);
     }
 
+    public static IQueryable<SellerProfile> WhereVisibleTo(this IQueryable<SellerProfile> query, Guid? userId)
+    {
+        return query.Where(profile => profile.UserId == userId);
+    }
+
     public static void StampCreate(Client client, Guid? userId)
     {
         client.CreatedByUserId = userId;
@@ -108,6 +113,20 @@ internal static class EndpointSupport
         }
 
         return null;
+    }
+
+    public static void StampCreate(SellerProfile profile, Guid? userId)
+    {
+        profile.CreatedByUserId = userId;
+        profile.UpdatedByUserId = userId;
+        profile.CreatedUtc = DateTimeOffset.UtcNow;
+        profile.UpdatedUtc = profile.CreatedUtc;
+    }
+
+    public static void StampUpdate(SellerProfile profile, Guid? userId)
+    {
+        profile.UpdatedByUserId = userId;
+        profile.UpdatedUtc = DateTimeOffset.UtcNow;
     }
 
     public static IResult? ValidateGigRequest(Gig gig)

--- a/backend/Glovelly.Api/Endpoints/SellerProfileEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/SellerProfileEndpoints.cs
@@ -1,0 +1,289 @@
+using Glovelly.Api.Auth;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+
+namespace Glovelly.Api.Endpoints;
+
+internal static class SellerProfileEndpoints
+{
+    public static RouteGroupBuilder MapSellerProfileEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/", [Authorize(Policy = GlovellyPolicies.GlovellyUser)] async (
+            AppDbContext dbContext,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            if (!userId.HasValue)
+            {
+                return Results.Unauthorized();
+            }
+
+            var profile = await dbContext.SellerProfiles
+                .AsNoTracking()
+                .FirstOrDefaultAsync(value => value.UserId == userId.Value);
+
+            return Results.Ok(ToResponse(profile, userId.Value));
+        });
+
+        group.MapPut("/", [Authorize(Policy = GlovellyPolicies.GlovellyUser)] async (
+            SellerProfileRequest request,
+            AppDbContext dbContext,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var validationErrors = ValidateRequest(request);
+            if (validationErrors is not null)
+            {
+                return Results.ValidationProblem(validationErrors);
+            }
+
+            var userId = currentUserAccessor.TryGetUserId(user);
+            if (!userId.HasValue)
+            {
+                return Results.Unauthorized();
+            }
+
+            var profile = await dbContext.SellerProfiles
+                .FirstOrDefaultAsync(value => value.UserId == userId.Value);
+
+            var now = DateTimeOffset.UtcNow;
+            if (profile is null)
+            {
+                profile = new SellerProfile
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId.Value,
+                };
+                EndpointSupport.StampCreate(profile, userId);
+                dbContext.SellerProfiles.Add(profile);
+            }
+
+            profile.SellerName = Normalize(request.SellerName);
+            profile.Address = new Address
+            {
+                Line1 = NormalizeRequired(request.AddressLine1),
+                Line2 = Normalize(request.AddressLine2),
+                City = NormalizeRequired(request.City),
+                StateOrCounty = Normalize(request.Region),
+                PostalCode = NormalizeRequired(request.Postcode),
+                Country = NormalizeRequired(request.Country),
+            };
+            profile.Email = Normalize(request.Email);
+            profile.Phone = Normalize(request.Phone);
+            profile.AccountName = Normalize(request.AccountName);
+            profile.SortCode = Normalize(request.SortCode);
+            profile.AccountNumber = Normalize(request.AccountNumber);
+            profile.PaymentReferenceNote = Normalize(request.PaymentReferenceNote);
+            profile.UpdatedUtc = now;
+            EndpointSupport.StampUpdate(profile, userId);
+
+            await dbContext.SaveChangesAsync();
+
+            return Results.Ok(ToResponse(profile, userId.Value));
+        });
+
+        return group;
+    }
+
+    private static object ToResponse(SellerProfile? profile, Guid userId)
+    {
+        var effectiveProfile = profile ?? new SellerProfile
+        {
+            UserId = userId,
+            Address = new Address(),
+        };
+        var missingFields = GetMissingFields(effectiveProfile);
+
+        return new
+        {
+            id = effectiveProfile.Id == Guid.Empty ? (Guid?)null : effectiveProfile.Id,
+            sellerName = effectiveProfile.SellerName,
+            addressLine1 = effectiveProfile.Address.Line1,
+            addressLine2 = effectiveProfile.Address.Line2,
+            city = effectiveProfile.Address.City,
+            region = effectiveProfile.Address.StateOrCounty,
+            postcode = effectiveProfile.Address.PostalCode,
+            country = effectiveProfile.Address.Country,
+            email = effectiveProfile.Email,
+            phone = effectiveProfile.Phone,
+            accountName = effectiveProfile.AccountName,
+            sortCode = effectiveProfile.SortCode,
+            accountNumber = effectiveProfile.AccountNumber,
+            paymentReferenceNote = effectiveProfile.PaymentReferenceNote,
+            isConfigured = HasAnyValue(effectiveProfile),
+            isInvoiceReady = missingFields.Count == 0,
+            missingFields,
+        };
+    }
+
+    private static List<string> GetMissingFields(SellerProfile profile)
+    {
+        var missingFields = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(profile.SellerName))
+        {
+            missingFields.Add("sellerName");
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.Address.Line1))
+        {
+            missingFields.Add("addressLine1");
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.Address.City))
+        {
+            missingFields.Add("city");
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.Address.Country))
+        {
+            missingFields.Add("country");
+        }
+
+        var hasPaymentValue =
+            !string.IsNullOrWhiteSpace(profile.AccountName) ||
+            !string.IsNullOrWhiteSpace(profile.SortCode) ||
+            !string.IsNullOrWhiteSpace(profile.AccountNumber);
+
+        if (hasPaymentValue)
+        {
+            if (string.IsNullOrWhiteSpace(profile.AccountName))
+            {
+                missingFields.Add("accountName");
+            }
+
+            if (string.IsNullOrWhiteSpace(profile.SortCode))
+            {
+                missingFields.Add("sortCode");
+            }
+
+            if (string.IsNullOrWhiteSpace(profile.AccountNumber))
+            {
+                missingFields.Add("accountNumber");
+            }
+        }
+
+        return missingFields;
+    }
+
+    private static bool HasAnyValue(SellerProfile profile)
+    {
+        return new[]
+        {
+            profile.SellerName,
+            profile.Address.Line1,
+            profile.Address.Line2,
+            profile.Address.City,
+            profile.Address.StateOrCounty,
+            profile.Address.PostalCode,
+            profile.Address.Country,
+            profile.Email,
+            profile.Phone,
+            profile.AccountName,
+            profile.SortCode,
+            profile.AccountNumber,
+            profile.PaymentReferenceNote,
+        }.Any(value => !string.IsNullOrWhiteSpace(value));
+    }
+
+    private static Dictionary<string, string[]>? ValidateRequest(SellerProfileRequest request)
+    {
+        var validationResults = new List<ValidationResult>();
+        var validationContext = new ValidationContext(request);
+        var isValid = Validator.TryValidateObject(
+            request,
+            validationContext,
+            validationResults,
+            validateAllProperties: true);
+
+        var errors = validationResults
+            .GroupBy(result => ToCamelCase(result.MemberNames.FirstOrDefault() ?? string.Empty))
+            .ToDictionary(
+                grouping => grouping.Key,
+                grouping => grouping.Select(result => result.ErrorMessage ?? "Invalid value.").ToArray());
+
+        var hasAnyPaymentValue =
+            !string.IsNullOrWhiteSpace(request.AccountName) ||
+            !string.IsNullOrWhiteSpace(request.SortCode) ||
+            !string.IsNullOrWhiteSpace(request.AccountNumber);
+
+        if (hasAnyPaymentValue)
+        {
+            AddRequiredError(
+                errors,
+                nameof(request.AccountName),
+                request.AccountName,
+                "Account name is required when payment details are provided.");
+            AddRequiredError(
+                errors,
+                nameof(request.SortCode),
+                request.SortCode,
+                "Sort code is required when payment details are provided.");
+            AddRequiredError(
+                errors,
+                nameof(request.AccountNumber),
+                request.AccountNumber,
+                "Account number is required when payment details are provided.");
+        }
+
+        return isValid && errors.Count == 0 ? null : errors;
+    }
+
+    private static void AddRequiredError(
+        Dictionary<string, string[]> errors,
+        string memberName,
+        string? value,
+        string message)
+    {
+        var key = ToCamelCase(memberName);
+        if (!errors.ContainsKey(key) && string.IsNullOrWhiteSpace(value))
+        {
+            errors[key] = [message];
+        }
+    }
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+
+    private static string NormalizeRequired(string? value)
+    {
+        return Normalize(value) ?? string.Empty;
+    }
+
+    private static string ToCamelCase(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        return char.ToLowerInvariant(value[0]) + value[1..];
+    }
+
+    internal sealed record SellerProfileRequest(
+        [StringLength(200)] string? SellerName,
+        [StringLength(200)] string? AddressLine1,
+        [StringLength(200)] string? AddressLine2,
+        [StringLength(100)] string? City,
+        [StringLength(100)] string? Region,
+        [StringLength(20)] string? Postcode,
+        [StringLength(100)] string? Country,
+        [EmailAddress(ErrorMessage = "Email must be a valid email address.")]
+        [StringLength(320)]
+        string? Email,
+        [Phone(ErrorMessage = "Phone must be a valid phone number.")]
+        [StringLength(50)]
+        string? Phone,
+        [StringLength(200)] string? AccountName,
+        [StringLength(20)] string? SortCode,
+        [StringLength(20)] string? AccountNumber,
+        [StringLength(500)] string? PaymentReferenceNote);
+}

--- a/backend/Glovelly.Api/Models/SellerProfile.cs
+++ b/backend/Glovelly.Api/Models/SellerProfile.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Glovelly.Api.Models;
+
+public sealed class SellerProfile
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public string? SellerName { get; set; }
+    public Address Address { get; set; } = new();
+    public string? Email { get; set; }
+    public string? Phone { get; set; }
+    public string? AccountName { get; set; }
+    public string? SortCode { get; set; }
+    public string? AccountNumber { get; set; }
+    public string? PaymentReferenceNote { get; set; }
+    public DateTimeOffset CreatedUtc { get; set; }
+    public DateTimeOffset UpdatedUtc { get; set; }
+    public Guid? CreatedByUserId { get; set; }
+    public Guid? UpdatedByUserId { get; set; }
+
+    [JsonIgnore]
+    public User? User { get; set; }
+    [JsonIgnore]
+    public User? CreatedByUser { get; set; }
+    [JsonIgnore]
+    public User? UpdatedByUser { get; set; }
+}

--- a/backend/Glovelly.Api/Models/User.cs
+++ b/backend/Glovelly.Api/Models/User.cs
@@ -31,4 +31,10 @@ public sealed class User
     public ICollection<Invoice> InvoicesCreated { get; set; } = new List<Invoice>();
     [JsonIgnore]
     public ICollection<Invoice> InvoicesUpdated { get; set; } = new List<Invoice>();
+    [JsonIgnore]
+    public ICollection<SellerProfile> SellerProfilesCreated { get; set; } = new List<SellerProfile>();
+    [JsonIgnore]
+    public ICollection<SellerProfile> SellerProfilesUpdated { get; set; } = new List<SellerProfile>();
+    [JsonIgnore]
+    public SellerProfile? SellerProfile { get; set; }
 }

--- a/backend/Glovelly.Api/Services/InvoiceWorkflowService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceWorkflowService.cs
@@ -36,7 +36,8 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
 
         var generatedLines = await BuildGeneratedInvoiceLinesForGigAsync(gig, userId, cancellationToken);
         invoice.Lines = generatedLines;
-        invoice.PdfBlob = GenerateInvoicePdf(invoice, client, gig, generatedLines);
+        var sellerProfile = await ResolveSellerProfileAsync(userId, cancellationToken);
+        invoice.PdfBlob = GenerateInvoicePdf(invoice, client, gig, generatedLines, sellerProfile);
 
         dbContext.Invoices.Add(invoice);
 
@@ -77,15 +78,23 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
         Guid? userId,
         CancellationToken cancellationToken = default)
     {
-        invoice.PdfBlob = GenerateInvoicePdf(invoice, client, null, invoice.Lines.ToList());
+        return ReissueInvoiceInternalAsync(invoice, client, userId, cancellationToken);
+    }
+
+    private async Task ReissueInvoiceInternalAsync(
+        Invoice invoice,
+        Client client,
+        Guid? userId,
+        CancellationToken cancellationToken)
+    {
+        var sellerProfile = await ResolveSellerProfileAsync(userId, cancellationToken);
+        invoice.PdfBlob = GenerateInvoicePdf(invoice, client, null, invoice.Lines.ToList(), sellerProfile);
         invoice.Status = InvoiceStatus.Draft;
         invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow;
         invoice.ReissueCount += 1;
         invoice.LastReissuedUtc = DateTimeOffset.UtcNow;
         invoice.LastReissuedByUserId = userId;
         StampUpdate(invoice, userId);
-
-        return Task.CompletedTask;
     }
 
     public async Task<InvoiceLine> CreateManualAdjustmentAsync(
@@ -295,11 +304,26 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
         return $"{yearPrefix}{nextSequence:000}";
     }
 
+    private Task<SellerProfile?> ResolveSellerProfileAsync(
+        Guid? userId,
+        CancellationToken cancellationToken)
+    {
+        if (!userId.HasValue)
+        {
+            return Task.FromResult<SellerProfile?>(null);
+        }
+
+        return dbContext.SellerProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(profile => profile.UserId == userId.Value, cancellationToken);
+    }
+
     private static byte[] GenerateInvoicePdf(
         Invoice invoice,
         Client client,
         Gig? gig,
-        IReadOnlyCollection<InvoiceLine> lines)
+        IReadOnlyCollection<InvoiceLine> lines,
+        SellerProfile? sellerProfile)
     {
         var rows = new List<string>
         {
@@ -308,9 +332,18 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
             $"Invoice date: {invoice.InvoiceDate:yyyy-MM-dd}",
             $"Due date: {invoice.DueDate:yyyy-MM-dd}",
             string.Empty,
+        };
+
+        if (sellerProfile is not null)
+        {
+            AppendSellerProfileRows(rows, sellerProfile);
+        }
+
+        rows.AddRange(
+        [
             $"Bill to: {client.Name}",
             client.Email,
-        };
+        ]);
 
         if (!string.IsNullOrWhiteSpace(client.BillingAddress?.Line1))
         {
@@ -357,7 +390,101 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
         rows.Add(string.Empty);
         rows.Add($"Total due: {invoice.Total:0.00} GBP");
 
+        if (sellerProfile is not null)
+        {
+            AppendPaymentDetailsRows(rows, sellerProfile);
+        }
+
         return BuildSimplePdf(rows);
+    }
+
+    private static void AppendSellerProfileRows(List<string> rows, SellerProfile sellerProfile)
+    {
+        var sellerRows = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.SellerName))
+        {
+            sellerRows.Add($"From: {sellerProfile.SellerName}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.Address.Line1))
+        {
+            sellerRows.Add(sellerProfile.Address.Line1);
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.Address.Line2))
+        {
+            sellerRows.Add(sellerProfile.Address.Line2);
+        }
+
+        var cityLine = string.Join(", ", new[]
+        {
+            sellerProfile.Address.City,
+            sellerProfile.Address.StateOrCounty,
+        }.Where(value => !string.IsNullOrWhiteSpace(value)));
+
+        if (!string.IsNullOrWhiteSpace(cityLine))
+        {
+            sellerRows.Add(cityLine);
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.Address.PostalCode))
+        {
+            sellerRows.Add(sellerProfile.Address.PostalCode);
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.Address.Country))
+        {
+            sellerRows.Add(sellerProfile.Address.Country);
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.Email))
+        {
+            sellerRows.Add($"Email: {sellerProfile.Email}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.Phone))
+        {
+            sellerRows.Add($"Phone: {sellerProfile.Phone}");
+        }
+
+        if (sellerRows.Count > 0)
+        {
+            rows.AddRange(sellerRows);
+            rows.Add(string.Empty);
+        }
+    }
+
+    private static void AppendPaymentDetailsRows(List<string> rows, SellerProfile sellerProfile)
+    {
+        var paymentRows = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.AccountName))
+        {
+            paymentRows.Add($"Account name: {sellerProfile.AccountName}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.SortCode))
+        {
+            paymentRows.Add($"Sort code: {sellerProfile.SortCode}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.AccountNumber))
+        {
+            paymentRows.Add($"Account number: {sellerProfile.AccountNumber}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(sellerProfile.PaymentReferenceNote))
+        {
+            paymentRows.Add($"Payment note: {sellerProfile.PaymentReferenceNote}");
+        }
+
+        if (paymentRows.Count > 0)
+        {
+            rows.Add(string.Empty);
+            rows.Add("Payment details:");
+            rows.AddRange(paymentRows);
+        }
     }
 
     private static byte[] BuildSimplePdf(IEnumerable<string> lines)

--- a/frontend/glovelly-web/public/sw.js
+++ b/frontend/glovelly-web/public/sw.js
@@ -33,7 +33,8 @@ self.addEventListener('fetch', (event) => {
     requestUrl.pathname.startsWith('/clients') ||
     requestUrl.pathname.startsWith('/gigs') ||
     requestUrl.pathname.startsWith('/invoices') ||
-    requestUrl.pathname.startsWith('/invoice-lines')
+    requestUrl.pathname.startsWith('/invoice-lines') ||
+    requestUrl.pathname.startsWith('/seller-profile')
   ) {
     return
   }

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -330,6 +330,69 @@
   gap: 18px;
 }
 
+.seller-profile-layout {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.9fr);
+}
+
+.seller-profile-sections {
+  display: grid;
+  gap: 18px;
+}
+
+.seller-profile-section {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 22px;
+  background: var(--surface-subtle);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 90%, transparent);
+}
+
+.seller-profile-section h3,
+.seller-profile-preview h3 {
+  margin: 4px 0 0;
+  color: var(--heading);
+}
+
+.seller-profile-preview {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+  padding: 18px;
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-panel) 88%, white 12%), var(--surface-accent));
+  border: 1px solid color-mix(in srgb, var(--surface-border) 90%, transparent);
+}
+
+.seller-profile-preview-note {
+  margin: 0;
+  color: var(--muted);
+}
+
+.seller-preview-card {
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  border-radius: 18px;
+  background: var(--surface-panel);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 88%, transparent);
+}
+
+.seller-preview-card strong {
+  color: var(--heading);
+}
+
+.seller-preview-card span {
+  color: var(--muted-strong);
+}
+
+.seller-profile-empty {
+  margin-bottom: 4px;
+}
+
 .settings-note {
   padding: 14px 16px;
   border-radius: 18px;
@@ -981,6 +1044,7 @@ button:disabled {
   .form-grid,
   .detail-grid,
   .gig-summary-grid,
+  .seller-profile-layout,
   .draft-grid,
   .invoice-adjustment-form,
   .gig-expense-item {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -6,6 +6,7 @@ import {
   ClientsSection,
   GigsSection,
   InvoicesSection,
+  SellerProfileModal,
   SessionCheckingScreen,
   SignInScreen,
   UserSettingsModal,
@@ -20,6 +21,7 @@ import {
   emptyClientSettingsForm,
   emptyForm,
   emptyGigForm,
+  emptySellerProfileForm,
   emptyUserSettingsForm,
   fetchWithSession,
   formatCurrency,
@@ -45,6 +47,8 @@ import type {
   GigForm,
   Invoice,
   InvoiceStatus,
+  SellerProfile,
+  SellerProfileForm,
   ThemePreference,
   UserSettingsForm,
 } from './appShared'
@@ -56,6 +60,46 @@ function getCurrentMonthValue() {
 
 function buildMonthlyInvoiceNumber(month: string, sequence: number) {
   return `GLV-${month.replace('-', '')}-${String(sequence).padStart(3, '0')}`
+}
+
+function toSellerProfileForm(profile: SellerProfile): SellerProfileForm {
+  return {
+    sellerName: profile.sellerName ?? '',
+    addressLine1: profile.addressLine1 ?? '',
+    addressLine2: profile.addressLine2 ?? '',
+    city: profile.city ?? '',
+    region: profile.region ?? '',
+    postcode: profile.postcode ?? '',
+    country: profile.country ?? 'United Kingdom',
+    email: profile.email ?? '',
+    phone: profile.phone ?? '',
+    accountName: profile.accountName ?? '',
+    sortCode: profile.sortCode ?? '',
+    accountNumber: profile.accountNumber ?? '',
+    paymentReferenceNote: profile.paymentReferenceNote ?? '',
+  }
+}
+
+function emptySellerProfile(): SellerProfile {
+  return {
+    id: null,
+    sellerName: null,
+    addressLine1: null,
+    addressLine2: null,
+    city: null,
+    region: null,
+    postcode: null,
+    country: 'United Kingdom',
+    email: null,
+    phone: null,
+    accountName: null,
+    sortCode: null,
+    accountNumber: null,
+    paymentReferenceNote: null,
+    isConfigured: false,
+    isInvoiceReady: false,
+    missingFields: ['sellerName', 'addressLine1', 'city', 'country'],
+  }
 }
 
 type AppProps = {
@@ -93,6 +137,14 @@ function App({ appMetadata }: AppProps) {
   const [userSettingsStatus, setUserSettingsStatus] =
     useState('Set the mileage defaults used when a client has no custom rates.')
   const [isUserSettingsSaving, setIsUserSettingsSaving] = useState(false)
+  const [sellerProfile, setSellerProfile] = useState<SellerProfile>(emptySellerProfile)
+  const [sellerProfileForm, setSellerProfileForm] =
+    useState<SellerProfileForm>(emptySellerProfileForm)
+  const [sellerProfileStatus, setSellerProfileStatus] = useState(
+    'Add the seller details that should appear on your invoices.'
+  )
+  const [isSellerProfileOpen, setIsSellerProfileOpen] = useState(false)
+  const [isSellerProfileSaving, setIsSellerProfileSaving] = useState(false)
 
   const [adminUsers, setAdminUsers] = useState<AdminUser[]>([])
   const [selectedAdminUserId, setSelectedAdminUserId] = useState<string>('')
@@ -245,6 +297,12 @@ function App({ appMetadata }: AppProps) {
       setUserSettingsStatus(
         'Set the mileage defaults used when a client has no custom rates.'
       )
+      setIsSellerProfileOpen(false)
+      setSellerProfile(emptySellerProfile())
+      setSellerProfileForm(emptySellerProfileForm())
+      setSellerProfileStatus(
+        'Add the seller details that should appear on your invoices.'
+      )
       resetAdminWorkspace()
     }
 
@@ -308,16 +366,18 @@ function App({ appMetadata }: AppProps) {
         setAuthUser(user)
         setIsLoading(true)
 
-        const [clientsResponse, gigsResponse, invoicesResponse] = await Promise.all([
+        const [clientsResponse, gigsResponse, invoicesResponse, sellerProfileResponse] = await Promise.all([
           fetchWithSession(buildApiUrl('/clients')),
           fetchWithSession(buildApiUrl('/gigs')),
           fetchWithSession(buildApiUrl('/invoices')),
+          fetchWithSession(buildApiUrl('/seller-profile')),
         ])
 
         if (
           clientsResponse.status === 401 ||
           gigsResponse.status === 401 ||
-          invoicesResponse.status === 401
+          invoicesResponse.status === 401 ||
+          sellerProfileResponse.status === 401
         ) {
           setIsAuthenticated(false)
           setAuthUser(null)
@@ -339,9 +399,14 @@ function App({ appMetadata }: AppProps) {
           throw new Error('Unable to load invoices.')
         }
 
+        if (!sellerProfileResponse.ok) {
+          throw new Error('Unable to load seller profile.')
+        }
+
         const data = (await clientsResponse.json()) as Client[]
         const gigData = (await gigsResponse.json()) as Gig[]
         const invoiceData = (await invoicesResponse.json()) as Invoice[]
+        const sellerProfileData = (await sellerProfileResponse.json()) as SellerProfile
         if (ignore) {
           return
         }
@@ -352,6 +417,8 @@ function App({ appMetadata }: AppProps) {
         setSelectedGigId(gigData[0]?.id ?? '')
         setInvoices(invoiceData)
         setSelectedInvoiceId(invoiceData[0]?.id ?? '')
+        setSellerProfile(sellerProfileData)
+        setSellerProfileForm(toSellerProfileForm(sellerProfileData))
         setIsApiConnected(true)
         setShouldCloseBrowserNotice(false)
         setStatus(
@@ -630,6 +697,24 @@ function App({ appMetadata }: AppProps) {
   const issuedInvoiceCount = invoices.filter((invoice) => invoice.status === 'Issued').length
   const overdueInvoiceCount = invoices.filter((invoice) => invoice.status === 'Overdue').length
   const outstandingInvoiceCount = issuedInvoiceCount + overdueInvoiceCount
+  const sellerProfileMissingLabels = useMemo(() => {
+    const labels: Record<string, string> = {
+      sellerName: 'seller name',
+      addressLine1: 'address line 1',
+      city: 'city',
+      country: 'country',
+      accountName: 'account name',
+      sortCode: 'sort code',
+      accountNumber: 'account number',
+    }
+
+    return sellerProfile.missingFields.map((field) => labels[field] ?? field)
+  }, [sellerProfile.missingFields])
+  const sellerProfileNotice = sellerProfile.isInvoiceReady
+    ? ' Seller profile is invoice-ready, so PDFs will include your sender and payment details.'
+    : sellerProfile.isConfigured
+      ? ` Seller profile is incomplete. Missing: ${sellerProfileMissingLabels.join(', ')}. You can still generate invoices, but some sender details may be omitted.`
+      : ' Seller profile is not set up yet. You can still generate invoices, but sender and payment details will be missing until you configure them.'
 
   const navigationItems: Array<{
     id: AppSection
@@ -957,6 +1042,11 @@ function App({ appMetadata }: AppProps) {
       setIsInvoiceEditorOpen(false)
       setInvoiceSearchQuery('')
       setInvoiceStatus(defaultInvoiceStatus)
+      setSellerProfile(emptySellerProfile())
+      setSellerProfileForm(emptySellerProfileForm())
+      setSellerProfileStatus(
+        'Add the seller details that should appear on your invoices.'
+      )
       resetAdminWorkspace()
       setShouldCloseBrowserNotice(true)
       setStatus('Signed out successfully.')
@@ -1115,6 +1205,31 @@ function App({ appMetadata }: AppProps) {
     setIsUserSettingsOpen(true)
   }
 
+  const openSellerProfile = () => {
+    setSellerProfileForm(toSellerProfileForm(sellerProfile))
+    setSellerProfileStatus(
+      sellerProfile.isConfigured
+        ? sellerProfileNotice
+        : 'Add the seller details that should appear on your invoices.'
+    )
+    setIsProfileMenuOpen(false)
+    setIsSellerProfileOpen(true)
+  }
+
+  const closeSellerProfile = () => {
+    setIsSellerProfileOpen(false)
+  }
+
+  const updateSellerProfileField = (
+    field: keyof SellerProfileForm,
+    value: string
+  ) => {
+    setSellerProfileForm((current) => ({
+      ...current,
+      [field]: value,
+    }))
+  }
+
   const closeUserSettings = () => {
     setIsUserSettingsOpen(false)
   }
@@ -1215,6 +1330,70 @@ function App({ appMetadata }: AppProps) {
       )
     } finally {
       setIsUserSettingsSaving(false)
+    }
+  }
+
+  const handleSellerProfileSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsSellerProfileSaving(true)
+
+    try {
+      const response = await fetchWithSession(buildApiUrl('/seller-profile'), {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          sellerName: sellerProfileForm.sellerName.trim() || null,
+          addressLine1: sellerProfileForm.addressLine1.trim() || null,
+          addressLine2: sellerProfileForm.addressLine2.trim() || null,
+          city: sellerProfileForm.city.trim() || null,
+          region: sellerProfileForm.region.trim() || null,
+          postcode: sellerProfileForm.postcode.trim() || null,
+          country: sellerProfileForm.country.trim() || null,
+          email: sellerProfileForm.email.trim() || null,
+          phone: sellerProfileForm.phone.trim() || null,
+          accountName: sellerProfileForm.accountName.trim() || null,
+          sortCode: sellerProfileForm.sortCode.trim() || null,
+          accountNumber: sellerProfileForm.accountNumber.trim() || null,
+          paymentReferenceNote: sellerProfileForm.paymentReferenceNote.trim() || null,
+        }),
+      })
+
+      if (response.status === 401) {
+        setIsAuthenticated(false)
+        setAuthUser(null)
+        setIsApiConnected(false)
+        setIsSellerProfileOpen(false)
+        setStatus('Your session expired. Sign in again to update your seller profile.')
+        return
+      }
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const validationMessages = problem?.errors
+          ? Object.values(problem.errors).flat().join(' ')
+          : problem?.detail ?? problem?.title
+
+        throw new Error(validationMessages || 'Unable to save seller profile.')
+      }
+
+      const savedProfile = (await response.json()) as SellerProfile
+      setSellerProfile(savedProfile)
+      setSellerProfileForm(toSellerProfileForm(savedProfile))
+      setSellerProfileStatus(
+        savedProfile.isInvoiceReady
+          ? 'Seller profile updated and ready for invoice generation.'
+          : `Seller profile saved. Missing: ${savedProfile.missingFields.join(', ')}.`
+      )
+    } catch (error) {
+      setSellerProfileStatus(
+        error instanceof Error
+          ? error.message
+          : 'Unable to save your seller profile right now.'
+      )
+    } finally {
+      setIsSellerProfileSaving(false)
     }
   }
 
@@ -1641,7 +1820,11 @@ function App({ appMetadata }: AppProps) {
         setGigStatus(
           `Invoice ${generatedInvoice.invoiceNumber} generated from ${selectedGigs.length} selected gig(s).`
         )
-        setInvoiceStatus(`Invoice ${generatedInvoice.invoiceNumber} is ready for review.`)
+        setInvoiceStatus(
+          sellerProfile.isInvoiceReady
+            ? `Invoice ${generatedInvoice.invoiceNumber} is ready for review.`
+            : `Invoice ${generatedInvoice.invoiceNumber} is ready for review. ${sellerProfileNotice}`
+        )
         setActiveSection('invoices')
       } catch (error) {
         setGigStatus(error instanceof Error ? error.message : 'Unable to generate invoice.')
@@ -1707,7 +1890,11 @@ function App({ appMetadata }: AppProps) {
         )
       )
       setGigStatus('Invoice generated and linked to this gig.')
-      setInvoiceStatus('New invoice generated from the selected gig.')
+      setInvoiceStatus(
+        sellerProfile.isInvoiceReady
+          ? 'New invoice generated from the selected gig.'
+          : `New invoice generated from the selected gig. ${sellerProfileNotice}`
+      )
       setActiveSection('invoices')
     } catch (error) {
       setGigStatus(error instanceof Error ? error.message : 'Unable to generate invoice.')
@@ -2160,6 +2347,7 @@ function App({ appMetadata }: AppProps) {
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateInvoice={handleGenerateInvoice}
         onOpenLinkedInvoice={openSelectedGigInvoice}
+        onOpenSellerProfile={openSellerProfile}
         onRemoveGigExpense={removeGigExpense}
         onResetForm={startGigCreate}
         onSearchQueryChange={setGigSearchQuery}
@@ -2170,6 +2358,8 @@ function App({ appMetadata }: AppProps) {
         onUpdateGigExpenseField={updateGigExpenseField}
         onUpdateGigField={updateGigField}
         plannedGigCount={plannedGigCount}
+        sellerProfile={sellerProfile}
+        sellerProfileNotice={sellerProfileNotice}
         selectedGig={selectedGig}
         selectedGigIds={selectedGigIds}
         selectedGigs={selectedGigs}
@@ -2187,6 +2377,7 @@ function App({ appMetadata }: AppProps) {
         invoices={invoices}
         issuedInvoiceCount={issuedInvoiceCount}
         isInvoiceLoading={isInvoiceLoading}
+        isSellerProfileConfigured={sellerProfile.isConfigured}
         onAdjustmentAmountChange={setAdjustmentAmount}
         onAdjustmentReasonChange={setAdjustmentReason}
         onAddAdjustment={handleAddInvoiceAdjustment}
@@ -2194,10 +2385,12 @@ function App({ appMetadata }: AppProps) {
         onDeleteInvoice={handleDeleteInvoice}
         onDownloadPdf={handleDownloadInvoicePdf}
         onInvoiceStatusChange={handleInvoiceStatusChange}
+        onOpenSellerProfile={openSellerProfile}
         onReissue={handleInvoiceReissue}
         onSearchQueryChange={setInvoiceSearchQuery}
         onSelectInvoice={setSelectedInvoiceId}
         onStartEditing={startInvoiceEdit}
+        sellerProfileNotice={sellerProfileNotice}
         selectedInvoice={selectedInvoice}
       />
     )
@@ -2250,6 +2443,15 @@ function App({ appMetadata }: AppProps) {
                     <div className="profile-meta">
                       <span>{isAdmin ? 'Administrator' : 'Standard access'}</span>
                     </div>
+                    <div className="profile-meta">
+                      <span>
+                        {sellerProfile.isInvoiceReady
+                          ? 'Seller profile ready'
+                          : sellerProfile.isConfigured
+                            ? 'Seller profile needs attention'
+                            : 'Seller profile not set up'}
+                      </span>
+                    </div>
                     <label className="theme-field" htmlFor="theme-preference-select">
                       <span>Theme</span>
                       <select
@@ -2264,6 +2466,15 @@ function App({ appMetadata }: AppProps) {
                         <option value="dark">Dark</option>
                       </select>
                     </label>
+                    <button
+                      className="ghost-button profile-settings"
+                      onClick={openSellerProfile}
+                      role="menuitem"
+                      type="button"
+                      disabled={isLoading || isAdminLoading || isSellerProfileSaving}
+                    >
+                      Seller profile
+                    </button>
                     <button
                       className="ghost-button profile-settings"
                       onClick={openUserSettings}
@@ -2353,6 +2564,17 @@ function App({ appMetadata }: AppProps) {
         onSubmit={handleUserSettingsSubmit}
         onUpdateField={updateUserSettingsField}
         status={userSettingsStatus}
+      />
+
+      <SellerProfileModal
+        form={sellerProfileForm}
+        isOpen={isSellerProfileOpen}
+        isSaving={isSellerProfileSaving}
+        onClose={closeSellerProfile}
+        onSubmit={handleSellerProfileSubmit}
+        onUpdateField={updateSellerProfileField}
+        profile={sellerProfile}
+        status={sellerProfileStatus}
       />
 
       <ClientSettingsModal

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -12,6 +12,8 @@ import type {
   GigStatus,
   Invoice,
   InvoiceStatus,
+  SellerProfile,
+  SellerProfileForm,
   UserSettingsForm,
 } from './appShared'
 import {
@@ -699,6 +701,7 @@ type GigsSectionProps = {
   onExpenseDescriptionChange: (value: string) => void
   onGenerateInvoice: () => void
   onOpenLinkedInvoice: () => void
+  onOpenSellerProfile: () => void
   onRemoveGigExpense: (index: number) => void
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
@@ -716,6 +719,8 @@ type GigsSectionProps = {
     value: string | boolean | GigExpenseForm[]
   ) => void
   plannedGigCount: number
+  sellerProfile: SellerProfile
+  sellerProfileNotice: string
   selectedGig: Gig | null
   selectedGigIds: string[]
   selectedGigs: Gig[]
@@ -742,6 +747,7 @@ export function GigsSection({
   onExpenseDescriptionChange,
   onGenerateInvoice,
   onOpenLinkedInvoice,
+  onOpenSellerProfile,
   onRemoveGigExpense,
   onResetForm,
   onSearchQueryChange,
@@ -752,6 +758,8 @@ export function GigsSection({
   onUpdateGigExpenseField,
   onUpdateGigField,
   plannedGigCount,
+  sellerProfile,
+  sellerProfileNotice,
   selectedGig,
   selectedGigIds,
   selectedGigs,
@@ -930,6 +938,7 @@ export function GigsSection({
                     ? 'This gig is already linked to an invoice. Open Invoices to review or download it.'
                     : 'This gig has everything needed to create an invoice when you are ready.'}
                 </span>
+                <span>{sellerProfileNotice}</span>
                 {selectedGigIds.length > 0 && (
                   <span>
                     {hasCrossClientSelection
@@ -937,6 +946,13 @@ export function GigsSection({
                       : ` ${selectedGigIds.length} gig(s) selected for a combined invoice.`}
                   </span>
                 )}
+                <button
+                  className="ghost-button"
+                  onClick={onOpenSellerProfile}
+                  type="button"
+                >
+                  {sellerProfile.isConfigured ? 'Review seller profile' : 'Set up seller profile'}
+                </button>
               </div>
             </>
           ) : (
@@ -1159,6 +1175,321 @@ export function GigsSection({
   )
 }
 
+type SellerProfileModalProps = {
+  form: SellerProfileForm
+  isOpen: boolean
+  isSaving: boolean
+  onClose: () => void
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
+  onUpdateField: (field: keyof SellerProfileForm, value: string) => void
+  profile: SellerProfile
+  status: string
+}
+
+export function SellerProfileModal({
+  form,
+  isOpen,
+  isSaving,
+  onClose,
+  onSubmit,
+  onUpdateField,
+  profile,
+  status,
+}: SellerProfileModalProps) {
+  if (!isOpen) {
+    return null
+  }
+
+  const liveMissingFields: string[] = []
+  const normalizedRequiredFields = {
+    sellerName: form.sellerName.trim(),
+    addressLine1: form.addressLine1.trim(),
+    city: form.city.trim(),
+    country: form.country.trim(),
+    accountName: form.accountName.trim(),
+    sortCode: form.sortCode.trim(),
+    accountNumber: form.accountNumber.trim(),
+  }
+
+  if (!normalizedRequiredFields.sellerName) {
+    liveMissingFields.push('seller name')
+  }
+
+  if (!normalizedRequiredFields.addressLine1) {
+    liveMissingFields.push('address line 1')
+  }
+
+  if (!normalizedRequiredFields.city) {
+    liveMissingFields.push('city')
+  }
+
+  if (!normalizedRequiredFields.country) {
+    liveMissingFields.push('country')
+  }
+
+  const hasAnyPaymentValue =
+    Boolean(normalizedRequiredFields.accountName) ||
+    Boolean(normalizedRequiredFields.sortCode) ||
+    Boolean(normalizedRequiredFields.accountNumber)
+
+  if (hasAnyPaymentValue) {
+    if (!normalizedRequiredFields.accountName) {
+      liveMissingFields.push('account name')
+    }
+
+    if (!normalizedRequiredFields.sortCode) {
+      liveMissingFields.push('sort code')
+    }
+
+    if (!normalizedRequiredFields.accountNumber) {
+      liveMissingFields.push('account number')
+    }
+  }
+
+  const hasAnyLiveValue = Object.values(form).some((value) => value.trim().length > 0)
+
+  const previewSellerRows = [
+    form.sellerName,
+    form.addressLine1,
+    form.addressLine2,
+    [form.city, form.region].filter(Boolean).join(', '),
+    [form.postcode, form.country].filter(Boolean).join(', '),
+    form.email ? `Email: ${form.email}` : '',
+    form.phone ? `Phone: ${form.phone}` : '',
+  ].filter(Boolean)
+
+  const previewPaymentRows = [
+    form.accountName ? `Account name: ${form.accountName}` : '',
+    form.sortCode ? `Sort code: ${form.sortCode}` : '',
+    form.accountNumber ? `Account number: ${form.accountNumber}` : '',
+    form.paymentReferenceNote ? `Payment note: ${form.paymentReferenceNote}` : '',
+  ].filter(Boolean)
+
+  return (
+    <div className="settings-overlay" onClick={onClose} role="presentation">
+      <section
+        aria-labelledby="seller-profile-title"
+        aria-modal="true"
+        className="settings-modal panel"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <div className="panel-heading">
+          <div>
+            <p className="section-label">Settings</p>
+            <h2 id="seller-profile-title">Seller profile</h2>
+          </div>
+          <button className="ghost-button" onClick={onClose} type="button">
+            Close
+          </button>
+        </div>
+
+        <p className="hero-text settings-intro">
+          These are the sender and payment details Glovelly uses on generated invoices.
+          They are customer-visible, so optimise for accuracy and clarity.
+        </p>
+
+        {!hasAnyLiveValue && !profile.isConfigured && (
+          <div className="settings-note seller-profile-empty">
+            Add your sender identity and remittance details here so invoice PDFs have a
+            reliable source of truth.
+          </div>
+        )}
+
+        <form className="settings-form" onSubmit={onSubmit}>
+          <div className="seller-profile-layout">
+            <div className="seller-profile-sections">
+              <section className="seller-profile-section">
+                <div>
+                  <p className="section-label">Seller identity</p>
+                  <h3>Shown in the invoice header</h3>
+                </div>
+
+                <div className="form-grid">
+                  <label className="full-width">
+                    <span>Seller / trading name</span>
+                    <input
+                      value={form.sellerName}
+                      onChange={(event) => onUpdateField('sellerName', event.target.value)}
+                      placeholder="Glovelly Music Ltd"
+                    />
+                  </label>
+
+                  <label className="full-width">
+                    <span>Address line 1</span>
+                    <input
+                      value={form.addressLine1}
+                      onChange={(event) => onUpdateField('addressLine1', event.target.value)}
+                      placeholder="1 Chapel Street"
+                    />
+                  </label>
+
+                  <label className="full-width">
+                    <span>Address line 2</span>
+                    <input
+                      value={form.addressLine2}
+                      onChange={(event) => onUpdateField('addressLine2', event.target.value)}
+                      placeholder="Optional"
+                    />
+                  </label>
+
+                  <label>
+                    <span>Town / city</span>
+                    <input
+                      value={form.city}
+                      onChange={(event) => onUpdateField('city', event.target.value)}
+                      placeholder="Manchester"
+                    />
+                  </label>
+
+                  <label>
+                    <span>County / region</span>
+                    <input
+                      value={form.region}
+                      onChange={(event) => onUpdateField('region', event.target.value)}
+                      placeholder="Greater Manchester"
+                    />
+                  </label>
+
+                  <label>
+                    <span>Postcode</span>
+                    <input
+                      value={form.postcode}
+                      onChange={(event) => onUpdateField('postcode', event.target.value)}
+                      placeholder="M1 1AA"
+                    />
+                  </label>
+
+                  <label>
+                    <span>Country</span>
+                    <input
+                      value={form.country}
+                      onChange={(event) => onUpdateField('country', event.target.value)}
+                      placeholder="United Kingdom"
+                    />
+                  </label>
+
+                  <label>
+                    <span>Contact email</span>
+                    <input
+                      type="email"
+                      value={form.email}
+                      onChange={(event) => onUpdateField('email', event.target.value)}
+                      placeholder="accounts@example.com"
+                    />
+                  </label>
+
+                  <label>
+                    <span>Contact phone</span>
+                    <input
+                      value={form.phone}
+                      onChange={(event) => onUpdateField('phone', event.target.value)}
+                      placeholder="+44 7700 900123"
+                    />
+                  </label>
+                </div>
+              </section>
+
+              <section className="seller-profile-section">
+                <div>
+                  <p className="section-label">Payment details</p>
+                  <h3>Shown in the remittance section</h3>
+                </div>
+
+                <div className="form-grid">
+                  <label>
+                    <span>Account name</span>
+                    <input
+                      value={form.accountName}
+                      onChange={(event) => onUpdateField('accountName', event.target.value)}
+                      placeholder="Glovelly Music Ltd"
+                    />
+                  </label>
+
+                  <label>
+                    <span>Sort code</span>
+                    <input
+                      value={form.sortCode}
+                      onChange={(event) => onUpdateField('sortCode', event.target.value)}
+                      placeholder="12-34-56"
+                    />
+                  </label>
+
+                  <label>
+                    <span>Account number</span>
+                    <input
+                      value={form.accountNumber}
+                      onChange={(event) => onUpdateField('accountNumber', event.target.value)}
+                      placeholder="12345678"
+                    />
+                  </label>
+
+                  <label className="full-width">
+                    <span>Payment reference note</span>
+                    <textarea
+                      rows={3}
+                      value={form.paymentReferenceNote}
+                      onChange={(event) =>
+                        onUpdateField('paymentReferenceNote', event.target.value)
+                      }
+                      placeholder="Use the invoice number as the payment reference."
+                    />
+                  </label>
+                </div>
+
+                <div className="settings-note">
+                  Payment details are visible to your customer on generated invoices.
+                </div>
+              </section>
+            </div>
+
+            <aside className="seller-profile-preview">
+              <div>
+                <p className="section-label">Preview</p>
+                <h3>Invoice identity</h3>
+              </div>
+              <p className="seller-profile-preview-note">
+                This is how your details will appear on generated invoices.
+              </p>
+
+              <div className="seller-preview-card">
+                <strong>Seller block</strong>
+                {previewSellerRows.length > 0 ? (
+                  previewSellerRows.map((row) => <span key={row}>{row}</span>)
+                ) : (
+                  <span>Add seller details to see the preview take shape.</span>
+                )}
+              </div>
+
+              <div className="seller-preview-card">
+                <strong>Payment details</strong>
+                {previewPaymentRows.length > 0 ? (
+                  previewPaymentRows.map((row) => <span key={row}>{row}</span>)
+                ) : (
+                  <span>Add bank and remittance details to preview the payment section.</span>
+                )}
+              </div>
+
+              {liveMissingFields.length > 0 && (
+                <div className="settings-note">
+                  Invoice-ready fields still missing: {liveMissingFields.join(', ')}.
+                </div>
+              )}
+            </aside>
+          </div>
+
+          <div className="form-actions">
+            <button className="primary-button" type="submit" disabled={isSaving}>
+              {isSaving ? 'Saving…' : 'Save seller profile'}
+            </button>
+            <span className="status-pill">{status}</span>
+          </div>
+        </form>
+      </section>
+    </div>
+  )
+}
+
 type InvoicesSectionProps = {
   adjustmentAmount: string
   adjustmentReason: string
@@ -1171,6 +1502,7 @@ type InvoicesSectionProps = {
   invoices: Invoice[]
   issuedInvoiceCount: number
   isInvoiceLoading: boolean
+  isSellerProfileConfigured: boolean
   onAdjustmentAmountChange: (value: string) => void
   onAdjustmentReasonChange: (value: string) => void
   onAddAdjustment: (invoice: Invoice) => Promise<void>
@@ -1178,10 +1510,12 @@ type InvoicesSectionProps = {
   onDeleteInvoice: (invoice: Invoice) => Promise<void>
   onDownloadPdf: (invoice: Invoice) => Promise<void>
   onInvoiceStatusChange: (invoice: Invoice, status: InvoiceStatus) => Promise<void>
+  onOpenSellerProfile: () => void
   onReissue: (invoice: Invoice) => Promise<void>
   onSearchQueryChange: (value: string) => void
   onSelectInvoice: (invoiceId: string) => void
   onStartEditing: () => void
+  sellerProfileNotice: string
   selectedInvoice: Invoice | null
 }
 
@@ -1197,6 +1531,7 @@ export function InvoicesSection({
   invoices,
   issuedInvoiceCount,
   isInvoiceLoading,
+  isSellerProfileConfigured,
   onAdjustmentAmountChange,
   onAdjustmentReasonChange,
   onAddAdjustment,
@@ -1204,10 +1539,12 @@ export function InvoicesSection({
   onDeleteInvoice,
   onDownloadPdf,
   onInvoiceStatusChange,
+  onOpenSellerProfile,
   onReissue,
   onSearchQueryChange,
   onSelectInvoice,
   onStartEditing,
+  sellerProfileNotice,
   selectedInvoice,
 }: InvoicesSectionProps) {
   const selectedInvoiceClientName =
@@ -1332,6 +1669,20 @@ export function InvoicesSection({
 
           {selectedInvoice ? (
             <>
+              {!isSellerProfileConfigured && (
+                <div className="settings-note">
+                  {sellerProfileNotice}
+                  {' '}
+                  <button
+                    className="ghost-button"
+                    onClick={onOpenSellerProfile}
+                    type="button"
+                  >
+                    Set up seller profile
+                  </button>
+                </div>
+              )}
+
               <div className="detail-grid">
                 <article>
                   <p className="detail-label">Client</p>

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -62,6 +62,42 @@ export type ClientSettingsForm = {
   passengerMileageRate: string
 }
 
+export type SellerProfile = {
+  id: string | null
+  sellerName: string | null
+  addressLine1: string | null
+  addressLine2: string | null
+  city: string | null
+  region: string | null
+  postcode: string | null
+  country: string | null
+  email: string | null
+  phone: string | null
+  accountName: string | null
+  sortCode: string | null
+  accountNumber: string | null
+  paymentReferenceNote: string | null
+  isConfigured: boolean
+  isInvoiceReady: boolean
+  missingFields: string[]
+}
+
+export type SellerProfileForm = {
+  sellerName: string
+  addressLine1: string
+  addressLine2: string
+  city: string
+  region: string
+  postcode: string
+  country: string
+  email: string
+  phone: string
+  accountName: string
+  sortCode: string
+  accountNumber: string
+  paymentReferenceNote: string
+}
+
 export type GigStatus = 'Draft' | 'Confirmed' | 'Completed' | 'Cancelled'
 
 export type GigExpense = {
@@ -180,6 +216,22 @@ export const emptyUserSettingsForm = (): UserSettingsForm => ({
 export const emptyClientSettingsForm = (): ClientSettingsForm => ({
   mileageRate: '',
   passengerMileageRate: '',
+})
+
+export const emptySellerProfileForm = (): SellerProfileForm => ({
+  sellerName: '',
+  addressLine1: '',
+  addressLine2: '',
+  city: '',
+  region: '',
+  postcode: '',
+  country: 'United Kingdom',
+  email: '',
+  phone: '',
+  accountName: '',
+  sortCode: '',
+  accountNumber: '',
+  paymentReferenceNote: '',
 })
 
 export const emptyGigForm = (): GigForm => ({

--- a/frontend/glovelly-web/vite.config.ts
+++ b/frontend/glovelly-web/vite.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
         target: 'http://localhost:5153',
         changeOrigin: true,
       },
+      '/seller-profile': {
+        target: 'http://localhost:5153',
+        changeOrigin: true,
+      },
       '/admin': {
         target: 'http://localhost:5153',
         changeOrigin: true,


### PR DESCRIPTION
## Summary
Adds a first-class seller profile flow so invoice generation can use editable seller identity and payment details instead of hardcoded sender information.

## What changed
- added a persisted user-scoped `SellerProfile` model and minimal API endpoints at `GET /seller-profile` and `PUT /seller-profile`
- integrated seller profile data into invoice PDF generation and reissue flows
- added backend coverage for seller profile API behavior and invoice PDF content
- added a frontend seller profile modal with live preview, completeness guidance, and invoice workflow warnings
- added invoice-section guidance when the seller profile has not yet been configured
- updated the Vite dev proxy and service worker routing for the new endpoint

## Why
Invoice PDFs needed a reliable source of truth for who invoices are from and which remittance details should be shown. This change makes that data editable in the app and flows it through to generated invoices.

## Validation
- `dotnet test glovelly.sln`
- `npm run build`

## Notes
- invoice generation is still allowed when the seller profile is incomplete, but the UI now warns clearly and links users to finish setup
- PR is opened as draft for review