### PR TITLE
Set gigs as default app section

### DIFF
--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -109,7 +109,7 @@ type AppProps = {
 }
 
 function App({ appMetadata }: AppProps) {
-  const [activeSection, setActiveSection] = useState<AppSection>('clients')
+  const [activeSection, setActiveSection] = useState<AppSection>('gigs')
   const [clients, setClients] = useState<Client[]>([])
   const [selectedClientId, setSelectedClientId] = useState<string>('')
   const [searchQuery, setSearchQuery] = useState('')
@@ -194,7 +194,7 @@ function App({ appMetadata }: AppProps) {
 
   useEffect(() => {
     if (!isAdmin && activeSection === 'admin') {
-      setActiveSection('clients')
+      setActiveSection('gigs')
     }
   }, [activeSection, isAdmin])
 


### PR DESCRIPTION
### Motivation
- Users typically want to land in the gigs workspace first, so make `gigs` the default active section instead of `clients`.

### Description
- Updated `frontend/glovelly-web/src/App.tsx` to initialize `activeSection` with `useState<AppSection>('gigs')` and changed the non-admin guard to call `setActiveSection('gigs')` when redirecting from `admin`.

### Testing
- Ran `npm --prefix frontend/glovelly-web run build` and the frontend build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebae7a4c5c832899d0273e79b348db)