### PR TITLE
Harden auth session identity resolution and treat /seller-profile as API

### DIFF
--- a/backend/Glovelly.Api.Tests/ApiCacheHeadersTests.cs
+++ b/backend/Glovelly.Api.Tests/ApiCacheHeadersTests.cs
@@ -15,6 +15,7 @@ public sealed class ApiCacheHeadersTests : IClassFixture<GlovellyApiFactory>
     [Theory]
     [InlineData("/auth/me")]
     [InlineData("/clients")]
+    [InlineData("/seller-profile")]
     [InlineData("/admin/users")]
     public async Task ApiEndpoints_ReturnNoStoreCacheHeaders(string path)
     {

--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using Glovelly.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public AuthEndpointsTests(GlovellyApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Me_ReturnsUnauthorized_WhenAuthenticatedClaimUserIsUnknown()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/auth/me");
+        request.Headers.Add("X-Test-UserId", TestAuthContext.AlternateUserId.ToString());
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -45,27 +45,29 @@ internal static class AuthEndpoints
             AppDbContext dbContext) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
-            var settingsResponse = userId.HasValue
-                ? await dbContext.Users
-                    .AsNoTracking()
-                    .Where(value => value.Id == userId.Value)
-                    .Select(value => new
-                    {
-                        value.MileageRate,
-                        value.PassengerMileageRate,
-                    })
-                    .FirstOrDefaultAsync()
-                : null;
+            if (!userId.HasValue)
+            {
+                return Results.Unauthorized();
+            }
+
+            var localUser = await dbContext.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(value => value.Id == userId.Value && value.IsActive);
+
+            if (localUser is null)
+            {
+                return Results.Unauthorized();
+            }
 
             return Results.Ok(new
             {
                 userId,
-                role = currentUserAccessor.TryGetRole(user)?.ToString(),
-                name = user.FindFirstValue(ClaimTypes.Name) ?? user.FindFirstValue("name") ?? "Signed in user",
-                email = user.FindFirstValue(ClaimTypes.Email) ?? user.FindFirstValue("email") ?? string.Empty,
+                role = localUser.Role.ToString(),
+                name = localUser.DisplayName ?? localUser.Email,
+                email = localUser.Email,
                 profileImageUrl = user.FindFirstValue("picture") ?? user.FindFirstValue("profile") ?? string.Empty,
-                mileageRate = settingsResponse?.MileageRate,
-                passengerMileageRate = settingsResponse?.PassengerMileageRate,
+                mileageRate = localUser.MileageRate,
+                passengerMileageRate = localUser.PassengerMileageRate,
             });
         });
 

--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -38,7 +38,8 @@ internal static class AuthFlowSupport
                path.StartsWithSegments("/clients") ||
                path.StartsWithSegments("/gigs") ||
                path.StartsWithSegments("/invoices") ||
-               path.StartsWithSegments("/invoice-lines");
+               path.StartsWithSegments("/invoice-lines") ||
+               path.StartsWithSegments("/seller-profile");
     }
 
     public static string GetAuthenticationFailureCode(Exception? exception)


### PR DESCRIPTION
### Motivation
- Users were sometimes returned as the fallback "Signed in user" with no app data after long sessions, indicating claim-based identities could not be resolved to a valid local user record.  
- API endpoints like `/seller-profile` were not included in API-detection logic, causing auth redirects to behave incorrectly for SPA fetches.

### Description
- Make `/auth/me` require a resolvable, active local user by checking `ICurrentUserAccessor.TryGetUserId(user)` and loading the local user from the DB, returning `401 Unauthorized` when the local user cannot be found or is inactive, instead of returning a partial/fallback identity (`backend/Glovelly.Api/Endpoints/AuthEndpoints.cs`).  
- Source `role`, `name`, `email`, `mileageRate`, and `passengerMileageRate` for `/auth/me` responses from the local DB user record to avoid stale/empty claim fallbacks (`backend/Glovelly.Api/Endpoints/AuthEndpoints.cs`).  
- Add `/seller-profile` to `AuthFlowSupport.IsApiRequest` so the middleware treats seller-profile requests as API calls and responds with status codes rather than redirects (`backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs`).  
- Add a regression test `Me_ReturnsUnauthorized_WhenAuthenticatedClaimUserIsUnknown` to validate that `/auth/me` returns `401` when the claim user does not map to a local user (`backend/Glovelly.Api.Tests/AuthEndpointsTests.cs`).  
- Extend the cache-header test matrix to include `"/seller-profile"` in `ApiCacheHeadersTests` so API no-store headers are asserted for that endpoint (`backend/Glovelly.Api.Tests/ApiCacheHeadersTests.cs`).

### Testing
- Added unit test `AuthEndpointsTests.Me_ReturnsUnauthorized_WhenAuthenticatedClaimUserIsUnknown` (new) and updated `ApiCacheHeadersTests` to include `"/seller-profile"` (modified).  
- Attempted to run `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj`, but the execution environment does not have the `dotnet` CLI installed so tests could not be executed here (failure: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8625cb1608328b2928124de8486e5)