### PR TITLE
[codex] Add access request request-access endpoint and branded notifications

### DIFF
--- a/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
+using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly GlovellyApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public AccessEndpointsTests(GlovellyApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task RequestAccess_SendsNotificationToEachAdministratorWithEmail()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<Glovelly.Api.Data.AppDbContext>();
+        dbContext.Users.Add(new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "second-admin@glovelly.local",
+            DisplayName = "Second Admin",
+            Role = UserRole.Admin,
+            IsActive = true,
+            CreatedUtc = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+        });
+        await dbContext.SaveChangesAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/access/request");
+        request.Headers.Add("X-Test-Include-UserId", "false");
+        request.Headers.Add("X-Test-Email", "new-user@glovelly.local");
+        request.Headers.Add("X-Test-Name", "New User");
+        request.Headers.Add("X-Test-Subject", "google-sub-new-user");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Collection(
+            _factory.Emails.SentEmails.OrderBy(value => value.To.Single().Address),
+            message =>
+            {
+                Assert.Equal("second-admin@glovelly.local", message.To.Single().Address);
+                Assert.Equal("Glovelly access request", message.Subject);
+                Assert.Contains("User email: new-user@glovelly.local", message.PlainTextBody);
+                Assert.Contains("User display name: New User", message.PlainTextBody);
+                Assert.Contains("Timestamp:", message.PlainTextBody);
+            },
+            message =>
+            {
+                Assert.Equal("test-admin@glovelly.local", message.To.Single().Address);
+                Assert.Equal("Glovelly access request", message.Subject);
+                Assert.Contains("User email: new-user@glovelly.local", message.PlainTextBody);
+                Assert.Contains("User display name: New User", message.PlainTextBody);
+                Assert.Contains("Timestamp:", message.PlainTextBody);
+            });
+    }
+
+    [Fact]
+    public async Task RequestAccess_SkipsAdministratorsWithoutEmail()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<Glovelly.Api.Data.AppDbContext>();
+        dbContext.Users.Add(new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "   ",
+            DisplayName = "Missing Email Admin",
+            Role = UserRole.Admin,
+            IsActive = true,
+            CreatedUtc = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+        });
+        await dbContext.SaveChangesAsync();
+
+        var response = await _client.PostAsync("/access/request", JsonContent.Create(new { }));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Single(_factory.Emails.SentEmails);
+        Assert.Equal("test-admin@glovelly.local", _factory.Emails.SentEmails[0].To.Single().Address);
+    }
+
+    [Fact]
+    public async Task RequestAccess_ReturnsBadRequest_WhenEmailClaimMissing()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/access/request");
+        request.Headers.Add("X-Test-Email", "   ");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(_factory.Emails.SentEmails);
+    }
+
+    [Fact]
+    public async Task RequestAccess_ReturnsProblem_WhenEmailDispatchFails()
+    {
+        _factory.Emails.ExceptionToThrow = new InvalidOperationException("SMTP unavailable");
+
+        var response = await _client.PostAsync("/access/request", JsonContent.Create(new { }));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Unable to submit access request", problem.GetProperty("title").GetString());
+        Assert.Equal(
+            "We couldn't submit your access request right now. Please try again shortly.",
+            problem.GetProperty("detail").GetString());
+    }
+}

--- a/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
@@ -52,17 +52,27 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
             {
                 Assert.Equal("second-admin@glovelly.local", message.To.Single().Address);
                 Assert.Equal("Glovelly access request", message.Subject);
+                Assert.Contains("Environment: Testing", message.PlainTextBody);
                 Assert.Contains("User email: new-user@glovelly.local", message.PlainTextBody);
                 Assert.Contains("User display name: New User", message.PlainTextBody);
                 Assert.Contains("Timestamp:", message.PlainTextBody);
+                Assert.Contains("Identity subject: google-sub-new-user", message.PlainTextBody);
+                Assert.NotNull(message.HtmlBody);
+                Assert.Contains("Glovelly", message.HtmlBody);
+                Assert.Contains("Testing", message.HtmlBody);
             },
             message =>
             {
                 Assert.Equal("test-admin@glovelly.local", message.To.Single().Address);
                 Assert.Equal("Glovelly access request", message.Subject);
+                Assert.Contains("Environment: Testing", message.PlainTextBody);
                 Assert.Contains("User email: new-user@glovelly.local", message.PlainTextBody);
                 Assert.Contains("User display name: New User", message.PlainTextBody);
                 Assert.Contains("Timestamp:", message.PlainTextBody);
+                Assert.Contains("Identity subject: google-sub-new-user", message.PlainTextBody);
+                Assert.NotNull(message.HtmlBody);
+                Assert.Contains("Glovelly", message.HtmlBody);
+                Assert.Contains("Testing", message.HtmlBody);
             });
     }
 

--- a/backend/Glovelly.Api.Tests/Infrastructure/FakeEmailSender.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/FakeEmailSender.cs
@@ -1,0 +1,22 @@
+using Glovelly.Api.Services;
+
+namespace Glovelly.Api.Tests.Infrastructure;
+
+internal sealed class FakeEmailSender : IEmailSender
+{
+    public List<EmailMessage> SentEmails { get; } = [];
+    public Exception? ExceptionToThrow { get; set; }
+
+    public Task SendAsync(EmailMessage message, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (ExceptionToThrow is not null)
+        {
+            throw ExceptionToThrow;
+        }
+
+        SentEmails.Add(message);
+        return Task.CompletedTask;
+    }
+}

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -1,5 +1,6 @@
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
+using Glovelly.Api.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -14,6 +15,9 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
 {
     private readonly string _databaseName = $"glovelly-tests-{Guid.NewGuid()}";
     private readonly object _databaseResetLock = new();
+    private readonly FakeEmailSender _fakeEmailSender = new();
+
+    internal FakeEmailSender Emails => _fakeEmailSender;
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -23,8 +27,10 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
         {
             services.RemoveAll<DbContextOptions<AppDbContext>>();
             services.RemoveAll<IPolicyEvaluator>();
+            services.RemoveAll<IEmailSender>();
 
             services.AddSingleton<IPolicyEvaluator, TestPolicyEvaluator>();
+            services.AddSingleton<IEmailSender>(_fakeEmailSender);
 
             services.AddDbContext<AppDbContext>(options =>
             {
@@ -44,6 +50,8 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
         {
             using var scope = Services.CreateScope();
             ResetDatabase(scope.ServiceProvider.GetRequiredService<AppDbContext>());
+            _fakeEmailSender.SentEmails.Clear();
+            _fakeEmailSender.ExceptionToThrow = null;
         }
 
         return client;

--- a/backend/Glovelly.Api.Tests/Infrastructure/TestAuthContext.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/TestAuthContext.cs
@@ -5,4 +5,7 @@ internal static class TestAuthContext
     public const string SchemeName = "Test";
     public static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     public static readonly Guid AlternateUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    public const string DefaultEmail = "test-admin@glovelly.local";
+    public const string DefaultName = "Test Admin";
+    public const string DefaultSubject = "google-sub-123";
 }

--- a/backend/Glovelly.Api.Tests/Infrastructure/TestPolicyEvaluator.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/TestPolicyEvaluator.cs
@@ -12,15 +12,7 @@ internal sealed class TestPolicyEvaluator : IPolicyEvaluator
 {
     public Task<AuthenticateResult> AuthenticateAsync(AuthorizationPolicy policy, HttpContext context)
     {
-        var userId = ResolveUserId(context);
-        var claims = new[]
-        {
-            new Claim(GlovellyClaimTypes.UserId, userId.ToString()),
-            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
-            new Claim(ClaimTypes.Name, "Test Admin"),
-            new Claim(ClaimTypes.Email, "test-admin@glovelly.local"),
-            new Claim(ClaimTypes.Role, UserRole.Admin.ToString()),
-        };
+        var claims = BuildClaims(context);
 
         var identity = new ClaimsIdentity(claims, TestAuthContext.SchemeName);
         var principal = new ClaimsPrincipal(identity);
@@ -40,14 +32,40 @@ internal sealed class TestPolicyEvaluator : IPolicyEvaluator
         return Task.FromResult(PolicyAuthorizationResult.Success());
     }
 
-    private static Guid ResolveUserId(HttpContext context)
+    private static Claim[] BuildClaims(HttpContext context)
     {
-        if (!context.Request.Headers.TryGetValue("X-Test-UserId", out var values))
+        var claims = new List<Claim>
         {
-            return TestAuthContext.UserId;
+            new(ClaimTypes.Name, ResolveHeader(context, "X-Test-Name") ?? TestAuthContext.DefaultName),
+            new(ClaimTypes.Email, ResolveHeader(context, "X-Test-Email") ?? TestAuthContext.DefaultEmail),
+            new Claim("email", ResolveHeader(context, "X-Test-Email") ?? TestAuthContext.DefaultEmail),
+            new Claim("sub", ResolveHeader(context, "X-Test-Subject") ?? TestAuthContext.DefaultSubject),
+        };
+
+        var role = ResolveHeader(context, "X-Test-Role") ?? UserRole.Admin.ToString();
+        claims.Add(new Claim(ClaimTypes.Role, role));
+        claims.Add(new Claim("role", role));
+
+        if (!string.Equals(ResolveHeader(context, "X-Test-Include-UserId"), "false", StringComparison.OrdinalIgnoreCase))
+        {
+            var userId = ResolveUserId(context);
+            claims.Add(new Claim(GlovellyClaimTypes.UserId, userId.ToString()));
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
         }
 
-        var value = values.FirstOrDefault();
+        return claims.ToArray();
+    }
+
+    private static Guid ResolveUserId(HttpContext context)
+    {
+        var value = ResolveHeader(context, "X-Test-UserId");
         return Guid.TryParse(value, out var parsed) ? parsed : TestAuthContext.UserId;
+    }
+
+    private static string? ResolveHeader(HttpContext context, string name)
+    {
+        return context.Request.Headers.TryGetValue(name, out var values)
+            ? values.FirstOrDefault()
+            : null;
     }
 }

--- a/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
@@ -1,0 +1,132 @@
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace Glovelly.Api.Endpoints;
+
+internal static class AccessEndpoints
+{
+    public static IEndpointRouteBuilder MapAccessEndpoints(this IEndpointRouteBuilder app)
+    {
+        var access = app.MapGroup("/access")
+            .WithTags("Access")
+            .RequireAuthorization();
+
+        access.MapPost("/request", [Authorize] async (
+            ClaimsPrincipal user,
+            AppDbContext dbContext,
+            IEmailSender emailSender,
+            ILoggerFactory loggerFactory,
+            CancellationToken cancellationToken) =>
+        {
+            var logger = loggerFactory.CreateLogger("Glovelly.AccessRequests");
+            var requestedAtUtc = DateTimeOffset.UtcNow;
+            var requester = AccessRequestEmailRequest.FromClaims(user, requestedAtUtc);
+
+            if (string.IsNullOrWhiteSpace(requester.Email))
+            {
+                logger.LogWarning(
+                    "Access request rejected because the authenticated principal did not include an email address. Subject: {Subject}",
+                    requester.Subject ?? "(missing)");
+                return Results.BadRequest(new { message = "A verified email address is required to request access." });
+            }
+
+            var administrators = await dbContext.Users
+                .AsNoTracking()
+                .Where(value => value.IsActive && value.Role == UserRole.Admin)
+                .OrderBy(value => value.Email)
+                .ToListAsync(cancellationToken);
+
+            var recipients = administrators
+                .Where(admin => !string.IsNullOrWhiteSpace(admin.Email))
+                .Select(admin => admin.Email.Trim().ToLowerInvariant())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var skippedAdminCount = administrators.Count - recipients.Length;
+            if (skippedAdminCount > 0)
+            {
+                logger.LogWarning(
+                    "Skipped {SkippedAdminCount} administrator access-request recipients because no valid email address was available.",
+                    skippedAdminCount);
+            }
+
+            try
+            {
+                foreach (var recipient in recipients)
+                {
+                    await emailSender.SendAsync(
+                        new EmailMessage(
+                            To: [new EmailAddress(recipient)],
+                            Subject: "Glovelly access request",
+                            PlainTextBody: BuildPlainTextBody(requester)),
+                        cancellationToken);
+                }
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(
+                    exception,
+                    "Failed to dispatch access request notification for requester subject {RequesterSubject}.",
+                    requester.Subject ?? "(missing)");
+                return Results.Problem(
+                    title: "Unable to submit access request",
+                    detail: "We couldn't submit your access request right now. Please try again shortly.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+
+            logger.LogInformation(
+                "Access request submitted for requester subject {RequesterSubject} to {RecipientCount} administrator recipients.",
+                requester.Subject ?? "(missing)",
+                recipients.Length);
+
+            return Results.Ok(new { message = "Access request submitted." });
+        });
+
+        return app;
+    }
+
+    private static string BuildPlainTextBody(AccessRequestEmailRequest requester)
+    {
+        var lines = new List<string>
+        {
+            "A Glovelly user has requested access.",
+            string.Empty,
+            FormattableString.Invariant($"User email: {requester.Email}"),
+        };
+
+        if (!string.IsNullOrWhiteSpace(requester.DisplayName))
+        {
+            lines.Add(FormattableString.Invariant($"User display name: {requester.DisplayName}"));
+        }
+
+        lines.Add(FormattableString.Invariant($"Timestamp: {requester.RequestedAtUtc:yyyy-MM-dd HH:mm:ss 'UTC'}"));
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private sealed record AccessRequestEmailRequest(
+        string Email,
+        string? DisplayName,
+        string? Subject,
+        DateTimeOffset RequestedAtUtc)
+    {
+        public static AccessRequestEmailRequest FromClaims(ClaimsPrincipal user, DateTimeOffset requestedAtUtc)
+        {
+            var email = AuthFlowSupport.NormalizeEmail(
+                user.FindFirstValue("email") ?? user.FindFirstValue(ClaimTypes.Email)) ?? string.Empty;
+            var displayName = Normalize(user.FindFirstValue("name") ?? user.FindFirstValue(ClaimTypes.Name));
+            var subject = Normalize(user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier));
+
+            return new AccessRequestEmailRequest(email, displayName, subject, requestedAtUtc);
+        }
+
+        private static string? Normalize(string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        }
+    }
+}

--- a/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
@@ -1,19 +1,22 @@
+using Glovelly.Api.Configuration;
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using System.Net;
 using System.Security.Claims;
 
 namespace Glovelly.Api.Endpoints;
 
 internal static class AccessEndpoints
 {
-    public static IEndpointRouteBuilder MapAccessEndpoints(this IEndpointRouteBuilder app)
+    public static IEndpointRouteBuilder MapAccessEndpoints(this IEndpointRouteBuilder app, StartupSettings settings)
     {
         var access = app.MapGroup("/access")
             .WithTags("Access")
             .RequireAuthorization();
+        var environmentLabel = ResolveEnvironmentLabel(settings);
 
         access.MapPost("/request", [Authorize] async (
             ClaimsPrincipal user,
@@ -62,7 +65,8 @@ internal static class AccessEndpoints
                         new EmailMessage(
                             To: [new EmailAddress(recipient)],
                             Subject: "Glovelly access request",
-                            PlainTextBody: BuildPlainTextBody(requester)),
+                            PlainTextBody: BuildPlainTextBody(requester, environmentLabel),
+                            HtmlBody: BuildHtmlBody(requester, environmentLabel)),
                         cancellationToken);
                 }
             }
@@ -89,12 +93,16 @@ internal static class AccessEndpoints
         return app;
     }
 
-    private static string BuildPlainTextBody(AccessRequestEmailRequest requester)
+    private static string BuildPlainTextBody(AccessRequestEmailRequest requester, string environmentLabel)
     {
         var lines = new List<string>
         {
-            "A Glovelly user has requested access.",
+            "Glovelly access request",
+            "=======================",
             string.Empty,
+            "A user has successfully authenticated and is asking to be enrolled in Glovelly.",
+            string.Empty,
+            FormattableString.Invariant($"Environment: {environmentLabel}"),
             FormattableString.Invariant($"User email: {requester.Email}"),
         };
 
@@ -105,7 +113,88 @@ internal static class AccessEndpoints
 
         lines.Add(FormattableString.Invariant($"Timestamp: {requester.RequestedAtUtc:yyyy-MM-dd HH:mm:ss 'UTC'}"));
 
+        if (!string.IsNullOrWhiteSpace(requester.Subject))
+        {
+            lines.Add(FormattableString.Invariant($"Identity subject: {requester.Subject}"));
+        }
+
+        lines.Add(string.Empty);
+        lines.Add("Review this user in the target environment and grant access if appropriate.");
+
         return string.Join(Environment.NewLine, lines);
+    }
+
+    private static string BuildHtmlBody(AccessRequestEmailRequest requester, string environmentLabel)
+    {
+        var encodedEmail = WebUtility.HtmlEncode(requester.Email);
+        var encodedDisplayName = WebUtility.HtmlEncode(requester.DisplayName ?? "Not provided");
+        var encodedEnvironment = WebUtility.HtmlEncode(environmentLabel);
+        var encodedTimestamp = WebUtility.HtmlEncode(
+            requester.RequestedAtUtc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"));
+        var encodedSubject = WebUtility.HtmlEncode(requester.Subject ?? "Not provided");
+
+        return $$"""
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="margin:0;padding:24px;background:#f5efe7;font-family:'Avenir Next','Segoe UI',sans-serif;color:#21313c;">
+                <div style="max-width:640px;margin:0 auto;background:#fffdf9;border:1px solid #e5d8ca;border-radius:24px;overflow:hidden;box-shadow:0 18px 45px rgba(39,31,24,0.08);">
+                    <div style="padding:24px 28px;background:linear-gradient(135deg,#17324d,#255a7a);color:#ffffff;">
+                        <div style="font-size:12px;letter-spacing:0.18em;text-transform:uppercase;opacity:0.82;">Glovelly</div>
+                        <h1 style="margin:12px 0 0;font-size:28px;line-height:1.05;font-family:Georgia,serif;">Access Request</h1>
+                        <p style="margin:12px 0 0;font-size:15px;line-height:1.6;color:rgba(255,255,255,0.88);">
+                            A user has successfully authenticated and is asking to be enrolled in Glovelly.
+                        </p>
+                    </div>
+                    <div style="padding:28px;">
+                        <div style="display:inline-block;padding:8px 12px;border-radius:999px;background:#efe4d7;color:#8c4920;font-size:12px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;">
+                            {{encodedEnvironment}}
+                        </div>
+                        <table style="width:100%;margin-top:20px;border-collapse:collapse;">
+                            <tr>
+                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;font-weight:700;width:180px;">User email</td>
+                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;">{{encodedEmail}}</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;font-weight:700;">Display name</td>
+                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;">{{encodedDisplayName}}</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;font-weight:700;">Timestamp</td>
+                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;">{{encodedTimestamp}}</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:12px 0;font-weight:700;">Identity subject</td>
+                                <td style="padding:12px 0;">{{encodedSubject}}</td>
+                            </tr>
+                        </table>
+                        <p style="margin:24px 0 0;font-size:14px;line-height:1.7;color:#52606b;">
+                            Review this user in the target environment and grant access if appropriate.
+                        </p>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """;
+    }
+
+    private static string ResolveEnvironmentLabel(StartupSettings settings)
+    {
+        if (!string.IsNullOrWhiteSpace(settings.DeploymentName))
+        {
+            return settings.DeploymentName.Trim();
+        }
+
+        if (settings.IsTesting)
+        {
+            return "Testing";
+        }
+
+        if (settings.IsDevelopment)
+        {
+            return "Development";
+        }
+
+        return "Production";
     }
 
     private sealed record AccessRequestEmailRequest(

--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -34,6 +34,7 @@ internal static class AuthFlowSupport
         var path = request.Path;
 
         return path.StartsWithSegments("/auth/me") ||
+               path.StartsWithSegments("/access") ||
                path.StartsWithSegments("/admin") ||
                path.StartsWithSegments("/clients") ||
                path.StartsWithSegments("/gigs") ||

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -14,7 +14,7 @@ await app.InitializeDatabaseAsync(builder.Configuration, startupSettings.ShouldS
 app.UseGlovellyHttpPipeline(startupSettings);
 app.MapAppMetadataEndpoints(startupSettings);
 app.MapAuthEndpoints(startupSettings);
-app.MapAccessEndpoints();
+app.MapAccessEndpoints(startupSettings);
 app.MapCrudEndpoints();
 app.MapAdminEndpoints();
 app.MapFallbackToFile("index.html");

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -14,6 +14,7 @@ await app.InitializeDatabaseAsync(builder.Configuration, startupSettings.ShouldS
 app.UseGlovellyHttpPipeline(startupSettings);
 app.MapAppMetadataEndpoints(startupSettings);
 app.MapAuthEndpoints(startupSettings);
+app.MapAccessEndpoints();
 app.MapCrudEndpoints();
 app.MapAdminEndpoints();
 app.MapFallbackToFile("index.html");


### PR DESCRIPTION
## What changed
This adds the backend flow for access requests so an authenticated but unenrolled user can submit a request for Glovelly access.

The branch introduces:
- a new `POST /access/request` endpoint
- administrator resolution and notification dispatch through the provider-agnostic outbound email infrastructure
- richer access-request email content with Glovelly branding and environment details
- test harness updates so request-access behavior can be exercised against the shared `IEmailSender` abstraction

## Why
We need a lightweight first step for enrolment requests that does not expose administrator contact details or require manual out-of-band coordination.

## Impact
Administrators receive a clear notification when a user requests access, including:
- requester email
- requester display name when present
- timestamp
- identity subject
- target environment such as staging or production

This keeps the implementation server-side and aligned with the new outbound email infrastructure.

## Validation
- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj`