### PR TITLE
Fix mobile horizontal overflow in workspace pane

### DIFF
--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -3,6 +3,7 @@
   padding: 32px;
   display: grid;
   gap: 24px;
+  overflow-x: clip;
 }
 
 .build-meta {
@@ -36,6 +37,7 @@
   gap: 28px;
   grid-template-columns: 1fr;
   align-items: end;
+  min-width: 0;
 }
 
 .app-frame {
@@ -61,6 +63,7 @@
   display: grid;
   gap: 24px;
   min-width: 0;
+  max-width: 100%;
 }
 
 .content-header {
@@ -69,6 +72,8 @@
   position: relative;
   z-index: 20;
   min-width: 0;
+  max-width: 100%;
+  overflow-x: clip;
 }
 
 .content-header-top {
@@ -531,6 +536,8 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .editor-panel {


### PR DESCRIPTION
### Motivation
- The inner workspace/details pane was overflowing horizontally on small screens, causing unwanted page scroll and layout breakage.
- Add defensive containment so grid/flex children can shrink and not force the viewport wider than the device.

### Description
- Updated `frontend/glovelly-web/src/App.css` to add `overflow-x: clip` on `.app-shell` and `.content-header` to prevent horizontal spill from propagating to the viewport.
- Added `min-width: 0` to `.hero-panel` and `.panel` and `max-width: 100%` to `.content-shell`, `.content-header`, and `.panel` so nested grid/flex children can shrink correctly.
- This is a CSS-only change focused on responsive containment and does not alter component structure or behavior.

### Testing
- Ran `cd frontend/glovelly-web && npm run build` and the build completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf4247eb4832898c3237123194f06)