### PR TITLE
[codex] Add default and previewable invoice filename patterns

### DIFF
--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
 using Glovelly.Api.Tests.Infrastructure;
 using Xunit;
 
@@ -6,6 +8,7 @@ namespace Glovelly.Api.Tests;
 
 public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _client;
 
     public AuthEndpointsTests(GlovellyApiFactory factory)
@@ -22,5 +25,62 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         var response = await _client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Me_ReturnsUserInvoiceFilenamePattern()
+    {
+        var updateResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            invoiceFilenamePattern = "{MonthName} {Year} {InvoiceNumber}",
+        });
+        updateResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.GetAsync("/auth/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "{MonthName} {Year} {InvoiceNumber}",
+            payload.GetProperty("invoiceFilenamePattern").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateSettings_PersistsInvoiceFilenamePattern()
+    {
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            invoiceFilenamePattern = "  {ClientName} {InvoiceNumber}  ",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "{ClientName} {InvoiceNumber}",
+            payload.GetProperty("invoiceFilenamePattern").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateSettings_WithWhitespaceOnlyInvoiceFilenamePattern_ReturnsValidationProblem()
+    {
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            invoiceFilenamePattern = "   ",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Invoice filename pattern cannot be empty or whitespace.",
+            problem.GetProperty("errors").GetProperty("invoiceFilenamePattern")[0].GetString());
     }
 }

--- a/backend/Glovelly.Api.Tests/ClientEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/ClientEndpointsTests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class ClientEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _client;
+
+    public ClientEndpointsTests(GlovellyApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task UpdateClientSettings_WithInvoiceFilenamePattern_PersistsTrimmedPattern()
+    {
+        var response = await _client.PutAsJsonAsync($"/clients/{TestData.FoxAndFinchId}", new
+        {
+            id = TestData.FoxAndFinchId,
+            name = "Fox & Finch Events",
+            email = "bookings@foxandfinch.co.uk",
+            billingAddress = new
+            {
+                line1 = "12 Chapel Street",
+                city = "Manchester",
+                stateOrCounty = "Greater Manchester",
+                postalCode = "M3 5JZ",
+                country = "United Kingdom",
+            },
+            mileageRate = 0.52m,
+            passengerMileageRate = 0.15m,
+            invoiceFilenamePattern = "  {ClientName} Invoice {InvoiceNumber}  ",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var client = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "{ClientName} Invoice {InvoiceNumber}",
+            client.GetProperty("invoiceFilenamePattern").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateClientSettings_WithWhitespaceOnlyInvoiceFilenamePattern_ReturnsValidationProblem()
+    {
+        var response = await _client.PutAsJsonAsync($"/clients/{TestData.FoxAndFinchId}", new
+        {
+            id = TestData.FoxAndFinchId,
+            name = "Fox & Finch Events",
+            email = "bookings@foxandfinch.co.uk",
+            billingAddress = new
+            {
+                line1 = "12 Chapel Street",
+                city = "Manchester",
+                stateOrCounty = "Greater Manchester",
+                postalCode = "M3 5JZ",
+                country = "United Kingdom",
+            },
+            mileageRate = 0.52m,
+            passengerMileageRate = 0.15m,
+            invoiceFilenamePattern = "   ",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Invoice filename pattern cannot be empty or whitespace.",
+            problem.GetProperty("errors").GetProperty("invoiceFilenamePattern")[0].GetString());
+    }
+}

--- a/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
+++ b/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
@@ -94,6 +94,9 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
         var pdfResponse = await _client.GetAsync($"/invoices/{invoice.GetProperty("id").GetGuid()}/pdf");
         Assert.Equal(HttpStatusCode.OK, pdfResponse.StatusCode);
         Assert.Equal("application/pdf", pdfResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(
+            $"{invoice.GetProperty("invoiceNumber").GetString()}.pdf",
+            pdfResponse.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
         var pdfBytes = await pdfResponse.Content.ReadAsByteArrayAsync();
         Assert.True(pdfBytes.Length > 0);
 
@@ -267,5 +270,123 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
         Assert.Equal("Selected gigs must all belong to the same client.", problem.GetProperty("errors").GetProperty("gigIds")[0].GetString());
+    }
+
+    [Fact]
+    public async Task DownloadInvoicePdf_WithClientFilenamePattern_UsesResolvedSanitizedFilename()
+    {
+        var sellerProfileResponse = await _client.PutAsJsonAsync("/seller-profile", new
+        {
+            sellerName = "Glovelly Music Ltd",
+            addressLine1 = "1 Chapel Street",
+            city = "Manchester",
+            country = "United Kingdom",
+            email = "accounts@glovelly.test",
+            accountName = "Glovelly Music Ltd",
+            sortCode = "12-34-56",
+            accountNumber = "12345678",
+        });
+        sellerProfileResponse.EnsureSuccessStatusCode();
+
+        var createGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Filename pattern booking",
+            date = "2026-04-20",
+            venue = "Albert Hall",
+            fee = 250.00m,
+            travelMiles = 0m,
+            wasDriving = false,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        createGigResponse.EnsureSuccessStatusCode();
+
+        var createdGig = await createGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var generateInvoiceResponse = await _client.PostAsync(
+            $"/gigs/{createdGig.GetProperty("id").GetGuid()}/generate-invoice",
+            content: null);
+        generateInvoiceResponse.EnsureSuccessStatusCode();
+
+        var generatedInvoice = await generateInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var updateClientResponse = await _client.PutAsJsonAsync($"/clients/{TestData.FoxAndFinchId}", new
+        {
+            id = TestData.FoxAndFinchId,
+            name = "Fox & Finch Events",
+            email = "bookings@foxandfinch.co.uk",
+            billingAddress = new
+            {
+                line1 = "12 Chapel Street",
+                city = "Manchester",
+                stateOrCounty = "Greater Manchester",
+                postalCode = "M3 5JZ",
+                country = "United Kingdom",
+            },
+            mileageRate = 0.52m,
+            passengerMileageRate = 0.15m,
+            invoiceFilenamePattern = "{ClientName}: {MonthName} {Year} {InvoiceNumber}",
+        });
+        updateClientResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.GetAsync($"/invoices/{generatedInvoice.GetProperty("id").GetGuid()}/pdf");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(
+            $"Fox & Finch Events- April 2026 {generatedInvoice.GetProperty("invoiceNumber").GetString()}.pdf",
+            response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+    }
+
+    [Fact]
+    public async Task DownloadInvoicePdf_WithoutClientPattern_UsesUserDefaultFilenamePattern()
+    {
+        var sellerProfileResponse = await _client.PutAsJsonAsync("/seller-profile", new
+        {
+            sellerName = "Glovelly Music Ltd",
+            addressLine1 = "1 Chapel Street",
+            city = "Manchester",
+            country = "United Kingdom",
+            email = "accounts@glovelly.test",
+            accountName = "Glovelly Music Ltd",
+            sortCode = "12-34-56",
+            accountNumber = "12345678",
+        });
+        sellerProfileResponse.EnsureSuccessStatusCode();
+
+        var updateUserSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            invoiceFilenamePattern = "{MonthName} {Year} {InvoiceNumber}",
+        });
+        updateUserSettingsResponse.EnsureSuccessStatusCode();
+
+        var createGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.RiversideId,
+            title = "User default filename booking",
+            date = "2026-04-21",
+            venue = "Riverside Hall",
+            fee = 250.00m,
+            travelMiles = 0m,
+            wasDriving = false,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        createGigResponse.EnsureSuccessStatusCode();
+
+        var createdGig = await createGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var generateInvoiceResponse = await _client.PostAsync(
+            $"/gigs/{createdGig.GetProperty("id").GetGuid()}/generate-invoice",
+            content: null);
+        generateInvoiceResponse.EnsureSuccessStatusCode();
+
+        var generatedInvoice = await generateInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var response = await _client.GetAsync($"/invoices/{generatedInvoice.GetProperty("id").GetGuid()}/pdf");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(
+            $"April 2026 {generatedInvoice.GetProperty("invoiceNumber").GetString()}.pdf",
+            response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
     }
 }

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -29,6 +29,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
                 .HasPrecision(18, 2);
             entity.Property(user => user.PassengerMileageRate)
                 .HasPrecision(18, 2);
+            entity.Property(user => user.InvoiceFilenamePattern)
+                .HasMaxLength(200);
             entity.Property(user => user.Role)
                 .HasConversion<string>()
                 .HasMaxLength(20);
@@ -51,6 +53,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
                 .HasPrecision(18, 2);
             entity.Property(client => client.PassengerMileageRate)
                 .HasPrecision(18, 2);
+            entity.Property(client => client.InvoiceFilenamePattern)
+                .HasMaxLength(200);
             entity.HasOne(client => client.CreatedByUser)
                 .WithMany(user => user.ClientsCreated)
                 .HasForeignKey(client => client.CreatedByUserId)

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -68,6 +68,7 @@ internal static class AuthEndpoints
                 profileImageUrl = user.FindFirstValue("picture") ?? user.FindFirstValue("profile") ?? string.Empty,
                 mileageRate = localUser.MileageRate,
                 passengerMileageRate = localUser.PassengerMileageRate,
+                invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
             });
         });
 
@@ -97,6 +98,7 @@ internal static class AuthEndpoints
 
             localUser.MileageRate = request.MileageRate;
             localUser.PassengerMileageRate = request.PassengerMileageRate;
+            localUser.InvoiceFilenamePattern = request.InvoiceFilenamePattern?.Trim();
 
             await dbContext.SaveChangesAsync();
 
@@ -104,6 +106,7 @@ internal static class AuthEndpoints
             {
                 mileageRate = localUser.MileageRate,
                 passengerMileageRate = localUser.PassengerMileageRate,
+                invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
             });
         });
 
@@ -153,6 +156,13 @@ internal static class AuthEndpoints
 
     private static Dictionary<string, string[]>? ValidateUserSettingsRequest(UserSettingsRequest request)
     {
+        if (EndpointSupport.TryValidateInvoiceFilenamePattern(
+                request.InvoiceFilenamePattern,
+                out var patternErrors))
+        {
+            return patternErrors;
+        }
+
         var validationResults = new List<ValidationResult>();
         var validationContext = new ValidationContext(request);
         var isValid = Validator.TryValidateObject(request, validationContext, validationResults, validateAllProperties: true);
@@ -182,5 +192,6 @@ internal static class AuthEndpoints
         [Range(0, double.MaxValue, ErrorMessage = "Mileage rate cannot be negative.")]
         decimal? MileageRate,
         [Range(0, double.MaxValue, ErrorMessage = "Passenger mileage rate cannot be negative.")]
-        decimal? PassengerMileageRate);
+        decimal? PassengerMileageRate,
+        string? InvoiceFilenamePattern);
 }

--- a/backend/Glovelly.Api/Endpoints/ClientEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/ClientEndpoints.cs
@@ -45,6 +45,7 @@ public static class ClientEndpoints
             client.Name = client.Name.Trim();
             client.Email = client.Email.Trim();
             client.BillingAddress ??= new Address();
+            client.InvoiceFilenamePattern = client.InvoiceFilenamePattern?.Trim();
             EndpointSupport.StampCreate(client, currentUserAccessor.TryGetUserId(user));
 
             db.Clients.Add(client);
@@ -75,6 +76,7 @@ public static class ClientEndpoints
             client.BillingAddress = request.BillingAddress ?? new Address();
             client.MileageRate = request.MileageRate;
             client.PassengerMileageRate = request.PassengerMileageRate;
+            client.InvoiceFilenamePattern = request.InvoiceFilenamePattern?.Trim();
             EndpointSupport.StampUpdate(client, userId);
 
             await db.SaveChangesAsync();

--- a/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
@@ -112,7 +112,28 @@ internal static class EndpointSupport
             });
         }
 
+        if (TryValidateInvoiceFilenamePattern(client.InvoiceFilenamePattern, out var patternErrors))
+        {
+            return Results.ValidationProblem(patternErrors);
+        }
+
         return null;
+    }
+
+    public static bool TryValidateInvoiceFilenamePattern(
+        string? pattern,
+        out Dictionary<string, string[]> errors,
+        string fieldName = "invoiceFilenamePattern")
+    {
+        errors = new Dictionary<string, string[]>();
+
+        if (pattern is not null && string.IsNullOrWhiteSpace(pattern))
+        {
+            errors[fieldName] = ["Invoice filename pattern cannot be empty or whitespace."];
+            return true;
+        }
+
+        return false;
     }
 
     public static void StampCreate(SellerProfile profile, Guid? userId)

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -31,6 +31,7 @@ public static class InvoiceEndpoints
             var invoice = await db.Invoices
                 .WhereVisibleTo(userId)
                 .AsNoTracking()
+                .Include(value => value.Client)
                 .FirstOrDefaultAsync(value => value.Id == id);
 
             if (invoice is null)
@@ -43,7 +44,18 @@ public static class InvoiceEndpoints
                 return Results.NotFound();
             }
 
-            return Results.File(invoice.PdfBlob, "application/pdf", $"{invoice.InvoiceNumber}.pdf");
+            var userDefaultPattern = userId.HasValue
+                ? await db.Users
+                    .AsNoTracking()
+                    .Where(value => value.Id == userId.Value && value.IsActive)
+                    .Select(value => value.InvoiceFilenamePattern)
+                    .FirstOrDefaultAsync()
+                : null;
+
+            return Results.File(
+                invoice.PdfBlob,
+                "application/pdf",
+                InvoicePdfFilenameBuilder.Build(invoice, invoice.Client, userDefaultPattern));
         });
 
         group.MapGet("/{id:guid}", async (Guid id, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>

--- a/backend/Glovelly.Api/Models/Client.cs
+++ b/backend/Glovelly.Api/Models/Client.cs
@@ -10,6 +10,7 @@ public sealed class Client
     public Address BillingAddress { get; set; } = new();
     public decimal? MileageRate { get; set; }
     public decimal? PassengerMileageRate { get; set; }
+    public string? InvoiceFilenamePattern { get; set; }
     public Guid? CreatedByUserId { get; set; }
     public Guid? UpdatedByUserId { get; set; }
 

--- a/backend/Glovelly.Api/Models/User.cs
+++ b/backend/Glovelly.Api/Models/User.cs
@@ -11,6 +11,7 @@ public sealed class User
     public string? DisplayName { get; set; }
     public decimal? MileageRate { get; set; }
     public decimal? PassengerMileageRate { get; set; }
+    public string? InvoiceFilenamePattern { get; set; }
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public UserRole Role { get; set; } = UserRole.User;
     public bool IsActive { get; set; } = true;

--- a/backend/Glovelly.Api/Services/InvoicePdfFilenameBuilder.cs
+++ b/backend/Glovelly.Api/Services/InvoicePdfFilenameBuilder.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Glovelly.Api.Models;
+
+namespace Glovelly.Api.Services;
+
+internal static partial class InvoicePdfFilenameBuilder
+{
+    public static readonly string[] SupportedTokens =
+    [
+        "{InvoiceNumber}",
+        "{InvoiceId}",
+        "{ClientName}",
+        "{Month}",
+        "{MonthName}",
+        "{Year}",
+        "{InvoiceDate}"
+    ];
+
+    public const string DefaultInvoiceNumber = "INV-2026-001";
+
+    public static string Build(Invoice invoice, Client? client, string? defaultPattern = null)
+    {
+        var pattern = client?.InvoiceFilenamePattern ?? defaultPattern;
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return AppendPdfExtension(Sanitize(invoice.InvoiceNumber));
+        }
+
+        if (ContainsUnsupportedTokens(pattern))
+        {
+            return AppendPdfExtension(Sanitize(invoice.InvoiceNumber));
+        }
+
+        var resolved = ResolveTokens(pattern, invoice, client);
+        var sanitized = Sanitize(resolved);
+
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            return AppendPdfExtension(Sanitize(invoice.InvoiceNumber));
+        }
+
+        return AppendPdfExtension(sanitized);
+    }
+
+    public static string BuildPreview(
+        string? pattern,
+        string? clientName,
+        DateOnly? invoiceDate = null,
+        string? defaultPattern = null)
+    {
+        var previewInvoice = new Invoice
+        {
+            Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            InvoiceNumber = DefaultInvoiceNumber,
+            InvoiceDate = invoiceDate ?? DateOnly.FromDateTime(DateTime.UtcNow),
+        };
+
+        var previewClient = new Client
+        {
+            Name = clientName ?? "Client Name",
+            InvoiceFilenamePattern = pattern,
+        };
+
+        return Build(previewInvoice, previewClient, defaultPattern);
+    }
+
+    private static bool ContainsUnsupportedTokens(string pattern)
+    {
+        var matches = TokenRegex().Matches(pattern);
+        foreach (Match match in matches)
+        {
+            if (!SupportedTokens.Contains(match.Value, StringComparer.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ResolveTokens(string pattern, Invoice invoice, Client? client)
+    {
+        var invoiceDate = invoice.InvoiceDate.ToDateTime(TimeOnly.MinValue);
+        var replacements = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["{InvoiceNumber}"] = invoice.InvoiceNumber,
+            ["{InvoiceId}"] = invoice.Id.ToString(),
+            ["{ClientName}"] = client?.Name ?? string.Empty,
+            ["{Month}"] = invoiceDate.ToString("MM", CultureInfo.InvariantCulture),
+            ["{MonthName}"] = invoiceDate.ToString("MMMM", CultureInfo.InvariantCulture),
+            ["{Year}"] = invoiceDate.ToString("yyyy", CultureInfo.InvariantCulture),
+            ["{InvoiceDate}"] = invoiceDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        };
+
+        var resolved = pattern;
+        foreach (var token in SupportedTokens)
+        {
+            resolved = resolved.Replace(token, replacements[token], StringComparison.Ordinal);
+        }
+
+        return resolved;
+    }
+
+    private static string AppendPdfExtension(string filename)
+    {
+        if (filename.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+        {
+            return filename;
+        }
+
+        return $"{filename}.pdf";
+    }
+
+    private static string Sanitize(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = InvalidFilenameCharactersRegex().Replace(value, "-");
+        sanitized = CollapseWhitespaceRegex().Replace(sanitized, " ").Trim(' ', '.');
+
+        return sanitized;
+    }
+
+    [GeneratedRegex(@"[<>:""/\\|?*\x00-\x1F]")]
+    private static partial Regex InvalidFilenameCharactersRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex CollapseWhitespaceRegex();
+
+    [GeneratedRegex(@"\{[^{}]+\}")]
+    private static partial Regex TokenRegex();
+}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -13,6 +13,7 @@ import {
 } from './AppSections'
 import {
   buildApiUrl,
+  buildInvoiceFilenamePreview,
   buildReturnUrl,
   defaultAdminStatus,
   defaultGigStatus,
@@ -23,6 +24,7 @@ import {
   emptyGigForm,
   emptySellerProfileForm,
   emptyUserSettingsForm,
+  invoiceFilenameTokens,
   fetchWithSession,
   formatCurrency,
   formatBuildMetadata,
@@ -1073,6 +1075,7 @@ function App({ appMetadata }: AppProps) {
         selectedClient.passengerMileageRate === null
           ? ''
           : String(selectedClient.passengerMileageRate),
+      invoiceFilenamePattern: selectedClient.invoiceFilenamePattern ?? '',
     })
     setClientSettingsStatus(
       'Client-specific rates override your personal defaults when set.'
@@ -1117,6 +1120,7 @@ function App({ appMetadata }: AppProps) {
     const passengerMileageRate = parseOptionalDecimal(
       clientSettingsForm.passengerMileageRate
     )
+    const invoiceFilenamePattern = clientSettingsForm.invoiceFilenamePattern.trim()
 
     if (Number.isNaN(mileageRate) || Number.isNaN(passengerMileageRate)) {
       setClientSettingsStatus('Rates must be valid numbers, for example 0.45.')
@@ -1140,6 +1144,7 @@ function App({ appMetadata }: AppProps) {
             billingAddress: selectedClient.billingAddress,
             mileageRate,
             passengerMileageRate,
+            invoiceFilenamePattern: invoiceFilenamePattern || null,
           }),
         }
       )
@@ -1173,6 +1178,7 @@ function App({ appMetadata }: AppProps) {
           savedClient.passengerMileageRate === null
             ? ''
             : String(savedClient.passengerMileageRate),
+        invoiceFilenamePattern: savedClient.invoiceFilenamePattern ?? '',
       })
       setClientSettingsStatus('Client settings updated.')
     } catch (error) {
@@ -1197,9 +1203,10 @@ function App({ appMetadata }: AppProps) {
         authUser?.passengerMileageRate === undefined
           ? ''
           : String(authUser.passengerMileageRate),
+      invoiceFilenamePattern: authUser?.invoiceFilenamePattern ?? '',
     })
     setUserSettingsStatus(
-      'Set the mileage defaults used when a client has no custom rates.'
+      'Set the defaults used when a client does not provide its own overrides.'
     )
     setIsProfileMenuOpen(false)
     setIsUserSettingsOpen(true)
@@ -1261,6 +1268,7 @@ function App({ appMetadata }: AppProps) {
     const passengerMileageRate = parseOptionalDecimal(
       userSettingsForm.passengerMileageRate
     )
+    const invoiceFilenamePattern = userSettingsForm.invoiceFilenamePattern.trim()
 
     if (Number.isNaN(mileageRate) || Number.isNaN(passengerMileageRate)) {
       setUserSettingsStatus('Rates must be valid numbers, for example 0.45.')
@@ -1278,6 +1286,7 @@ function App({ appMetadata }: AppProps) {
         body: JSON.stringify({
           mileageRate,
           passengerMileageRate,
+          invoiceFilenamePattern: invoiceFilenamePattern || null,
         }),
       })
 
@@ -1302,6 +1311,7 @@ function App({ appMetadata }: AppProps) {
       const savedSettings = (await response.json()) as {
         mileageRate: number | null
         passengerMileageRate: number | null
+        invoiceFilenamePattern: string | null
       }
 
       setAuthUser((current) =>
@@ -1310,6 +1320,7 @@ function App({ appMetadata }: AppProps) {
               ...current,
               mileageRate: savedSettings.mileageRate,
               passengerMileageRate: savedSettings.passengerMileageRate,
+              invoiceFilenamePattern: savedSettings.invoiceFilenamePattern,
             }
           : current
       )
@@ -1320,6 +1331,7 @@ function App({ appMetadata }: AppProps) {
           savedSettings.passengerMileageRate === null
             ? ''
             : String(savedSettings.passengerMileageRate),
+        invoiceFilenamePattern: savedSettings.invoiceFilenamePattern ?? '',
       })
       setUserSettingsStatus('Settings updated.')
     } catch (error) {
@@ -2052,8 +2064,9 @@ function App({ appMetadata }: AppProps) {
   }
 
   const handleDownloadInvoicePdf = async (invoice: Invoice) => {
+    const fallbackFilename = `${invoice.invoiceNumber}.pdf`
     setIsInvoiceLoading(true)
-    setInvoiceStatus(`Preparing ${invoice.invoiceNumber}.pdf...`)
+    setInvoiceStatus(`Preparing ${fallbackFilename}...`)
 
     try {
       const response = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}/pdf`))
@@ -2061,16 +2074,17 @@ function App({ appMetadata }: AppProps) {
         throw new Error('Unable to download the invoice PDF.')
       }
 
+      const contentDisposition = response.headers.get('Content-Disposition')
       const blob = await response.blob()
       const downloadUrl = window.URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = downloadUrl
-      link.download = `${invoice.invoiceNumber}.pdf`
+      link.download = extractDownloadFilename(contentDisposition) ?? fallbackFilename
       document.body.append(link)
       link.click()
       link.remove()
       window.URL.revokeObjectURL(downloadUrl)
-      setInvoiceStatus(`Downloaded ${invoice.invoiceNumber}.pdf.`)
+      setInvoiceStatus(`Downloaded ${link.download}.`)
     } catch (error) {
       setInvoiceStatus(
         error instanceof Error ? error.message : 'Unable to download the invoice PDF.'
@@ -2078,6 +2092,29 @@ function App({ appMetadata }: AppProps) {
     } finally {
       setIsInvoiceLoading(false)
     }
+  }
+
+  const extractDownloadFilename = (contentDisposition: string | null) => {
+    if (!contentDisposition) {
+      return null
+    }
+
+    const encodedMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i)
+    if (encodedMatch?.[1]) {
+      try {
+        return decodeURIComponent(encodedMatch[1])
+      } catch {
+        return encodedMatch[1]
+      }
+    }
+
+    const quotedMatch = contentDisposition.match(/filename=\"([^\"]+)\"/i)
+    if (quotedMatch?.[1]) {
+      return quotedMatch[1]
+    }
+
+    const plainMatch = contentDisposition.match(/filename=([^;]+)/i)
+    return plainMatch?.[1]?.trim() ?? null
   }
 
   const handleInvoiceStatusChange = async (invoice: Invoice, status: InvoiceStatus) => {
@@ -2558,6 +2595,11 @@ function App({ appMetadata }: AppProps) {
 
       <UserSettingsModal
         form={userSettingsForm}
+        invoiceFilenamePreview={buildInvoiceFilenamePreview(
+          userSettingsForm.invoiceFilenamePattern,
+          null
+        )}
+        invoiceFilenameTokens={invoiceFilenameTokens}
         isOpen={isUserSettingsOpen}
         isSaving={isUserSettingsSaving}
         onClose={closeUserSettings}
@@ -2580,6 +2622,11 @@ function App({ appMetadata }: AppProps) {
       <ClientSettingsModal
         authUser={authUser}
         form={clientSettingsForm}
+        invoiceFilenamePreview={buildInvoiceFilenamePreview(
+          clientSettingsForm.invoiceFilenamePattern || authUser?.invoiceFilenamePattern,
+          selectedClient?.name
+        )}
+        invoiceFilenameTokens={invoiceFilenameTokens}
         isOpen={isClientSettingsOpen}
         isSaving={isClientSettingsSaving}
         onClose={closeClientSettings}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -1847,6 +1847,8 @@ export function InvoicesSection({
 
 type UserSettingsModalProps = {
   form: UserSettingsForm
+  invoiceFilenamePreview: string
+  invoiceFilenameTokens: string[]
   isOpen: boolean
   isSaving: boolean
   onClose: () => void
@@ -1857,6 +1859,8 @@ type UserSettingsModalProps = {
 
 export function UserSettingsModal({
   form,
+  invoiceFilenamePreview,
+  invoiceFilenameTokens,
   isOpen,
   isSaving,
   onClose,
@@ -1880,7 +1884,7 @@ export function UserSettingsModal({
         <div className="panel-heading">
           <div>
             <p className="section-label">User settings</p>
-            <h2 id="user-settings-title">Mileage defaults</h2>
+            <h2 id="user-settings-title">Default invoice settings</h2>
           </div>
           <button className="ghost-button" onClick={onClose} type="button">
             Close
@@ -1888,8 +1892,8 @@ export function UserSettingsModal({
         </div>
 
         <p className="hero-text settings-intro">
-          These rates are used as your personal fallback when a client does not
-          have custom mileage pricing configured.
+          These defaults are used when a client does not provide its own pricing
+          or invoice filename pattern.
         </p>
 
         <form className="settings-form" onSubmit={onSubmit}>
@@ -1917,10 +1921,31 @@ export function UserSettingsModal({
                 }
               />
             </label>
+
+            <label>
+              <span>Default invoice filename pattern</span>
+              <input
+                placeholder="{InvoiceNumber}"
+                type="text"
+                value={form.invoiceFilenamePattern}
+                onChange={(event) =>
+                  onUpdateField('invoiceFilenamePattern', event.target.value)
+                }
+              />
+            </label>
+          </div>
+
+          <div className="detail-grid client-settings-preview">
+            <article className="setting-card override">
+              <p className="detail-label">Preview</p>
+              <strong>{invoiceFilenamePreview}</strong>
+              <span>Using today's date and a sample invoice number.</span>
+            </article>
           </div>
 
           <div className="settings-note">
-            Leave a field blank if you do not want a default for that rate.
+            Leave a rate blank if you do not want a personal default. Filename tokens:
+            {` ${invoiceFilenameTokens.join(', ')}.`}
           </div>
 
           <div className="form-actions">
@@ -1938,6 +1963,8 @@ export function UserSettingsModal({
 type ClientSettingsModalProps = {
   authUser: AuthUser | null
   form: ClientSettingsForm
+  invoiceFilenamePreview: string
+  invoiceFilenameTokens: string[]
   isOpen: boolean
   isSaving: boolean
   onClose: () => void
@@ -1950,6 +1977,8 @@ type ClientSettingsModalProps = {
 export function ClientSettingsModal({
   authUser,
   form,
+  invoiceFilenamePreview,
+  invoiceFilenameTokens,
   isOpen,
   isSaving,
   onClose,
@@ -1983,7 +2012,7 @@ export function ClientSettingsModal({
 
         <p className="hero-text settings-intro">
           Leave a field blank to inherit the default from your own user settings.
-          Add a value here only when this client needs a special rate.
+          Add a value here only when this client needs special handling.
         </p>
 
         <div className="detail-grid client-settings-preview">
@@ -2025,6 +2054,23 @@ export function ClientSettingsModal({
                 : 'Overriding your default'}
             </span>
           </article>
+          <article
+            className={
+              selectedClient.invoiceFilenamePattern === null
+                ? 'setting-card inherited'
+                : 'setting-card override'
+            }
+          >
+            <p className="detail-label">Invoice PDF filename</p>
+            <strong>
+              {selectedClient.invoiceFilenamePattern ?? '{InvoiceNumber}'}
+            </strong>
+            <span>
+              {selectedClient.invoiceFilenamePattern === null
+                ? 'Using the default invoice number filename'
+                : 'Custom pattern for this client'}
+            </span>
+          </article>
         </div>
 
         <form className="settings-form" onSubmit={onSubmit}>
@@ -2061,10 +2107,30 @@ export function ClientSettingsModal({
                 }
               />
             </label>
+
+            <label>
+              <span>Invoice filename pattern</span>
+              <input
+                placeholder="{InvoiceNumber}"
+                type="text"
+                value={form.invoiceFilenamePattern}
+                onChange={(event) =>
+                  onUpdateField('invoiceFilenamePattern', event.target.value)
+                }
+              />
+            </label>
           </div>
 
           <div className="settings-note">
-            Blank means inherited. A filled value becomes a client-specific override.
+            Blank means inherited. Filename tokens: {invoiceFilenameTokens.join(', ')}.
+          </div>
+
+          <div className="detail-grid client-settings-preview">
+            <article className="setting-card override">
+              <p className="detail-label">Preview</p>
+              <strong>{invoiceFilenamePreview}</strong>
+              <span>Using today's date and the current effective pattern.</span>
+            </article>
           </div>
 
           <div className="form-actions">

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -14,6 +14,7 @@ export type Client = {
   billingAddress: Address
   mileageRate: number | null
   passengerMileageRate: number | null
+  invoiceFilenamePattern: string | null
 }
 
 export type ClientForm = {
@@ -30,6 +31,7 @@ export type AuthUser = {
   profileImageUrl: string
   mileageRate: number | null
   passengerMileageRate: number | null
+  invoiceFilenamePattern: string | null
 }
 
 export type AdminUser = {
@@ -55,11 +57,13 @@ export type AdminUserForm = {
 export type UserSettingsForm = {
   mileageRate: string
   passengerMileageRate: string
+  invoiceFilenamePattern: string
 }
 
 export type ClientSettingsForm = {
   mileageRate: string
   passengerMileageRate: string
+  invoiceFilenamePattern: string
 }
 
 export type SellerProfile = {
@@ -211,12 +215,70 @@ export const emptyAdminForm = (): AdminUserForm => ({
 export const emptyUserSettingsForm = (): UserSettingsForm => ({
   mileageRate: '',
   passengerMileageRate: '',
+  invoiceFilenamePattern: '',
 })
 
 export const emptyClientSettingsForm = (): ClientSettingsForm => ({
   mileageRate: '',
   passengerMileageRate: '',
+  invoiceFilenamePattern: '',
 })
+
+export const invoiceFilenameTokens = [
+  '{InvoiceNumber}',
+  '{InvoiceId}',
+  '{ClientName}',
+  '{Month}',
+  '{MonthName}',
+  '{Year}',
+  '{InvoiceDate}',
+]
+
+const previewInvoiceNumber = 'INV-2026-001'
+const previewInvoiceId = '11111111-1111-1111-1111-111111111111'
+
+export function buildInvoiceFilenamePreview(
+  pattern: string | null | undefined,
+  clientName: string | null | undefined,
+  invoiceDate = new Date()
+) {
+  const trimmedPattern = pattern?.trim() ?? ''
+  const effectivePattern = trimmedPattern || '{InvoiceNumber}'
+
+  const replacements = new Map<string, string>([
+    ['{InvoiceNumber}', previewInvoiceNumber],
+    ['{InvoiceId}', previewInvoiceId],
+    ['{ClientName}', (clientName?.trim() || 'Client Name')],
+    ['{Month}', String(invoiceDate.getMonth() + 1).padStart(2, '0')],
+    [
+      '{MonthName}',
+      new Intl.DateTimeFormat('en-GB', { month: 'long' }).format(invoiceDate),
+    ],
+    ['{Year}', String(invoiceDate.getFullYear())],
+    ['{InvoiceDate}', invoiceDate.toISOString().slice(0, 10)],
+  ])
+
+  const containsUnsupportedToken = Array.from(
+    effectivePattern.matchAll(/\{[^{}]+\}/g)
+  ).some(([token]) => !replacements.has(token))
+
+  if (containsUnsupportedToken) {
+    return `${previewInvoiceNumber}.pdf`
+  }
+
+  let resolved = effectivePattern
+  for (const [token, replacement] of replacements) {
+    resolved = resolved.replaceAll(token, replacement)
+  }
+
+  const sanitized = resolved
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[. ]+|[. ]+$/g, '')
+
+  return `${sanitized || previewInvoiceNumber}.pdf`
+}
 
 export const emptySellerProfileForm = (): SellerProfileForm => ({
   sellerName: '',


### PR DESCRIPTION
## What changed
This adds configurable invoice PDF filename patterns across both client settings and user settings.

Client settings can now define an `invoiceFilenamePattern` override, and user settings can define a default pattern that applies when a client does not provide one. The backend now resolves supported tokens, sanitizes invalid filename characters, falls back safely when a pattern is empty or invalid, and sends the final filename via `Content-Disposition` when downloading invoice PDFs.

The frontend now exposes invoice filename pattern fields in both settings modals, follows the existing user-default/client-override structure, and shows a live preview including the `.pdf` extension so the effective filename is visible before saving.

## Why it changed
Users needed invoice downloads to match client-specific naming expectations without manual renaming. After the initial client-level support, adding a user-level default keeps the behavior consistent with the existing mileage override model, and the live preview makes the token-based format much easier to understand and trust.

## Impact
Glovelly users can now:
- set a personal default invoice filename pattern
- override that pattern per client when needed
- see the effective filename preview before saving
- download PDFs using the effective server-generated filename

## Validation
- `dotnet test glovelly.sln`
- `npm run build`

## Notes
This PR includes backend coverage for:
- auth settings round-trip for the user default pattern
- client settings validation and persistence
- invoice PDF downloads using both client-specific and user-default filename patterns