### PR TITLE
[codex] Add abuse controls for access request notifications

### DIFF
--- a/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
@@ -1,10 +1,12 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Glovelly.Api.Tests.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -37,15 +39,15 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
         });
         await dbContext.SaveChangesAsync();
 
-        var request = new HttpRequestMessage(HttpMethod.Post, "/access/request");
+        var request = CreateAccessRequest("new-user@glovelly.local", "198.51.100.10");
         request.Headers.Add("X-Test-Include-UserId", "false");
-        request.Headers.Add("X-Test-Email", "new-user@glovelly.local");
         request.Headers.Add("X-Test-Name", "New User");
         request.Headers.Add("X-Test-Subject", "google-sub-new-user");
 
         var response = await _client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Access request submitted.", await ReadMessageAsync(response));
         Assert.Collection(
             _factory.Emails.SentEmails.OrderBy(value => value.To.Single().Address),
             message =>
@@ -92,9 +94,10 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
         });
         await dbContext.SaveChangesAsync();
 
-        var response = await _client.PostAsync("/access/request", JsonContent.Create(new { }));
+        var response = await _client.SendAsync(CreateAccessRequest(TestAuthContext.DefaultEmail, "198.51.100.11"));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Access request submitted.", await ReadMessageAsync(response));
         Assert.Single(_factory.Emails.SentEmails);
         Assert.Equal("test-admin@glovelly.local", _factory.Emails.SentEmails[0].To.Single().Address);
     }
@@ -102,8 +105,7 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task RequestAccess_ReturnsBadRequest_WhenEmailClaimMissing()
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, "/access/request");
-        request.Headers.Add("X-Test-Email", "   ");
+        var request = CreateAccessRequest("   ", "198.51.100.12");
 
         var response = await _client.SendAsync(request);
 
@@ -116,7 +118,7 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         _factory.Emails.ExceptionToThrow = new InvalidOperationException("SMTP unavailable");
 
-        var response = await _client.PostAsync("/access/request", JsonContent.Create(new { }));
+        var response = await _client.SendAsync(CreateAccessRequest(TestAuthContext.DefaultEmail, "198.51.100.13"));
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
@@ -125,5 +127,117 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(
             "We couldn't submit your access request right now. Please try again shortly.",
             problem.GetProperty("detail").GetString());
+    }
+
+    [Fact]
+    public async Task RequestAccess_SuppressesRepeatNotificationsForSameEmailWithinWindow()
+    {
+        var firstRequest = CreateAccessRequest("repeat-user@glovelly.local", "198.51.100.14");
+        var secondRequest = CreateAccessRequest("REPEAT-USER@glovelly.local", "198.51.100.14");
+
+        var firstResponse = await _client.SendAsync(firstRequest);
+        var secondResponse = await _client.SendAsync(secondRequest);
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal("Access request submitted.", await ReadMessageAsync(firstResponse));
+        Assert.Equal("Access request submitted.", await ReadMessageAsync(secondResponse));
+        Assert.Single(_factory.Emails.SentEmails);
+
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var storedRequests = await dbContext.AccessRequests
+            .OrderBy(value => value.RequestedAtUtc)
+            .ToListAsync();
+
+        Assert.Equal(2, storedRequests.Count);
+        Assert.NotNull(storedRequests[0].NotificationSentAtUtc);
+        Assert.Null(storedRequests[0].NotificationSuppressionReason);
+        Assert.Null(storedRequests[1].NotificationSentAtUtc);
+        Assert.Equal(
+            AccessRequestWorkflowService.DuplicateEmailSuppressionReason,
+            storedRequests[1].NotificationSuppressionReason);
+    }
+
+    [Fact]
+    public async Task RequestAccess_SuppressesNotificationWhenDailyCapReached()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var now = DateTimeOffset.UtcNow;
+
+            for (var index = 0; index < 50; index++)
+            {
+                dbContext.AccessRequests.Add(new AccessRequest
+                {
+                    Id = Guid.NewGuid(),
+                    Email = $"existing-{index}@glovelly.local",
+                    NormalizedEmail = $"existing-{index}@glovelly.local",
+                    RequestedAtUtc = now.AddMinutes(-index),
+                    NotificationSentAtUtc = now.AddMinutes(-index)
+                });
+            }
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        var request = CreateAccessRequest("quota-target@glovelly.local", "198.51.100.15");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Access request submitted.", await ReadMessageAsync(response));
+        Assert.Empty(_factory.Emails.SentEmails);
+
+        using var verificationScope = _factory.Services.CreateScope();
+        var verificationDbContext = verificationScope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var storedRequest = await verificationDbContext.AccessRequests
+            .OrderByDescending(value => value.RequestedAtUtc)
+            .FirstAsync(value => value.NormalizedEmail == "quota-target@glovelly.local");
+
+        Assert.Null(storedRequest.NotificationSentAtUtc);
+        Assert.Equal(
+            AccessRequestWorkflowService.DailyNotificationCapSuppressionReason,
+            storedRequest.NotificationSuppressionReason);
+    }
+
+    [Fact]
+    public async Task RequestAccess_ReturnsGenericSuccess_WhenRateLimited()
+    {
+        var responses = new List<HttpResponseMessage>();
+
+        for (var index = 0; index < 6; index++)
+        {
+            var request = CreateAccessRequest($"rate-limit-{index}@glovelly.local", "198.51.100.16");
+            responses.Add(await _client.SendAsync(request));
+        }
+
+        Assert.All(responses, response => Assert.Equal(HttpStatusCode.OK, response.StatusCode));
+
+        foreach (var response in responses)
+        {
+            Assert.Equal("Access request submitted.", await ReadMessageAsync(response));
+        }
+
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        Assert.Equal(5, await dbContext.AccessRequests.CountAsync());
+        Assert.Equal(5, _factory.Emails.SentEmails.Count);
+    }
+
+    private static async Task<string?> ReadMessageAsync(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        return payload.GetProperty("message").GetString();
+    }
+
+    private static HttpRequestMessage CreateAccessRequest(string email, string remoteIp)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/access/request");
+        request.Headers.Add("X-Test-Email", email);
+        request.Headers.Add("X-Test-Remote-Ip", remoteIp);
+        return request;
     }
 }

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -3,8 +3,10 @@ using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 
 namespace Glovelly.Api.Configuration;
 
@@ -15,10 +17,15 @@ internal static class InfrastructureServiceCollectionExtensions
         IConfiguration configuration,
         StartupSettings settings)
     {
+        var accessRequestSettings = configuration.GetSection(AccessRequestProtectionSettings.SectionName)
+            .Get<AccessRequestProtectionSettings>() ?? new AccessRequestProtectionSettings();
+
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen();
         services.AddOptions<EmailSettings>()
             .Bind(configuration.GetSection("Email"));
+        services.AddOptions<AccessRequestProtectionSettings>()
+            .Bind(configuration.GetSection(AccessRequestProtectionSettings.SectionName));
         services.AddGlovellyApplicationServices();
         services.ConfigureHttpJsonOptions(options =>
         {
@@ -61,6 +68,36 @@ internal static class InfrastructureServiceCollectionExtensions
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(GlovellyClaimTypes.UserId);
                 policy.RequireRole(UserRole.Admin.ToString());
+            });
+        });
+        services.AddRateLimiter(options =>
+        {
+            options.OnRejected = async (context, cancellationToken) =>
+            {
+                var logger = context.HttpContext.RequestServices
+                    .GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("Glovelly.AccessRequests");
+                logger.LogWarning(
+                    "Access request rate limit triggered for IP {RemoteIpAddress}.",
+                    context.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "(unknown)");
+                context.HttpContext.Response.StatusCode = StatusCodes.Status200OK;
+                context.HttpContext.Response.ContentType = "application/json";
+                await context.HttpContext.Response.WriteAsync(
+                    "{\"message\":\"Access request submitted.\"}",
+                    cancellationToken);
+            };
+            options.AddPolicy<string>("PublicAccessRequest", httpContext =>
+            {
+                var remoteIp = AccessRequestRequestContext.ResolveRateLimitPartitionKey(httpContext);
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    remoteIp,
+                    _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = accessRequestSettings.PerIpShortWindowPermitLimit,
+                        Window = accessRequestSettings.PerIpShortWindow,
+                        QueueLimit = 0,
+                        AutoReplenishment = true
+                    });
             });
         });
 

--- a/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
@@ -33,6 +33,7 @@ internal static class WebApplicationExtensions
             app.UseCors(settings.DevCorsPolicy);
         }
 
+        app.UseRateLimiter();
         app.UseAuthentication();
         app.UseAuthorization();
         app.UseDefaultFiles();

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -5,6 +5,7 @@ namespace Glovelly.Api.Data;
 
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
+    public DbSet<AccessRequest> AccessRequests => Set<AccessRequest>();
     public DbSet<User> Users => Set<User>();
     public DbSet<Client> Clients => Set<Client>();
     public DbSet<Gig> Gigs => Set<Gig>();
@@ -15,6 +16,30 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Entity<AccessRequest>(entity =>
+        {
+            entity.HasKey(accessRequest => accessRequest.Id);
+            entity.Property(accessRequest => accessRequest.Email)
+                .IsRequired()
+                .HasMaxLength(320);
+            entity.Property(accessRequest => accessRequest.NormalizedEmail)
+                .IsRequired()
+                .HasMaxLength(320);
+            entity.Property(accessRequest => accessRequest.DisplayName)
+                .HasMaxLength(200);
+            entity.Property(accessRequest => accessRequest.Subject)
+                .HasMaxLength(255);
+            entity.Property(accessRequest => accessRequest.RequestedAtUtc)
+                .IsRequired();
+            entity.Property(accessRequest => accessRequest.RequestIpHash)
+                .HasMaxLength(128);
+            entity.Property(accessRequest => accessRequest.NotificationSuppressionReason)
+                .HasMaxLength(100);
+            entity.HasIndex(accessRequest => accessRequest.NormalizedEmail);
+            entity.HasIndex(accessRequest => accessRequest.NotificationSentAtUtc);
+            entity.HasIndex(accessRequest => accessRequest.RequestedAtUtc);
+        });
+
         modelBuilder.Entity<User>(entity =>
         {
             entity.HasKey(user => user.Id);

--- a/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
@@ -6,11 +6,15 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using System.Net;
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Glovelly.Api.Endpoints;
 
 internal static class AccessEndpoints
 {
+    private const string GenericSuccessMessage = "Access request submitted.";
+
     public static IEndpointRouteBuilder MapAccessEndpoints(this IEndpointRouteBuilder app, StartupSettings settings)
     {
         var access = app.MapGroup("/access")
@@ -22,12 +26,13 @@ internal static class AccessEndpoints
             ClaimsPrincipal user,
             AppDbContext dbContext,
             IEmailSender emailSender,
+            AccessRequestWorkflowService workflowService,
+            HttpContext httpContext,
             ILoggerFactory loggerFactory,
             CancellationToken cancellationToken) =>
         {
             var logger = loggerFactory.CreateLogger("Glovelly.AccessRequests");
-            var requestedAtUtc = DateTimeOffset.UtcNow;
-            var requester = AccessRequestEmailRequest.FromClaims(user, requestedAtUtc);
+            var requester = AccessRequestEmailRequest.FromClaims(user);
 
             if (string.IsNullOrWhiteSpace(requester.Email))
             {
@@ -36,6 +41,17 @@ internal static class AccessEndpoints
                     requester.Subject ?? "(missing)");
                 return Results.BadRequest(new { message = "A verified email address is required to request access." });
             }
+
+            var workflowResult = await workflowService.RecordAsync(
+                requester.Email,
+                requester.DisplayName,
+                requester.Subject,
+                AccessRequestRequestContext.ResolveRemoteIpAddress(httpContext),
+                cancellationToken);
+            var notificationRequest = requester with
+            {
+                RequestedAtUtc = workflowResult.AccessRequest.RequestedAtUtc
+            };
 
             var administrators = await dbContext.Users
                 .AsNoTracking()
@@ -57,18 +73,40 @@ internal static class AccessEndpoints
                     skippedAdminCount);
             }
 
+            if (!workflowResult.ShouldSendNotification)
+            {
+                logger.LogInformation(
+                    "Access request notification suppressed.");
+                return Results.Ok(new { message = GenericSuccessMessage });
+            }
+
+            if (recipients.Length == 0)
+            {
+                logger.LogWarning(
+                    "Access request recorded, but no administrator recipients were available for notification.");
+                return Results.Ok(new { message = GenericSuccessMessage });
+            }
+
             try
             {
+                logger.LogInformation(
+                    "Attempting access request notification send to {RecipientCount} administrator recipients.",
+                    recipients.Length);
+
                 foreach (var recipient in recipients)
                 {
                     await emailSender.SendAsync(
                         new EmailMessage(
                             To: [new EmailAddress(recipient)],
                             Subject: "Glovelly access request",
-                            PlainTextBody: BuildPlainTextBody(requester, environmentLabel),
-                            HtmlBody: BuildHtmlBody(requester, environmentLabel)),
+                            PlainTextBody: BuildPlainTextBody(notificationRequest, environmentLabel),
+                            HtmlBody: BuildHtmlBody(notificationRequest, environmentLabel)),
                         cancellationToken);
                 }
+
+                await workflowService.MarkNotificationSentAsync(
+                    workflowResult.AccessRequest.Id,
+                    cancellationToken);
             }
             catch (Exception exception)
             {
@@ -87,8 +125,9 @@ internal static class AccessEndpoints
                 requester.Subject ?? "(missing)",
                 recipients.Length);
 
-            return Results.Ok(new { message = "Access request submitted." });
-        });
+            return Results.Ok(new { message = GenericSuccessMessage });
+        })
+        .RequireRateLimiting("PublicAccessRequest");
 
         return app;
     }
@@ -203,14 +242,14 @@ internal static class AccessEndpoints
         string? Subject,
         DateTimeOffset RequestedAtUtc)
     {
-        public static AccessRequestEmailRequest FromClaims(ClaimsPrincipal user, DateTimeOffset requestedAtUtc)
+        public static AccessRequestEmailRequest FromClaims(ClaimsPrincipal user)
         {
             var email = AuthFlowSupport.NormalizeEmail(
                 user.FindFirstValue("email") ?? user.FindFirstValue(ClaimTypes.Email)) ?? string.Empty;
             var displayName = Normalize(user.FindFirstValue("name") ?? user.FindFirstValue(ClaimTypes.Name));
             var subject = Normalize(user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier));
 
-            return new AccessRequestEmailRequest(email, displayName, subject, requestedAtUtc);
+            return new AccessRequestEmailRequest(email, displayName, subject, DateTimeOffset.MinValue);
         }
 
         private static string? Normalize(string? value)

--- a/backend/Glovelly.Api/Models/AccessRequest.cs
+++ b/backend/Glovelly.Api/Models/AccessRequest.cs
@@ -1,0 +1,14 @@
+namespace Glovelly.Api.Models;
+
+public sealed class AccessRequest
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string NormalizedEmail { get; set; } = string.Empty;
+    public string? DisplayName { get; set; }
+    public string? Subject { get; set; }
+    public DateTimeOffset RequestedAtUtc { get; set; }
+    public string? RequestIpHash { get; set; }
+    public DateTimeOffset? NotificationSentAtUtc { get; set; }
+    public string? NotificationSuppressionReason { get; set; }
+}

--- a/backend/Glovelly.Api/Services/AccessRequestProtectionSettings.cs
+++ b/backend/Glovelly.Api/Services/AccessRequestProtectionSettings.cs
@@ -1,0 +1,14 @@
+namespace Glovelly.Api.Services;
+
+public sealed class AccessRequestProtectionSettings
+{
+    public const string SectionName = "AccessRequests";
+
+    public int PerIpShortWindowPermitLimit { get; set; } = 5;
+    public TimeSpan PerIpShortWindow { get; set; } = TimeSpan.FromMinutes(10);
+    public int PerIpDailyPermitLimit { get; set; } = 20;
+    public TimeSpan PerIpDailyWindow { get; set; } = TimeSpan.FromHours(24);
+    public TimeSpan EmailNotificationSuppressionWindow { get; set; } = TimeSpan.FromHours(12);
+    public int GlobalNotificationDailyCap { get; set; } = 50;
+    public TimeSpan GlobalNotificationWindow { get; set; } = TimeSpan.FromHours(24);
+}

--- a/backend/Glovelly.Api/Services/AccessRequestRequestContext.cs
+++ b/backend/Glovelly.Api/Services/AccessRequestRequestContext.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+using System.Net;
+
+namespace Glovelly.Api.Services;
+
+internal static class AccessRequestRequestContext
+{
+    private const string TestRemoteIpHeader = "X-Test-Remote-Ip";
+
+    public static IPAddress? ResolveRemoteIpAddress(HttpContext httpContext)
+    {
+        if (httpContext.Request.Headers.TryGetValue(TestRemoteIpHeader, out var values)
+            && IPAddress.TryParse(values.FirstOrDefault(), out var parsed))
+        {
+            return parsed;
+        }
+
+        return httpContext.Connection.RemoteIpAddress;
+    }
+
+    public static string ResolveRateLimitPartitionKey(HttpContext httpContext)
+    {
+        if (httpContext.Request.Headers.TryGetValue(TestRemoteIpHeader, out var values))
+        {
+            var testIp = values.FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(testIp))
+            {
+                return testIp.Trim();
+            }
+        }
+
+        return httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+}

--- a/backend/Glovelly.Api/Services/AccessRequestWorkflowService.cs
+++ b/backend/Glovelly.Api/Services/AccessRequestWorkflowService.cs
@@ -1,0 +1,136 @@
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Glovelly.Api.Services;
+
+public sealed class AccessRequestWorkflowService(
+    AppDbContext dbContext,
+    TimeProvider timeProvider,
+    IOptions<AccessRequestProtectionSettings> settings)
+{
+    public const string DuplicateEmailSuppressionReason = "duplicate_email_window";
+    public const string DailyIpSuppressionReason = "daily_ip_window";
+    public const string DailyNotificationCapSuppressionReason = "daily_notification_cap";
+    private readonly AccessRequestProtectionSettings _settings = settings.Value;
+
+    public async Task<AccessRequestWorkflowResult> RecordAsync(
+        string email,
+        string? displayName,
+        string? subject,
+        IPAddress? remoteIpAddress,
+        CancellationToken cancellationToken)
+    {
+        var requestedAtUtc = timeProvider.GetUtcNow();
+        var normalizedEmail = email.Trim().ToLowerInvariant();
+        var requestIpHash = HashIpAddress(remoteIpAddress);
+        var notificationSuppressionReason = await ResolveSuppressionReasonAsync(
+            normalizedEmail,
+            requestIpHash,
+            requestedAtUtc,
+            cancellationToken);
+
+        var request = new AccessRequest
+        {
+            Id = Guid.NewGuid(),
+            Email = email.Trim(),
+            NormalizedEmail = normalizedEmail,
+            DisplayName = Normalize(displayName),
+            Subject = Normalize(subject),
+            RequestedAtUtc = requestedAtUtc,
+            RequestIpHash = requestIpHash,
+            NotificationSuppressionReason = notificationSuppressionReason
+        };
+
+        dbContext.AccessRequests.Add(request);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new AccessRequestWorkflowResult(
+            request,
+            ShouldSendNotification: notificationSuppressionReason is null,
+            notificationSuppressionReason);
+    }
+
+    public async Task MarkNotificationSentAsync(Guid accessRequestId, CancellationToken cancellationToken)
+    {
+        var request = await dbContext.AccessRequests.FirstAsync(
+            value => value.Id == accessRequestId,
+            cancellationToken);
+        request.NotificationSentAtUtc = timeProvider.GetUtcNow();
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<string?> ResolveSuppressionReasonAsync(
+        string normalizedEmail,
+        string? requestIpHash,
+        DateTimeOffset requestedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(requestIpHash))
+        {
+            var dailyIpWindowStart = requestedAtUtc - _settings.PerIpDailyWindow;
+            var recentRequestCountForIp = await dbContext.AccessRequests
+                .AsNoTracking()
+                .CountAsync(
+                    value => value.RequestIpHash == requestIpHash
+                        && value.RequestedAtUtc >= dailyIpWindowStart,
+                    cancellationToken);
+
+            if (recentRequestCountForIp >= _settings.PerIpDailyPermitLimit)
+            {
+                return DailyIpSuppressionReason;
+            }
+        }
+
+        var duplicateWindowStart = requestedAtUtc - _settings.EmailNotificationSuppressionWindow;
+        var recentNotificationExists = await dbContext.AccessRequests
+            .AsNoTracking()
+            .AnyAsync(
+                value => value.NormalizedEmail == normalizedEmail
+                    && value.NotificationSentAtUtc != null
+                    && value.NotificationSentAtUtc >= duplicateWindowStart,
+                cancellationToken);
+
+        if (recentNotificationExists)
+        {
+            return DuplicateEmailSuppressionReason;
+        }
+
+        var globalWindowStart = requestedAtUtc - _settings.GlobalNotificationWindow;
+        var recentNotificationCount = await dbContext.AccessRequests
+            .AsNoTracking()
+            .CountAsync(
+                value => value.NotificationSentAtUtc != null
+                    && value.NotificationSentAtUtc >= globalWindowStart,
+                cancellationToken);
+
+        return recentNotificationCount >= _settings.GlobalNotificationDailyCap
+            ? DailyNotificationCapSuppressionReason
+            : null;
+    }
+
+    private static string? Normalize(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string? HashIpAddress(IPAddress? remoteIpAddress)
+    {
+        if (remoteIpAddress is null)
+        {
+            return null;
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(remoteIpAddress.ToString()));
+        return Convert.ToHexStringLower(bytes);
+    }
+}
+
+public sealed record AccessRequestWorkflowResult(
+    AccessRequest AccessRequest,
+    bool ShouldSendNotification,
+    string? NotificationSuppressionReason);

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -8,6 +8,8 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddGlovellyApplicationServices(this IServiceCollection services)
     {
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<AccessRequestWorkflowService>();
         services.AddScoped<IInvoiceWorkflowService, InvoiceWorkflowService>();
         services.AddOptions<ResendClientOptions>()
             .Configure<IOptions<EmailSettings>>((resendOptions, emailOptions) =>

--- a/backend/Glovelly.Api/appsettings.Development.json
+++ b/backend/Glovelly.Api/appsettings.Development.json
@@ -19,5 +19,14 @@
       "http://localhost:5173",
       "https://localhost:5173"
     ]
+  },
+  "AccessRequests": {
+    "PerIpShortWindowPermitLimit": 5,
+    "PerIpShortWindow": "00:10:00",
+    "PerIpDailyPermitLimit": 20,
+    "PerIpDailyWindow": "1.00:00:00",
+    "EmailNotificationSuppressionWindow": "12:00:00",
+    "GlobalNotificationDailyCap": 50,
+    "GlobalNotificationWindow": "1.00:00:00"
   }
 }

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -24,5 +24,14 @@
   "Cors": {
     "AllowedOrigins": []
   },
+  "AccessRequests": {
+    "PerIpShortWindowPermitLimit": 5,
+    "PerIpShortWindow": "00:10:00",
+    "PerIpDailyPermitLimit": 20,
+    "PerIpDailyWindow": "1.00:00:00",
+    "EmailNotificationSuppressionWindow": "12:00:00",
+    "GlobalNotificationDailyCap": 50,
+    "GlobalNotificationWindow": "1.00:00:00"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## What changed

This adds abuse controls around the public access-request flow so outbound email is treated as a bounded side effect rather than an unguarded action.

The branch introduces:

- persisted `AccessRequests` records for request history and decision-making
- per-IP short-window endpoint rate limiting with a generic success response on rejection
- per-email notification suppression for repeated submissions inside the configured window
- a global daily notification cap for this workflow
- structured logging around throttling, suppression, and notification send attempts
- test coverage for duplicate suppression, daily cap behaviour, and generic-success rate limiting

## Why

Issue #63 is about protecting the unauthenticated enrolment/access-request path from noisy or repeated submissions exhausting outbound email quota or turning the app into a noisy notification cannon.

The main goal here is to keep legitimate UX simple while bounding notification behaviour and preserving room for stronger anti-abuse measures later.

## Impact

The access-request endpoint now records requests and decides whether notification should be sent after abuse-control checks pass.

Caller-facing behaviour stays intentionally bland for throttled and suppressed cases, while actual mail dispatch remains visible through structured logs and tests.

## Validation

- `dotnet test glovelly.sln`
