### PR TITLE
Add access requests to the unauthorized sign-in flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,11 +129,14 @@ jobs:
           image: ${{ env.IMAGE_URI }}:sha-${{ github.sha }}
           env_vars: |-
             App__DeploymentName=Production
+            Email__Mode=Resend
+            Email__Resend__DefaultFromDisplayName=Glovelly
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest
             ConnectionStrings__Glovelly=glovelly-connection-string:latest
             Email__Resend__ApiKey=glovelly-resend-api-key:latest
+            Email__Resend__DefaultFromAddress=glovelly-resend-default-from-address:latest
           secrets_update_strategy: merge
           flags: >-
             --allow-unauthenticated
@@ -153,11 +156,14 @@ jobs:
           image: ${{ env.IMAGE_URI }}:sha-${{ github.sha }}
           env_vars: |-
             App__DeploymentName=Staging
+            Email__Mode=Resend
+            Email__Resend__DefaultFromDisplayName=Glovelly
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest
             ConnectionStrings__Glovelly=glovelly-connection-string-staging:latest
             Email__Resend__ApiKey=glovelly-resend-api-key:latest
+            Email__Resend__DefaultFromAddress=glovelly-resend-default-from-address:latest
           secrets_update_strategy: merge
           flags: >-
             --allow-unauthenticated

--- a/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AccessEndpointsTests.cs
@@ -5,8 +5,9 @@ using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Glovelly.Api.Tests.Infrastructure;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -27,7 +28,7 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
     public async Task RequestAccess_SendsNotificationToEachAdministratorWithEmail()
     {
         using var scope = _factory.Services.CreateScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<Glovelly.Api.Data.AppDbContext>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         dbContext.Users.Add(new User
         {
             Id = Guid.NewGuid(),
@@ -39,12 +40,13 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
         });
         await dbContext.SaveChangesAsync();
 
-        var request = CreateAccessRequest("new-user@glovelly.local", "198.51.100.10");
-        request.Headers.Add("X-Test-Include-UserId", "false");
-        request.Headers.Add("X-Test-Name", "New User");
-        request.Headers.Add("X-Test-Subject", "google-sub-new-user");
-
-        var response = await _client.SendAsync(request);
+        var response = await _client.PostAsJsonAsync("/access/request", new
+        {
+            accessRequestToken = CreateAccessRequestToken(
+                "new-user@glovelly.local",
+                "New User",
+                "google-sub-new-user"),
+        });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("Access request submitted.", await ReadMessageAsync(response));
@@ -82,7 +84,7 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
     public async Task RequestAccess_SkipsAdministratorsWithoutEmail()
     {
         using var scope = _factory.Services.CreateScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<Glovelly.Api.Data.AppDbContext>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         dbContext.Users.Add(new User
         {
             Id = Guid.NewGuid(),
@@ -94,7 +96,13 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
         });
         await dbContext.SaveChangesAsync();
 
-        var response = await _client.SendAsync(CreateAccessRequest(TestAuthContext.DefaultEmail, "198.51.100.11"));
+        var response = await _client.PostAsJsonAsync("/access/request", new
+        {
+            accessRequestToken = CreateAccessRequestToken(
+                "new-user@glovelly.local",
+                "New User",
+                "google-sub-new-user"),
+        });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("Access request submitted.", await ReadMessageAsync(response));
@@ -105,9 +113,13 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task RequestAccess_ReturnsBadRequest_WhenEmailClaimMissing()
     {
-        var request = CreateAccessRequest("   ", "198.51.100.12");
-
-        var response = await _client.SendAsync(request);
+        var response = await _client.PostAsJsonAsync("/access/request", new
+        {
+            accessRequestToken = CreateAccessRequestToken(
+                "   ",
+                "New User",
+                "google-sub-new-user"),
+        });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Empty(_factory.Emails.SentEmails);
@@ -118,7 +130,13 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         _factory.Emails.ExceptionToThrow = new InvalidOperationException("SMTP unavailable");
 
-        var response = await _client.SendAsync(CreateAccessRequest(TestAuthContext.DefaultEmail, "198.51.100.13"));
+        var response = await _client.PostAsJsonAsync("/access/request", new
+        {
+            accessRequestToken = CreateAccessRequestToken(
+                "new-user@glovelly.local",
+                "New User",
+                "google-sub-new-user"),
+        });
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
@@ -132,8 +150,8 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task RequestAccess_SuppressesRepeatNotificationsForSameEmailWithinWindow()
     {
-        var firstRequest = CreateAccessRequest("repeat-user@glovelly.local", "198.51.100.14");
-        var secondRequest = CreateAccessRequest("REPEAT-USER@glovelly.local", "198.51.100.14");
+        var firstRequest = CreateAccessRequestWithToken("repeat-user@glovelly.local", "198.51.100.14");
+        var secondRequest = CreateAccessRequestWithToken("REPEAT-USER@glovelly.local", "198.51.100.14");
 
         var firstResponse = await _client.SendAsync(firstRequest);
         var secondResponse = await _client.SendAsync(secondRequest);
@@ -182,7 +200,7 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
             await dbContext.SaveChangesAsync();
         }
 
-        var request = CreateAccessRequest("quota-target@glovelly.local", "198.51.100.15");
+        var request = CreateAccessRequestWithToken("quota-target@glovelly.local", "198.51.100.15");
 
         var response = await _client.SendAsync(request);
 
@@ -209,7 +227,7 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
 
         for (var index = 0; index < 6; index++)
         {
-            var request = CreateAccessRequest($"rate-limit-{index}@glovelly.local", "198.51.100.16");
+            var request = CreateAccessRequestWithToken($"rate-limit-{index}@glovelly.local", "198.51.100.16");
             responses.Add(await _client.SendAsync(request));
         }
 
@@ -227,17 +245,55 @@ public sealed class AccessEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(5, _factory.Emails.SentEmails.Count);
     }
 
+    [Fact]
+    public async Task RequestAccess_AllowsAnonymousSubmissionWithValidAccessRequestToken()
+    {
+        var token = CreateAccessRequestToken("new-user@glovelly.local", "New User", "google-sub-new-user");
+
+        var response = await _client.PostAsJsonAsync("/access/request", new
+        {
+            accessRequestToken = token,
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Single(_factory.Emails.SentEmails);
+        Assert.Equal("test-admin@glovelly.local", _factory.Emails.SentEmails[0].To.Single().Address);
+        Assert.Contains("User email: new-user@glovelly.local", _factory.Emails.SentEmails[0].PlainTextBody);
+        Assert.Contains("User display name: New User", _factory.Emails.SentEmails[0].PlainTextBody);
+    }
+
     private static async Task<string?> ReadMessageAsync(HttpResponseMessage response)
     {
         var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
         return payload.GetProperty("message").GetString();
     }
 
-    private static HttpRequestMessage CreateAccessRequest(string email, string remoteIp)
+    private HttpRequestMessage CreateAccessRequestWithToken(string email, string remoteIp)
     {
         var request = new HttpRequestMessage(HttpMethod.Post, "/access/request");
-        request.Headers.Add("X-Test-Email", email);
         request.Headers.Add("X-Test-Remote-Ip", remoteIp);
+        request.Content = JsonContent.Create(new
+        {
+            accessRequestToken = CreateAccessRequestToken(email, "New User", "google-sub-new-user"),
+        });
         return request;
+    }
+
+    private string CreateAccessRequestToken(string email, string displayName, string subject)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dataProtectionProvider = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
+        var protector = dataProtectionProvider
+            .CreateProtector("Glovelly.AccessRequest")
+            .ToTimeLimitedDataProtector();
+
+        return protector.Protect(
+            JsonSerializer.Serialize(new
+            {
+                email,
+                displayName,
+                subject,
+            }),
+            lifetime: TimeSpan.FromMinutes(15));
     }
 }

--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -9,10 +11,12 @@ namespace Glovelly.Api.Tests;
 public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly GlovellyApiFactory _factory;
     private readonly HttpClient _client;
 
     public AuthEndpointsTests(GlovellyApiFactory factory)
     {
+        _factory = factory;
         _client = factory.CreateClient();
     }
 
@@ -82,5 +86,36 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(
             "Invoice filename pattern cannot be empty or whitespace.",
             problem.GetProperty("errors").GetProperty("invoiceFilenamePattern")[0].GetString());
+    }
+
+    [Fact]
+    public async Task DeniedPage_ShowsRequestAccessUi_WhenSignedRequestTokenProvided()
+    {
+        var token = CreateAccessRequestToken("new-user@glovelly.local", "New User", "google-sub-new-user");
+
+        var response = await _client.GetAsync($"/auth/denied?code=not_authorized&request={Uri.EscapeDataString(token)}");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("Request access", html);
+        Assert.Contains("data-access-request-button", html);
+    }
+
+    private string CreateAccessRequestToken(string email, string displayName, string subject)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dataProtectionProvider = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
+        var protector = dataProtectionProvider
+            .CreateProtector("Glovelly.AccessRequest")
+            .ToTimeLimitedDataProtector();
+
+        return protector.Protect(
+            JsonSerializer.Serialize(new
+            {
+                email,
+                displayName,
+                subject,
+            }),
+            lifetime: TimeSpan.FromMinutes(15));
     }
 }

--- a/backend/Glovelly.Api/Configuration/AuthenticationServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/AuthenticationServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Glovelly.Api.Auth;
 using Glovelly.Api.Data;
 using Glovelly.Api.Endpoints;
+using Microsoft.AspNetCore.DataProtection;
 using Glovelly.Api.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -85,9 +86,12 @@ internal static class AuthenticationServiceCollectionExtensions
                         context.HandleResponse();
 
                         var failureCode = AuthFlowSupport.GetAuthenticationFailureCode(context.Failure);
+                        string? requestToken = null;
+                        context.Properties?.Items.TryGetValue("access_request_token", out requestToken);
+                        var deniedPath = AuthFlowSupport.BuildDeniedPath(failureCode, requestToken);
                         var redirectUri = AuthFlowSupport.BuildSafeRedirectUri(
                             context.HttpContext,
-                            $"/auth/denied?code={Uri.EscapeDataString(failureCode)}");
+                            deniedPath);
 
                         context.Response.Redirect(redirectUri);
                         return Task.CompletedTask;
@@ -168,7 +172,15 @@ internal static class AuthenticationServiceCollectionExtensions
 
             if (user is null)
             {
-                context.Fail("You do not have access to Glovelly.");
+                var requestToken = AuthFlowSupport.CreateAccessRequestToken(
+                    principal,
+                    context.HttpContext.RequestServices.GetRequiredService<IDataProtectionProvider>());
+                var redirectUri = AuthFlowSupport.BuildSafeRedirectUri(
+                    context.HttpContext,
+                    AuthFlowSupport.BuildDeniedPath("not_authorized", requestToken));
+
+                context.HandleResponse();
+                context.Response.Redirect(redirectUri);
                 return;
             }
 

--- a/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
@@ -2,6 +2,7 @@ using Glovelly.Api.Configuration;
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using System.Net;
@@ -18,21 +19,34 @@ internal static class AccessEndpoints
     public static IEndpointRouteBuilder MapAccessEndpoints(this IEndpointRouteBuilder app, StartupSettings settings)
     {
         var access = app.MapGroup("/access")
-            .WithTags("Access")
-            .RequireAuthorization();
+            .WithTags("Access");
         var environmentLabel = ResolveEnvironmentLabel(settings);
 
-        access.MapPost("/request", [Authorize] async (
+        access.MapPost("/request", async (
+            AccessRequestSubmission? request,
             ClaimsPrincipal user,
             AppDbContext dbContext,
             IEmailSender emailSender,
             AccessRequestWorkflowService workflowService,
             HttpContext httpContext,
+            IDataProtectionProvider dataProtectionProvider,
             ILoggerFactory loggerFactory,
             CancellationToken cancellationToken) =>
         {
             var logger = loggerFactory.CreateLogger("Glovelly.AccessRequests");
-            var requester = AccessRequestEmailRequest.FromClaims(user);
+            var requestedAtUtc = DateTimeOffset.UtcNow;
+            var requester =
+                AccessRequestEmailRequest.FromClaims(user, requestedAtUtc) ??
+                AccessRequestEmailRequest.FromToken(
+                    request?.AccessRequestToken,
+                    dataProtectionProvider,
+                    requestedAtUtc,
+                    logger);
+
+            if (requester is null)
+            {
+                return Results.Unauthorized();
+            }
 
             if (string.IsNullOrWhiteSpace(requester.Email))
             {
@@ -127,7 +141,8 @@ internal static class AccessEndpoints
 
             return Results.Ok(new { message = GenericSuccessMessage });
         })
-        .RequireRateLimiting("PublicAccessRequest");
+        .RequireRateLimiting("PublicAccessRequest")
+        .AllowAnonymous();
 
         return app;
     }
@@ -242,14 +257,39 @@ internal static class AccessEndpoints
         string? Subject,
         DateTimeOffset RequestedAtUtc)
     {
-        public static AccessRequestEmailRequest FromClaims(ClaimsPrincipal user)
+        public static AccessRequestEmailRequest? FromClaims(ClaimsPrincipal user, DateTimeOffset requestedAtUtc)
         {
+            if (user.Identity?.IsAuthenticated != true)
+            {
+                return null;
+            }
+
             var email = AuthFlowSupport.NormalizeEmail(
                 user.FindFirstValue("email") ?? user.FindFirstValue(ClaimTypes.Email)) ?? string.Empty;
             var displayName = Normalize(user.FindFirstValue("name") ?? user.FindFirstValue(ClaimTypes.Name));
             var subject = Normalize(user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier));
 
-            return new AccessRequestEmailRequest(email, displayName, subject, DateTimeOffset.MinValue);
+            return new AccessRequestEmailRequest(email, displayName, subject, requestedAtUtc);
+        }
+
+        public static AccessRequestEmailRequest? FromToken(
+            string? accessRequestToken,
+            IDataProtectionProvider dataProtectionProvider,
+            DateTimeOffset requestedAtUtc,
+            ILogger logger)
+        {
+            var tokenIdentity = AuthFlowSupport.ReadAccessRequestIdentity(
+                accessRequestToken,
+                dataProtectionProvider,
+                logger);
+
+            return tokenIdentity is null
+                ? null
+                : new AccessRequestEmailRequest(
+                    tokenIdentity.Email,
+                    tokenIdentity.DisplayName,
+                    tokenIdentity.Subject,
+                    requestedAtUtc);
         }
 
         private static string? Normalize(string? value)
@@ -257,4 +297,6 @@ internal static class AccessEndpoints
             return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
         }
     }
+
+    internal sealed record AccessRequestSubmission(string? AccessRequestToken);
 }

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -144,10 +144,11 @@ internal static class AuthEndpoints
             });
         }
 
-        auth.MapGet("/denied", (string? code) =>
+        auth.MapGet("/denied", (HttpContext httpContext, string? code) =>
         {
             var failureCode = string.IsNullOrWhiteSpace(code) ? "not_authorized" : code;
-            var html = AuthFlowSupport.RenderUnauthorizedPage(failureCode);
+            var accessRequestToken = httpContext.Request.Query["request"].FirstOrDefault();
+            var html = AuthFlowSupport.RenderUnauthorizedPage(failureCode, accessRequestToken);
             return Results.Content(html, "text/html; charset=utf-8");
         });
 

--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -1,9 +1,15 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace Glovelly.Api.Endpoints;
 
 internal static class AuthFlowSupport
 {
+    private const string AccessRequestProtectionPurpose = "Glovelly.AccessRequest";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     public static string BuildSafeRedirectUri(HttpContext httpContext, string? returnUrl)
     {
         if (string.IsNullOrWhiteSpace(returnUrl))
@@ -27,6 +33,13 @@ internal static class AuthFlowSupport
         }
 
         return returnUrl.StartsWith('/') ? returnUrl : "/";
+    }
+
+    public static string BuildDeniedPath(string failureCode, string? accessRequestToken = null)
+    {
+        return string.IsNullOrWhiteSpace(accessRequestToken)
+            ? $"/auth/denied?code={Uri.EscapeDataString(failureCode)}"
+            : $"/auth/denied?code={Uri.EscapeDataString(failureCode)}&request={Uri.EscapeDataString(accessRequestToken)}";
     }
 
     public static bool IsApiRequest(HttpRequest request)
@@ -111,9 +124,81 @@ internal static class AuthFlowSupport
         };
     }
 
-    public static string RenderUnauthorizedPage(string failureCode)
+    public static string? CreateAccessRequestToken(
+        ClaimsPrincipal principal,
+        IDataProtectionProvider dataProtectionProvider)
+    {
+        var email = NormalizeEmail(
+            principal.FindFirstValue("email") ?? principal.FindFirstValue(ClaimTypes.Email));
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return null;
+        }
+
+        if (TryGetEmailVerified(principal) == false)
+        {
+            return null;
+        }
+
+        var payload = new AccessRequestIdentity(
+            email,
+            Normalize(principal.FindFirstValue("name") ?? principal.FindFirstValue(ClaimTypes.Name)),
+            Normalize(principal.FindFirstValue("sub") ?? principal.FindFirstValue(ClaimTypes.NameIdentifier)));
+
+        var protector = dataProtectionProvider
+            .CreateProtector(AccessRequestProtectionPurpose)
+            .ToTimeLimitedDataProtector();
+
+        return protector.Protect(
+            JsonSerializer.Serialize(payload, JsonOptions),
+            lifetime: TimeSpan.FromMinutes(15));
+    }
+
+    public static AccessRequestIdentity? ReadAccessRequestIdentity(
+        string? accessRequestToken,
+        IDataProtectionProvider dataProtectionProvider,
+        ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(accessRequestToken))
+        {
+            return null;
+        }
+
+        try
+        {
+            var protector = dataProtectionProvider
+                .CreateProtector(AccessRequestProtectionPurpose)
+                .ToTimeLimitedDataProtector();
+            var payloadJson = protector.Unprotect(accessRequestToken, out _);
+            var payload = JsonSerializer.Deserialize<AccessRequestIdentity>(payloadJson, JsonOptions);
+
+            if (payload is null || payload.Email is null)
+            {
+                return null;
+            }
+
+            return payload with
+            {
+                Email = NormalizeEmail(payload.Email) ?? string.Empty,
+                DisplayName = Normalize(payload.DisplayName),
+                Subject = Normalize(payload.Subject),
+            };
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Rejected invalid or expired access request token.");
+            return null;
+        }
+    }
+
+    public static string RenderUnauthorizedPage(string failureCode, string? accessRequestToken = null)
     {
         var copy = GetUnauthorizedPageCopy(failureCode);
+        var canRequestAccess =
+            failureCode.Equals("not_authorized", StringComparison.Ordinal) &&
+            !string.IsNullOrWhiteSpace(accessRequestToken);
+        var accessRequestTokenJson = JsonSerializer.Serialize(accessRequestToken, JsonOptions);
+        var showAccessRequestUi = canRequestAccess ? "true" : "false";
 
         return $$"""
             <!DOCTYPE html>
@@ -202,7 +287,49 @@ internal static class AuthFlowSupport
                         flex-wrap: wrap;
                     }
 
-                    a {
+                    .request-panel {
+                        margin-top: 22px;
+                        padding: 18px;
+                        border-radius: 20px;
+                        background: rgba(27, 63, 97, 0.06);
+                        border: 1px solid rgba(37, 90, 122, 0.16);
+                    }
+
+                    .request-panel[hidden] {
+                        display: none;
+                    }
+
+                    .request-panel p {
+                        max-width: none;
+                    }
+
+                    .request-feedback {
+                        margin-top: 14px;
+                        padding: 14px 16px;
+                        border-radius: 16px;
+                        border: 1px solid transparent;
+                        font-size: 0.95rem;
+                        line-height: 1.5;
+                    }
+
+                    .request-feedback[hidden] {
+                        display: none;
+                    }
+
+                    .request-feedback[data-tone="success"] {
+                        background: rgba(34, 116, 76, 0.08);
+                        border-color: rgba(34, 116, 76, 0.16);
+                        color: #1f573d;
+                    }
+
+                    .request-feedback[data-tone="error"] {
+                        background: rgba(151, 63, 49, 0.08);
+                        border-color: rgba(151, 63, 49, 0.16);
+                        color: #7b3124;
+                    }
+
+                    a,
+                    button {
                         display: inline-flex;
                         align-items: center;
                         justify-content: center;
@@ -211,6 +338,9 @@ internal static class AuthFlowSupport
                         border-radius: 999px;
                         text-decoration: none;
                         font-weight: 600;
+                        font: inherit;
+                        cursor: pointer;
+                        border: 0;
                     }
 
                     .primary {
@@ -235,7 +365,8 @@ internal static class AuthFlowSupport
                             flex-direction: column;
                         }
 
-                        a {
+                        a,
+                        button {
                             width: 100%;
                         }
                     }
@@ -247,11 +378,74 @@ internal static class AuthFlowSupport
                     <h1>{{copy.Title}}</h1>
                     <p>{{copy.Body}}</p>
                     <p class="note">{{copy.Note}}</p>
+                    <section class="request-panel" data-access-request-panel{{(canRequestAccess ? string.Empty : " hidden")}}>
+                        <p>If you think this account should be able to use Glovelly, send a request and we’ll notify the administrators.</p>
+                        <div class="actions">
+                            <button class="primary" type="button" data-access-request-button>Request access</button>
+                        </div>
+                        <p class="request-feedback" data-access-request-feedback hidden></p>
+                    </section>
                     <div class="actions">
                         <a class="primary" href="/auth/login">Try again</a>
                         <a class="secondary" href="/">Back to Glovelly</a>
                     </div>
                 </main>
+                <script>
+                    const showAccessRequestUi = {{showAccessRequestUi}};
+                    const accessRequestToken = {{accessRequestTokenJson}};
+
+                    if (showAccessRequestUi) {
+                        const button = document.querySelector('[data-access-request-button]');
+                        const feedback = document.querySelector('[data-access-request-feedback]');
+
+                        const showFeedback = (message, tone) => {
+                            if (!feedback) {
+                                return;
+                            }
+
+                            feedback.hidden = false;
+                            feedback.textContent = message;
+                            feedback.setAttribute('data-tone', tone);
+                        };
+
+                        button?.addEventListener('click', async () => {
+                            if (!button || !accessRequestToken) {
+                                return;
+                            }
+
+                            button.disabled = true;
+                            showFeedback('Sending your request...', 'success');
+
+                            try {
+                                const response = await fetch('/access/request', {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                    },
+                                    body: JSON.stringify({
+                                        accessRequestToken,
+                                    }),
+                                });
+
+                                if (response.ok) {
+                                    showFeedback('Request sent to administrators.', 'success');
+                                    button.textContent = 'Request sent';
+                                    return;
+                                }
+
+                                showFeedback(
+                                    'We could not send your request right now. Please try again shortly.',
+                                    'error');
+                                button.disabled = false;
+                            } catch {
+                                showFeedback(
+                                    'We could not send your request right now. Please try again shortly.',
+                                    'error');
+                                button.disabled = false;
+                            }
+                        });
+                    }
+                </script>
             </body>
             </html>
             """;
@@ -286,6 +480,11 @@ internal static class AuthFlowSupport
                 "Sign-in did not complete.",
                 "Something interrupted the sign-in process before it finished.",
                 "Try again. If it keeps happening, ask an admin for help."),
+            "not_authorized" => new UnauthorizedPageCopy(
+                "Access Needed",
+                "This account does not currently have access to Glovelly.",
+                "You have signed in successfully, but this account is not set up to use Glovelly yet.",
+                "Ask an admin to grant access, then try again."),
             _ => new UnauthorizedPageCopy(
                 "Access Needed",
                 "This account does not currently have access to Glovelly.",
@@ -294,5 +493,11 @@ internal static class AuthFlowSupport
         };
     }
 
+    private static string? Normalize(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    internal sealed record AccessRequestIdentity(string Email, string? DisplayName, string? Subject);
     private sealed record UnauthorizedPageCopy(string Eyebrow, string Title, string Body, string Note);
 }


### PR DESCRIPTION
## What changed
- adds a `Request access` flow to the unauthorized sign-in page so unenrolled users can notify admins directly
- carries a short-lived signed token from the denied auth flow into `/access/request` so the request can be submitted safely without an app session
- keeps the access-request abuse protections from the rebased branch, including request recording, duplicate suppression, daily notification caps, and public rate limiting
- updates the backend tests to cover the combined flow

## Why
Users who successfully authenticated with Google but had not yet been enrolled could see the denied page, but they had no way to trigger the existing access-request notification flow from there. The root issue was that the denied page appeared before a Glovelly app session existed, so the original authenticated-only endpoint could not be called from that screen.

## Impact
- unenrolled users can now request access directly from the denied page
- admins still receive branded access-request emails with environment details
- notification abuse is limited by duplicate suppression, quota checks, and rate limiting

## Validation
- `dotnet test glovelly.sln`

## Notes
This PR was rebased on top of the abuse-control work so the public enrolment request path keeps its safeguards while adding the new UI flow.