### PR TITLE
Fix stale build metadata caching in service worker

### DIFF
--- a/frontend/glovelly-web/public/sw.js
+++ b/frontend/glovelly-web/public/sw.js
@@ -34,7 +34,8 @@ self.addEventListener('fetch', (event) => {
     requestUrl.pathname.startsWith('/gigs') ||
     requestUrl.pathname.startsWith('/invoices') ||
     requestUrl.pathname.startsWith('/invoice-lines') ||
-    requestUrl.pathname.startsWith('/seller-profile')
+    requestUrl.pathname.startsWith('/seller-profile') ||
+    requestUrl.pathname === '/app/metadata'
   ) {
     return
   }


### PR DESCRIPTION
### Motivation
- The app's build metadata displayed in the UI could become stale because the service worker served cached responses for app routes, requiring a hard refresh to see updated `build-meta` information.

### Description
- Update `frontend/glovelly-web/public/sw.js` to skip handling requests to `/app/metadata` by adding `requestUrl.pathname === '/app/metadata'` to the fetch-bypass list so metadata requests always go to the network.

### Testing
- Ran `npm run build` in `frontend/glovelly-web` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87a3b47ac83288d2d002f0562b6a9)