### PR TITLE
[codex] Add AccessRequests retention cleanup

### DIFF
--- a/backend/Glovelly.Api.Tests/AccessRequestRetentionServiceTests.cs
+++ b/backend/Glovelly.Api.Tests/AccessRequestRetentionServiceTests.cs
@@ -1,0 +1,88 @@
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class AccessRequestRetentionServiceTests
+{
+    [Fact]
+    public async Task CleanupIfDueAsync_DeletesRequestsOlderThanRetentionWindow_WhenProbeFindsStaleRows()
+    {
+        var now = new DateTimeOffset(2026, 4, 22, 12, 0, 0, TimeSpan.Zero);
+        await using var dbContext = CreateDbContext();
+        dbContext.AccessRequests.AddRange(
+            CreateRequest("expired@glovelly.local", now.AddDays(-183)),
+            CreateRequest("boundary@glovelly.local", now.AddDays(-180)),
+            CreateRequest("recent@glovelly.local", now.AddDays(-30)));
+        await dbContext.SaveChangesAsync();
+
+        var service = CreateService(dbContext, now);
+
+        await service.CleanupIfDueAsync(CancellationToken.None);
+
+        var remainingEmails = await dbContext.AccessRequests
+            .OrderBy(value => value.RequestedAtUtc)
+            .Select(value => value.NormalizedEmail)
+            .ToListAsync();
+
+        Assert.Equal(
+            ["boundary@glovelly.local", "recent@glovelly.local"],
+            remainingEmails);
+    }
+
+    [Fact]
+    public async Task CleanupIfDueAsync_SkipsCleanupWhenNoRowsExceedRetentionPlusSlack()
+    {
+        var now = new DateTimeOffset(2026, 4, 22, 12, 0, 0, TimeSpan.Zero);
+        await using var dbContext = CreateDbContext();
+        dbContext.AccessRequests.AddRange(
+            CreateRequest("expired@glovelly.local", now.AddDays(-181)),
+            CreateRequest("recent@glovelly.local", now.AddDays(-10)));
+        await dbContext.SaveChangesAsync();
+
+        var service = CreateService(dbContext, now);
+
+        await service.CleanupIfDueAsync(CancellationToken.None);
+
+        Assert.Equal(2, await dbContext.AccessRequests.CountAsync());
+    }
+
+    private static AccessRequestRetentionService CreateService(AppDbContext dbContext, DateTimeOffset now)
+    {
+        return new AccessRequestRetentionService(
+            dbContext,
+            new FixedTimeProvider(now),
+            Options.Create(new AccessRequestProtectionSettings()),
+            NullLogger<AccessRequestRetentionService>.Instance);
+    }
+
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"access-request-retention-{Guid.NewGuid()}")
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static AccessRequest CreateRequest(string email, DateTimeOffset requestedAtUtc)
+    {
+        return new AccessRequest
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            NormalizedEmail = email,
+            RequestedAtUtc = requestedAtUtc
+        };
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/backend/Glovelly.Api/Services/AccessRequestProtectionSettings.cs
+++ b/backend/Glovelly.Api/Services/AccessRequestProtectionSettings.cs
@@ -11,4 +11,6 @@ public sealed class AccessRequestProtectionSettings
     public TimeSpan EmailNotificationSuppressionWindow { get; set; } = TimeSpan.FromHours(12);
     public int GlobalNotificationDailyCap { get; set; } = 50;
     public TimeSpan GlobalNotificationWindow { get; set; } = TimeSpan.FromHours(24);
+    public TimeSpan RetentionWindow { get; set; } = TimeSpan.FromDays(180);
+    public TimeSpan CleanupSlack { get; set; } = TimeSpan.FromDays(2);
 }

--- a/backend/Glovelly.Api/Services/AccessRequestRetentionService.cs
+++ b/backend/Glovelly.Api/Services/AccessRequestRetentionService.cs
@@ -1,0 +1,80 @@
+using Glovelly.Api.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Glovelly.Api.Services;
+
+public sealed class AccessRequestRetentionService(
+    AppDbContext dbContext,
+    TimeProvider timeProvider,
+    IOptions<AccessRequestProtectionSettings> settings,
+    ILogger<AccessRequestRetentionService> logger)
+{
+    private readonly AccessRequestProtectionSettings _settings = settings.Value;
+
+    public async Task CleanupIfDueAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var now = timeProvider.GetUtcNow();
+            var probeCutoffUtc = now - _settings.RetentionWindow - _settings.CleanupSlack;
+            var cleanupIsDue = await dbContext.AccessRequests
+                .AsNoTracking()
+                .AnyAsync(value => value.RequestedAtUtc < probeCutoffUtc, cancellationToken);
+
+            if (!cleanupIsDue)
+            {
+                return;
+            }
+
+            await CleanupExpiredRequestsAsync(cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Access request retention cleanup attempt failed.");
+        }
+    }
+
+    internal async Task<int> CleanupExpiredRequestsAsync(CancellationToken cancellationToken)
+    {
+        var cutoffUtc = timeProvider.GetUtcNow() - _settings.RetentionWindow;
+
+        logger.LogInformation(
+            "Access request retention cleanup started with cutoff {CutoffUtc}.",
+            cutoffUtc);
+
+        try
+        {
+            var expiredRequests = await dbContext.AccessRequests
+                .Where(value => value.RequestedAtUtc < cutoffUtc)
+                .ToListAsync(cancellationToken);
+
+            if (expiredRequests.Count == 0)
+            {
+                logger.LogInformation(
+                    "Access request retention cleanup completed with cutoff {CutoffUtc}. DeletedRows: {DeletedRows}.",
+                    cutoffUtc,
+                    0);
+                return 0;
+            }
+
+            dbContext.AccessRequests.RemoveRange(expiredRequests);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            logger.LogInformation(
+                "Access request retention cleanup completed with cutoff {CutoffUtc}. DeletedRows: {DeletedRows}.",
+                cutoffUtc,
+                expiredRequests.Count);
+
+            return expiredRequests.Count;
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "Access request retention cleanup failed with cutoff {CutoffUtc}.",
+                cutoffUtc);
+            throw;
+        }
+    }
+}

--- a/backend/Glovelly.Api/Services/AccessRequestWorkflowService.cs
+++ b/backend/Glovelly.Api/Services/AccessRequestWorkflowService.cs
@@ -11,7 +11,8 @@ namespace Glovelly.Api.Services;
 public sealed class AccessRequestWorkflowService(
     AppDbContext dbContext,
     TimeProvider timeProvider,
-    IOptions<AccessRequestProtectionSettings> settings)
+    IOptions<AccessRequestProtectionSettings> settings,
+    AccessRequestRetentionService retentionService)
 {
     public const string DuplicateEmailSuppressionReason = "duplicate_email_window";
     public const string DailyIpSuppressionReason = "daily_ip_window";
@@ -48,6 +49,7 @@ public sealed class AccessRequestWorkflowService(
 
         dbContext.AccessRequests.Add(request);
         await dbContext.SaveChangesAsync(cancellationToken);
+        await retentionService.CleanupIfDueAsync(cancellationToken);
 
         return new AccessRequestWorkflowResult(
             request,

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(TimeProvider.System);
         services.AddScoped<AccessRequestWorkflowService>();
+        services.AddScoped<AccessRequestRetentionService>();
         services.AddScoped<IInvoiceWorkflowService, InvoiceWorkflowService>();
         services.AddOptions<ResendClientOptions>()
             .Configure<IOptions<EmailSettings>>((resendOptions, emailOptions) =>

--- a/backend/Glovelly.Api/appsettings.Development.json
+++ b/backend/Glovelly.Api/appsettings.Development.json
@@ -27,6 +27,8 @@
     "PerIpDailyWindow": "1.00:00:00",
     "EmailNotificationSuppressionWindow": "12:00:00",
     "GlobalNotificationDailyCap": 50,
-    "GlobalNotificationWindow": "1.00:00:00"
+    "GlobalNotificationWindow": "1.00:00:00",
+    "RetentionWindow": "180.00:00:00",
+    "CleanupSlack": "2.00:00:00"
   }
 }

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -31,7 +31,9 @@
     "PerIpDailyWindow": "1.00:00:00",
     "EmailNotificationSuppressionWindow": "12:00:00",
     "GlobalNotificationDailyCap": 50,
-    "GlobalNotificationWindow": "1.00:00:00"
+    "GlobalNotificationWindow": "1.00:00:00",
+    "RetentionWindow": "180.00:00:00",
+    "CleanupSlack": "2.00:00:00"
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## What changed
- add explicit `AccessRequests` retention settings for a 180-day retention window and a 48-hour cleanup slack
- add an `AccessRequestRetentionService` that opportunistically probes for stale rows and deletes expired `AccessRequests`
- trigger retention cleanup from the access-request workflow instead of using a hosted background service
- add focused tests covering cleanup execution and the slack-gated no-op path

## Why
`AccessRequests` stores abuse-control and notification-suppression data that is useful in the short term but should not grow without bounds. For Cloud Run, an on-demand cleanup path is a better fit than an always-on hosted service because instances are short-lived and can scale out unpredictably.

## Impact
- keeps the public access-request flow behavior unchanged for callers
- bounds long-term growth of the `AccessRequests` table
- keeps cleanup lightweight by only attempting deletion when rows older than `retention + slack` exist

## Validation
- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj`
