### PR TITLE
[codex] Add Google Drive invoice publishing

### DIFF
--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -69,8 +69,8 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
             {
                 Id = Guid.NewGuid(),
                 UserId = TestAuthContext.UserId,
-                AccessToken = "access-token",
-                RefreshToken = "refresh-token",
+                EncryptedAccessToken = "encrypted-access-token",
+                EncryptedRefreshToken = "encrypted-refresh-token",
                 AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(30),
                 RefreshTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(1),
                 Scope = "https://www.googleapis.com/auth/drive.file",

--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
 using Glovelly.Api.Tests.Infrastructure;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,6 +56,37 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(
             "billing@example.com",
             payload.GetProperty("invoiceReplyToEmail").GetString());
+        Assert.False(payload.GetProperty("isGoogleDriveConnected").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Me_ReturnsGoogleDriveConnected_WhenActiveConnectionExists()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            dbContext.GoogleDriveConnections.Add(new GoogleDriveConnection
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                AccessToken = "access-token",
+                RefreshToken = "refresh-token",
+                AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(30),
+                RefreshTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(1),
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+                ConnectedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        var response = await _client.GetAsync("/auth/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.True(payload.GetProperty("isGoogleDriveConnected").GetBoolean());
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly GlovellyApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public GoogleDriveIntegrationEndpointsTests(GlovellyApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Callback_WithCodeAndState_RedirectsToIntegrationStatus()
+    {
+        var client = _factory.CreateClient(new()
+        {
+            AllowAutoRedirect = false,
+        });
+
+        var response = await client.GetAsync(
+            "/integrations/google-drive/callback?code=auth-code&state=state-token");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Equal(
+            "/?integration=google-drive&status=callback-received",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Callback_WithoutCodeOrState_ReturnsValidationProblem()
+    {
+        var response = await _client.GetAsync("/integrations/google-drive/callback");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Google Drive authorization code is required.",
+            problem.GetProperty("errors").GetProperty("code")[0].GetString());
+        Assert.Equal(
+            "Google Drive OAuth state is required.",
+            problem.GetProperty("errors").GetProperty("state")[0].GetString());
+    }
+
+    [Fact]
+    public async Task Callback_WithGoogleError_ReturnsProblem()
+    {
+        var response = await _client.GetAsync(
+            "/integrations/google-drive/callback?error=access_denied&error_description=User%20cancelled");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Google Drive connection was not approved.", problem.GetProperty("title").GetString());
+        Assert.Equal("User cancelled", problem.GetProperty("detail").GetString());
+    }
+}

--- a/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
@@ -2,6 +2,14 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Glovelly.Api.Tests.Infrastructure;
+using Glovelly.Api.Services;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -19,24 +27,63 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
     }
 
     [Fact]
+    public async Task Connect_RedirectsToGoogleAuthorizationEndpoint()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Authentication:Google:ClientId", "google-client-id");
+            builder.UseSetting("Authentication:Google:ClientSecret", "google-client-secret");
+        });
+        var client = factory.CreateClient(new()
+        {
+            AllowAutoRedirect = false,
+        });
+
+        var response = await client.GetAsync("/integrations/google-drive/connect");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+
+        var location = Assert.IsType<Uri>(response.Headers.Location);
+        Assert.Equal("https", location.Scheme);
+        Assert.Equal("accounts.google.com", location.Host);
+        Assert.Equal("/o/oauth2/v2/auth", location.AbsolutePath);
+
+        var query = QueryHelpers.ParseQuery(location.Query);
+        Assert.Equal("google-client-id", query["client_id"]);
+        Assert.Equal("code", query["response_type"]);
+        Assert.Equal("https://www.googleapis.com/auth/drive.file", query["scope"]);
+        Assert.Equal("offline", query["access_type"]);
+        Assert.Equal("consent", query["prompt"]);
+        Assert.Equal(
+            "http://localhost/integrations/google-drive/callback",
+            query["redirect_uri"]);
+        Assert.False(string.IsNullOrWhiteSpace(query["state"]));
+    }
+
+    [Fact]
     public async Task Callback_WithCodeAndState_RedirectsToIntegrationStatus()
     {
-        var client = _factory.CreateClient(new()
+        var tokenExchanger = new FakeGoogleDriveOAuthTokenExchanger();
+        using var factory = CreateConfiguredFactory(tokenExchanger);
+        var state = CreateGoogleDriveStateToken(factory.Services);
+        var client = factory.CreateClient(new()
         {
             AllowAutoRedirect = false,
         });
 
         var response = await client.GetAsync(
-            "/integrations/google-drive/callback?code=auth-code&state=state-token");
+            $"/integrations/google-drive/callback?code=auth-code&state={Uri.EscapeDataString(state)}");
 
         Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
         Assert.Equal(
             "/?integration=google-drive&status=callback-received",
             response.Headers.Location?.OriginalString);
+        Assert.Equal("auth-code", tokenExchanger.Code);
+        Assert.Equal("http://localhost/integrations/google-drive/callback", tokenExchanger.RedirectUri);
     }
 
     [Fact]
-    public async Task Callback_WithoutCodeOrState_ReturnsValidationProblem()
+    public async Task Callback_WithoutState_ReturnsValidationProblem()
     {
         var response = await _client.GetAsync("/integrations/google-drive/callback");
 
@@ -44,23 +91,113 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
 
         var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
         Assert.Equal(
-            "Google Drive authorization code is required.",
-            problem.GetProperty("errors").GetProperty("code")[0].GetString());
-        Assert.Equal(
             "Google Drive OAuth state is required.",
             problem.GetProperty("errors").GetProperty("state")[0].GetString());
     }
 
     [Fact]
-    public async Task Callback_WithGoogleError_ReturnsProblem()
+    public async Task Callback_WithInvalidState_ReturnsValidationProblem()
     {
         var response = await _client.GetAsync(
-            "/integrations/google-drive/callback?error=access_denied&error_description=User%20cancelled");
+            "/integrations/google-drive/callback?code=auth-code&state=not-a-state-token");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Google Drive OAuth state is invalid or expired.",
+            problem.GetProperty("errors").GetProperty("state")[0].GetString());
+    }
+
+    [Fact]
+    public async Task Callback_WithStateButNoCode_ReturnsValidationProblem()
+    {
+        var state = CreateGoogleDriveStateToken();
+
+        var response = await _client.GetAsync(
+            $"/integrations/google-drive/callback?state={Uri.EscapeDataString(state)}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Google Drive authorization code is required.",
+            problem.GetProperty("errors").GetProperty("code")[0].GetString());
+    }
+
+    [Fact]
+    public async Task Callback_WithGoogleError_ReturnsProblem()
+    {
+        var state = CreateGoogleDriveStateToken();
+
+        var response = await _client.GetAsync(
+            $"/integrations/google-drive/callback?error=access_denied&error_description=User%20cancelled&state={Uri.EscapeDataString(state)}");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
         Assert.Equal("Google Drive connection was not approved.", problem.GetProperty("title").GetString());
         Assert.Equal("User cancelled", problem.GetProperty("detail").GetString());
+    }
+
+    private string CreateGoogleDriveStateToken(Guid? userId = null)
+    {
+        return CreateGoogleDriveStateToken(_factory.Services, userId);
+    }
+
+    private static string CreateGoogleDriveStateToken(IServiceProvider services, Guid? userId = null)
+    {
+        using var scope = services.CreateScope();
+        var dataProtectionProvider = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
+        var protector = dataProtectionProvider
+            .CreateProtector("Glovelly.GoogleDriveOAuthState")
+            .ToTimeLimitedDataProtector();
+
+        return protector.Protect(
+            JsonSerializer.Serialize(new
+            {
+                userId = userId ?? TestAuthContext.UserId,
+                createdUtc = DateTime.UtcNow,
+            }, JsonOptions),
+            lifetime: TimeSpan.FromMinutes(15));
+    }
+
+    private WebApplicationFactory<Program> CreateConfiguredFactory(
+        FakeGoogleDriveOAuthTokenExchanger tokenExchanger)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Authentication:Google:ClientId", "google-client-id");
+            builder.UseSetting("Authentication:Google:ClientSecret", "google-client-secret");
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IGoogleDriveOAuthTokenExchanger>();
+                services.AddSingleton<IGoogleDriveOAuthTokenExchanger>(tokenExchanger);
+            });
+        });
+    }
+
+    private sealed class FakeGoogleDriveOAuthTokenExchanger : IGoogleDriveOAuthTokenExchanger
+    {
+        public string? Code { get; private set; }
+        public string? RedirectUri { get; private set; }
+
+        public Task<GoogleDriveOAuthTokenExchangeResult> ExchangeCodeAsync(
+            string code,
+            string redirectUri,
+            string clientId,
+            string clientSecret,
+            CancellationToken cancellationToken)
+        {
+            Code = code;
+            RedirectUri = redirectUri;
+
+            return Task.FromResult(new GoogleDriveOAuthTokenExchangeResult(
+                true,
+                StatusCodes.Status200OK,
+                """
+                {"access_token":"ya29.test","expires_in":3599,"refresh_token":"1//test","scope":"https://www.googleapis.com/auth/drive.file","token_type":"Bearer"}
+                """));
+        }
     }
 }

--- a/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
@@ -86,10 +86,13 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
 
         using var scope = factory.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var tokenProtector = scope.ServiceProvider.GetRequiredService<IGoogleDriveTokenProtector>();
         var connection = await dbContext.GoogleDriveConnections.SingleAsync();
         Assert.Equal(TestAuthContext.UserId, connection.UserId);
-        Assert.Equal("ya29.test", connection.AccessToken);
-        Assert.Equal("1//test", connection.RefreshToken);
+        Assert.NotEqual("ya29.test", connection.EncryptedAccessToken);
+        Assert.NotEqual("1//test", connection.EncryptedRefreshToken);
+        Assert.Equal("ya29.test", tokenProtector.Unprotect(connection.EncryptedAccessToken));
+        Assert.Equal("1//test", tokenProtector.Unprotect(connection.EncryptedRefreshToken));
         Assert.Equal("https://www.googleapis.com/auth/drive.file", connection.Scope);
         Assert.Equal("Bearer", connection.TokenType);
         Assert.True(connection.AccessTokenExpiresAtUtc > DateTimeOffset.UtcNow);
@@ -113,16 +116,19 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
         };
         using var factory = CreateConfiguredFactory(tokenExchanger);
         var previousRefreshExpiry = DateTimeOffset.UtcNow.AddDays(5);
+        string encryptedExistingRefreshToken;
 
         using (var scope = factory.Services.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var tokenProtector = scope.ServiceProvider.GetRequiredService<IGoogleDriveTokenProtector>();
+            encryptedExistingRefreshToken = tokenProtector.Protect("1//existing");
             dbContext.GoogleDriveConnections.Add(new GoogleDriveConnection
             {
                 Id = Guid.NewGuid(),
                 UserId = TestAuthContext.UserId,
-                AccessToken = "ya29.old",
-                RefreshToken = "1//existing",
+                EncryptedAccessToken = tokenProtector.Protect("ya29.old"),
+                EncryptedRefreshToken = encryptedExistingRefreshToken,
                 AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(10),
                 RefreshTokenExpiresAtUtc = previousRefreshExpiry,
                 Scope = "https://www.googleapis.com/auth/drive.file",
@@ -146,9 +152,12 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
 
         using var assertionScope = factory.Services.CreateScope();
         var assertionDbContext = assertionScope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var assertionTokenProtector = assertionScope.ServiceProvider.GetRequiredService<IGoogleDriveTokenProtector>();
         var connection = await assertionDbContext.GoogleDriveConnections.SingleAsync();
-        Assert.Equal("ya29.new", connection.AccessToken);
-        Assert.Equal("1//existing", connection.RefreshToken);
+        Assert.NotEqual("ya29.new", connection.EncryptedAccessToken);
+        Assert.Equal("ya29.new", assertionTokenProtector.Unprotect(connection.EncryptedAccessToken));
+        Assert.Equal(encryptedExistingRefreshToken, connection.EncryptedRefreshToken);
+        Assert.Equal("1//existing", assertionTokenProtector.Unprotect(connection.EncryptedRefreshToken));
         Assert.Equal(previousRefreshExpiry, connection.RefreshTokenExpiresAtUtc);
     }
 

--- a/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleDriveIntegrationEndpointsTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
 using Glovelly.Api.Tests.Infrastructure;
 using Glovelly.Api.Services;
 using Microsoft.AspNetCore.DataProtection;
@@ -8,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
@@ -80,6 +83,73 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
             response.Headers.Location?.OriginalString);
         Assert.Equal("auth-code", tokenExchanger.Code);
         Assert.Equal("http://localhost/integrations/google-drive/callback", tokenExchanger.RedirectUri);
+
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var connection = await dbContext.GoogleDriveConnections.SingleAsync();
+        Assert.Equal(TestAuthContext.UserId, connection.UserId);
+        Assert.Equal("ya29.test", connection.AccessToken);
+        Assert.Equal("1//test", connection.RefreshToken);
+        Assert.Equal("https://www.googleapis.com/auth/drive.file", connection.Scope);
+        Assert.Equal("Bearer", connection.TokenType);
+        Assert.True(connection.AccessTokenExpiresAtUtc > DateTimeOffset.UtcNow);
+        Assert.True(connection.RefreshTokenExpiresAtUtc > DateTimeOffset.UtcNow);
+        Assert.Null(connection.RevokedAtUtc);
+    }
+
+    [Fact]
+    public async Task Callback_WithoutNewRefreshToken_PreservesExistingRefreshToken()
+    {
+        var tokenExchanger = new FakeGoogleDriveOAuthTokenExchanger
+        {
+            Response = new GoogleDriveOAuthTokenResponse
+            {
+                AccessToken = "ya29.new",
+                ExpiresIn = 1800,
+                RefreshToken = null,
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+            }
+        };
+        using var factory = CreateConfiguredFactory(tokenExchanger);
+        var previousRefreshExpiry = DateTimeOffset.UtcNow.AddDays(5);
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            dbContext.GoogleDriveConnections.Add(new GoogleDriveConnection
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                AccessToken = "ya29.old",
+                RefreshToken = "1//existing",
+                AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(10),
+                RefreshTokenExpiresAtUtc = previousRefreshExpiry,
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+                ConnectedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+                UpdatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        var state = CreateGoogleDriveStateToken(factory.Services);
+        var client = factory.CreateClient(new()
+        {
+            AllowAutoRedirect = false,
+        });
+
+        var response = await client.GetAsync(
+            $"/integrations/google-drive/callback?code=auth-code&state={Uri.EscapeDataString(state)}");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+
+        using var assertionScope = factory.Services.CreateScope();
+        var assertionDbContext = assertionScope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var connection = await assertionDbContext.GoogleDriveConnections.SingleAsync();
+        Assert.Equal("ya29.new", connection.AccessToken);
+        Assert.Equal("1//existing", connection.RefreshToken);
+        Assert.Equal(previousRefreshExpiry, connection.RefreshTokenExpiresAtUtc);
     }
 
     [Fact]
@@ -181,6 +251,15 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
     {
         public string? Code { get; private set; }
         public string? RedirectUri { get; private set; }
+        public GoogleDriveOAuthTokenResponse Response { get; set; } = new()
+        {
+            AccessToken = "ya29.test",
+            ExpiresIn = 3599,
+            RefreshToken = "1//test",
+            RefreshTokenExpiresIn = 604799,
+            Scope = "https://www.googleapis.com/auth/drive.file",
+            TokenType = "Bearer",
+        };
 
         public Task<GoogleDriveOAuthTokenExchangeResult> ExchangeCodeAsync(
             string code,
@@ -195,9 +274,8 @@ public sealed class GoogleDriveIntegrationEndpointsTests : IClassFixture<Glovell
             return Task.FromResult(new GoogleDriveOAuthTokenExchangeResult(
                 true,
                 StatusCodes.Status200OK,
-                """
-                {"access_token":"ya29.test","expires_in":3599,"refresh_token":"1//test","scope":"https://www.googleapis.com/auth/drive.file","token_type":"Bearer"}
-                """));
+                JsonSerializer.Serialize(Response, JsonOptions),
+                Response));
         }
     }
 }

--- a/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
@@ -2,7 +2,16 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
 using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -168,5 +177,218 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
         Assert.Equal(
             "Invoice PDF is missing.",
             problem.GetProperty("errors").GetProperty("pdf")[0].GetString());
+    }
+
+    [Fact]
+    public async Task PublishGoogleDrive_WhenConnected_UploadsPdfAndLogsDelivery()
+    {
+        var driveClient = new FakeGoogleDriveApiClient();
+        using var factory = CreateFactoryWithGoogleDriveClient(driveClient);
+        var client = factory.CreateClient();
+        var pdfBytes = Encoding.ASCII.GetBytes("%PDF-1.4 drive invoice content");
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var tokenProtector = scope.ServiceProvider.GetRequiredService<IGoogleDriveTokenProtector>();
+            dbContext.GoogleDriveConnections.Add(new GoogleDriveConnection
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                EncryptedAccessToken = tokenProtector.Protect("access-token"),
+                EncryptedRefreshToken = tokenProtector.Protect("refresh-token"),
+                AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(30),
+                RefreshTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(1),
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+                ConnectedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        var createInvoiceResponse = await client.PostAsJsonAsync("/invoices", new
+        {
+            invoiceNumber = "GLV-DRIVE-001",
+            clientId = TestData.FoxAndFinchId,
+            invoiceDate = "2026-04-20",
+            dueDate = "2026-05-04",
+            status = "Issued",
+            description = "Drive delivery test.",
+            pdfBlob = Convert.ToBase64String(pdfBytes),
+        });
+        createInvoiceResponse.EnsureSuccessStatusCode();
+        var createdInvoice = await createInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var invoiceId = createdInvoice.GetProperty("id").GetGuid();
+
+        var response = await client.PostAsync(
+            $"/invoices/{invoiceId}/publish/google-drive",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        Assert.Equal("access-token", driveClient.AccessToken);
+        Assert.Equal("GLV-DRIVE-001.pdf", driveClient.FileName);
+        Assert.Equal(pdfBytes, driveClient.Content);
+        Assert.Equal(1, updatedInvoice.GetProperty("deliveryCount").GetInt32());
+        Assert.Equal("GoogleDrive", updatedInvoice.GetProperty("lastDeliveryChannel").GetString());
+        Assert.Equal(
+            "https://drive.google.com/file/d/drive-file-id/view",
+            updatedInvoice.GetProperty("lastDeliveryRecipient").GetString());
+        Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("lastDeliveredByUserId").GetGuid());
+    }
+
+    [Fact]
+    public async Task PublishGoogleDrive_WhenNotConnected_ReturnsProblem()
+    {
+        var driveClient = new FakeGoogleDriveApiClient();
+        using var factory = CreateFactoryWithGoogleDriveClient(driveClient);
+        var client = factory.CreateClient();
+        var createInvoiceResponse = await client.PostAsJsonAsync("/invoices", new
+        {
+            invoiceNumber = "GLV-DRIVE-MISSING-CONNECTION",
+            clientId = TestData.FoxAndFinchId,
+            invoiceDate = "2026-04-20",
+            dueDate = "2026-05-04",
+            status = "Issued",
+            description = "Drive missing connection test.",
+            pdfBlob = Convert.ToBase64String(Encoding.ASCII.GetBytes("%PDF-1.4 invoice content")),
+        });
+        createInvoiceResponse.EnsureSuccessStatusCode();
+        var createdInvoice = await createInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await client.PostAsync(
+            $"/invoices/{createdInvoice.GetProperty("id").GetGuid()}/publish/google-drive",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Null(driveClient.FileName);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Unable to publish invoice to Google Drive", problem.GetProperty("title").GetString());
+        Assert.Equal("Google Drive is not connected.", problem.GetProperty("detail").GetString());
+    }
+
+    [Fact]
+    public async Task PublishGoogleDrive_WhenAccessTokenExpired_RefreshesBeforeUpload()
+    {
+        var driveClient = new FakeGoogleDriveApiClient
+        {
+            RefreshedAccessToken = "new-access-token",
+        };
+        using var factory = CreateFactoryWithGoogleDriveClient(driveClient);
+        var client = factory.CreateClient();
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var tokenProtector = scope.ServiceProvider.GetRequiredService<IGoogleDriveTokenProtector>();
+            dbContext.GoogleDriveConnections.Add(new GoogleDriveConnection
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                EncryptedAccessToken = tokenProtector.Protect("expired-access-token"),
+                EncryptedRefreshToken = tokenProtector.Protect("refresh-token"),
+                AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+                RefreshTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(1),
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+                ConnectedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        var createInvoiceResponse = await client.PostAsJsonAsync("/invoices", new
+        {
+            invoiceNumber = "GLV-DRIVE-REFRESH",
+            clientId = TestData.FoxAndFinchId,
+            invoiceDate = "2026-04-20",
+            dueDate = "2026-05-04",
+            status = "Issued",
+            description = "Drive refresh test.",
+            pdfBlob = Convert.ToBase64String(Encoding.ASCII.GetBytes("%PDF-1.4 invoice content")),
+        });
+        createInvoiceResponse.EnsureSuccessStatusCode();
+        var createdInvoice = await createInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await client.PostAsync(
+            $"/invoices/{createdInvoice.GetProperty("id").GetGuid()}/publish/google-drive",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("refresh-token", driveClient.RefreshToken);
+        Assert.Equal("new-access-token", driveClient.AccessToken);
+
+        using var assertionScope = factory.Services.CreateScope();
+        var assertionDbContext = assertionScope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var assertionTokenProtector = assertionScope.ServiceProvider.GetRequiredService<IGoogleDriveTokenProtector>();
+        var connection = await assertionDbContext.GoogleDriveConnections.SingleAsync();
+        Assert.Equal("new-access-token", assertionTokenProtector.Unprotect(connection.EncryptedAccessToken));
+    }
+
+    private WebApplicationFactory<Program> CreateFactoryWithGoogleDriveClient(
+        FakeGoogleDriveApiClient driveClient)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Authentication:Google:ClientId", "google-client-id");
+            builder.UseSetting("Authentication:Google:ClientSecret", "google-client-secret");
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IGoogleDriveApiClient>();
+                services.AddSingleton<IGoogleDriveApiClient>(driveClient);
+            });
+        });
+    }
+
+    private sealed class FakeGoogleDriveApiClient : IGoogleDriveApiClient
+    {
+        public string? AccessToken { get; private set; }
+        public string? ContentText { get; private set; }
+        public byte[]? Content { get; private set; }
+        public string? FileName { get; private set; }
+        public string? RefreshToken { get; private set; }
+        public string RefreshedAccessToken { get; set; } = "refreshed-access-token";
+
+        public Task<GoogleDriveAccessTokenRefreshResult> RefreshAccessTokenAsync(
+            string refreshToken,
+            string clientId,
+            string clientSecret,
+            CancellationToken cancellationToken)
+        {
+            RefreshToken = refreshToken;
+            var tokenResponse = new GoogleDriveOAuthTokenResponse
+            {
+                AccessToken = RefreshedAccessToken,
+                ExpiresIn = 3599,
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+            };
+
+            return Task.FromResult(new GoogleDriveAccessTokenRefreshResult(
+                true,
+                StatusCodes.Status200OK,
+                "{}",
+                tokenResponse));
+        }
+
+        public Task<GoogleDriveUploadResult> UploadPdfAsync(
+            string accessToken,
+            string fileName,
+            byte[] content,
+            CancellationToken cancellationToken)
+        {
+            AccessToken = accessToken;
+            FileName = fileName;
+            Content = content;
+            ContentText = Encoding.ASCII.GetString(content);
+
+            return Task.FromResult(new GoogleDriveUploadResult(
+                "drive-file-id",
+                fileName,
+                "https://drive.google.com/file/d/drive-file-id/view"));
+        }
     }
 }

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json.Serialization;
@@ -27,7 +28,14 @@ internal static class InfrastructureServiceCollectionExtensions
         services.AddOptions<AccessRequestProtectionSettings>()
             .Bind(configuration.GetSection(AccessRequestProtectionSettings.SectionName));
         services.AddGlovellyApplicationServices();
+        services.AddScoped<IGoogleDriveTokenProtector, GoogleDriveTokenProtector>();
         services.AddHttpClient<IGoogleDriveOAuthTokenExchanger, GoogleDriveOAuthTokenExchanger>();
+        if (settings.UsePostgres)
+        {
+            services.AddDataProtection()
+                .SetApplicationName("Glovelly")
+                .PersistKeysToDbContext<AppDbContext>();
+        }
         services.ConfigureHttpJsonOptions(options =>
         {
             options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ internal static class InfrastructureServiceCollectionExtensions
         var accessRequestSettings = configuration.GetSection(AccessRequestProtectionSettings.SectionName)
             .Get<AccessRequestProtectionSettings>() ?? new AccessRequestProtectionSettings();
 
+        services.AddSingleton(settings);
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen();
         services.AddOptions<EmailSettings>()

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ internal static class InfrastructureServiceCollectionExtensions
         services.AddOptions<AccessRequestProtectionSettings>()
             .Bind(configuration.GetSection(AccessRequestProtectionSettings.SectionName));
         services.AddGlovellyApplicationServices();
+        services.AddHttpClient<IGoogleDriveOAuthTokenExchanger, GoogleDriveOAuthTokenExchanger>();
         services.ConfigureHttpJsonOptions(options =>
         {
             options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -13,6 +13,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<Invoice> Invoices => Set<Invoice>();
     public DbSet<InvoiceLine> InvoiceLines => Set<InvoiceLine>();
     public DbSet<SellerProfile> SellerProfiles => Set<SellerProfile>();
+    public DbSet<GoogleDriveConnection> GoogleDriveConnections => Set<GoogleDriveConnection>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -67,6 +68,29 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
                 .IsUnique();
             entity.HasIndex(user => user.Email)
                 .IsUnique();
+        });
+
+        modelBuilder.Entity<GoogleDriveConnection>(entity =>
+        {
+            entity.HasKey(connection => connection.Id);
+            entity.Property(connection => connection.AccessToken)
+                .IsRequired();
+            entity.Property(connection => connection.RefreshToken)
+                .IsRequired();
+            entity.Property(connection => connection.Scope)
+                .HasMaxLength(500);
+            entity.Property(connection => connection.TokenType)
+                .HasMaxLength(50);
+            entity.Property(connection => connection.ConnectedAtUtc)
+                .IsRequired();
+            entity.Property(connection => connection.UpdatedAtUtc)
+                .IsRequired();
+            entity.HasIndex(connection => connection.UserId)
+                .IsUnique();
+            entity.HasOne(connection => connection.User)
+                .WithOne(user => user.GoogleDriveConnection)
+                .HasForeignKey<GoogleDriveConnection>(connection => connection.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<Client>(entity =>

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -1,11 +1,13 @@
 using Glovelly.Api.Models;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Glovelly.Api.Data;
 
-public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options), IDataProtectionKeyContext
 {
     public DbSet<AccessRequest> AccessRequests => Set<AccessRequest>();
+    public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
     public DbSet<User> Users => Set<User>();
     public DbSet<Client> Clients => Set<Client>();
     public DbSet<Gig> Gigs => Set<Gig>();
@@ -73,9 +75,9 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
         modelBuilder.Entity<GoogleDriveConnection>(entity =>
         {
             entity.HasKey(connection => connection.Id);
-            entity.Property(connection => connection.AccessToken)
+            entity.Property(connection => connection.EncryptedAccessToken)
                 .IsRequired();
-            entity.Property(connection => connection.RefreshToken)
+            entity.Property(connection => connection.EncryptedRefreshToken)
                 .IsRequired();
             entity.Property(connection => connection.Scope)
                 .HasMaxLength(500);

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -59,6 +59,15 @@ internal static class AuthEndpoints
                 return Results.Unauthorized();
             }
 
+            var now = DateTimeOffset.UtcNow;
+            var isGoogleDriveConnected = await dbContext.GoogleDriveConnections
+                .AsNoTracking()
+                .AnyAsync(connection =>
+                    connection.UserId == userId.Value &&
+                    connection.RevokedAtUtc == null &&
+                    (connection.RefreshTokenExpiresAtUtc == null ||
+                     connection.RefreshTokenExpiresAtUtc > now));
+
             return Results.Ok(new
             {
                 userId,
@@ -70,6 +79,7 @@ internal static class AuthEndpoints
                 passengerMileageRate = localUser.PassengerMileageRate,
                 invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
                 invoiceReplyToEmail = localUser.InvoiceReplyToEmail,
+                isGoogleDriveConnected,
             });
         });
 

--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -51,6 +51,7 @@ internal static class AuthFlowSupport
                path.StartsWithSegments("/admin") ||
                path.StartsWithSegments("/clients") ||
                path.StartsWithSegments("/gigs") ||
+               path.StartsWithSegments("/integrations") ||
                path.StartsWithSegments("/invoices") ||
                path.StartsWithSegments("/invoice-lines") ||
                path.StartsWithSegments("/seller-profile");

--- a/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Glovelly.Api.Auth;
 using Glovelly.Api.Configuration;
 using Glovelly.Api.Data;
+using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
@@ -147,6 +148,21 @@ internal static class GoogleDriveIntegrationEndpoints
                     statusCode: StatusCodes.Status502BadGateway);
             }
 
+            if (tokenResponse.TokenResponse is null ||
+                string.IsNullOrWhiteSpace(tokenResponse.TokenResponse.AccessToken))
+            {
+                return Results.Problem(
+                    title: "Google Drive token exchange failed.",
+                    detail: "Google token response did not include an access token.",
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+
+            await SaveGoogleDriveConnectionAsync(
+                dbContext,
+                currentUserId.Value,
+                tokenResponse.TokenResponse,
+                cancellationToken);
+
             return Results.Redirect(BuildIntegrationStatusRedirectUri(settings));
         });
 
@@ -191,6 +207,49 @@ internal static class GoogleDriveIntegrationEndpoints
             ?? settings.AllowedCorsOrigins[0];
 
         return $"{frontendOrigin.TrimEnd('/')}{integrationStatusPath}";
+    }
+
+    private static async Task SaveGoogleDriveConnectionAsync(
+        AppDbContext dbContext,
+        Guid userId,
+        GoogleDriveOAuthTokenResponse tokenResponse,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var connection = await dbContext.GoogleDriveConnections
+            .SingleOrDefaultAsync(value => value.UserId == userId, cancellationToken);
+
+        if (connection is null)
+        {
+            connection = new GoogleDriveConnection
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ConnectedAtUtc = now,
+            };
+
+            dbContext.GoogleDriveConnections.Add(connection);
+        }
+
+        connection.AccessToken = tokenResponse.AccessToken;
+
+        if (!string.IsNullOrWhiteSpace(tokenResponse.RefreshToken))
+        {
+            connection.RefreshToken = tokenResponse.RefreshToken;
+            connection.RefreshTokenExpiresAtUtc = tokenResponse.RefreshTokenExpiresIn is { } refreshSeconds
+                ? now.AddSeconds(refreshSeconds)
+                : null;
+        }
+
+        connection.AccessTokenExpiresAtUtc = now.AddSeconds(tokenResponse.ExpiresIn);
+        connection.Scope = tokenResponse.Scope;
+        connection.TokenType = string.IsNullOrWhiteSpace(tokenResponse.TokenType)
+            ? "Bearer"
+            : tokenResponse.TokenType;
+        connection.UpdatedAtUtc = now;
+        connection.RevokedAtUtc = null;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
     }
 
     private static string CreateStateToken(

--- a/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
@@ -1,19 +1,73 @@
 using System.Security.Claims;
+using System.Text.Json;
 using Glovelly.Api.Auth;
+using Glovelly.Api.Configuration;
 using Glovelly.Api.Data;
+using Glovelly.Api.Services;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Glovelly.Api.Endpoints;
 
-public static class GoogleDriveIntegrationEndpoints
+internal static class GoogleDriveIntegrationEndpoints
 {
-    public static IEndpointRouteBuilder MapGoogleDriveIntegrationEndpoints(this IEndpointRouteBuilder app)
+    private const string GoogleAuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth";
+    private const string GoogleDriveFileScope = "https://www.googleapis.com/auth/drive.file";
+    private const string StateProtectionPurpose = "Glovelly.GoogleDriveOAuthState";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static IEndpointRouteBuilder MapGoogleDriveIntegrationEndpoints(
+        this IEndpointRouteBuilder app,
+        StartupSettings settings)
     {
         var googleDrive = app.MapGroup("/integrations/google-drive")
             .WithTags("Integrations")
             .RequireAuthorization(GlovellyPolicies.GlovellyUser);
 
+        googleDrive.MapGet("/connect", async (
+            HttpContext httpContext,
+            ClaimsPrincipal principal,
+            ICurrentUserAccessor currentUserAccessor,
+            AppDbContext dbContext,
+            IDataProtectionProvider dataProtectionProvider) =>
+        {
+            if (string.IsNullOrWhiteSpace(settings.GoogleClientId) ||
+                string.IsNullOrWhiteSpace(settings.GoogleClientSecret))
+            {
+                return Results.Problem(
+                    detail: "Google OAuth is not configured. Set Authentication:Google:ClientId and ClientSecret.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+
+            var currentUserId = await GetActiveCurrentUserIdAsync(
+                principal,
+                currentUserAccessor,
+                dbContext);
+            if (!currentUserId.HasValue)
+            {
+                return Results.Unauthorized();
+            }
+
+            var state = CreateStateToken(currentUserId.Value, dataProtectionProvider);
+            var authorizationUrl = QueryHelpers.AddQueryString(
+                GoogleAuthorizationEndpoint,
+                new Dictionary<string, string?>
+                {
+                    ["client_id"] = settings.GoogleClientId,
+                    ["redirect_uri"] = BuildCallbackUri(httpContext),
+                    ["response_type"] = "code",
+                    ["scope"] = GoogleDriveFileScope,
+                    ["access_type"] = "offline",
+                    ["prompt"] = "consent",
+                    ["state"] = state,
+                });
+
+            return Results.Redirect(authorizationUrl);
+        });
+
         googleDrive.MapGet("/callback", async (
+            HttpContext httpContext,
             string? code,
             string? state,
             string? error,
@@ -21,20 +75,24 @@ public static class GoogleDriveIntegrationEndpoints
             ClaimsPrincipal principal,
             ICurrentUserAccessor currentUserAccessor,
             AppDbContext dbContext,
-            ILoggerFactory loggerFactory) =>
+            IDataProtectionProvider dataProtectionProvider,
+            IGoogleDriveOAuthTokenExchanger tokenExchanger,
+            ILoggerFactory loggerFactory,
+            CancellationToken cancellationToken) =>
         {
-            var currentUserId = currentUserAccessor.TryGetUserId(principal);
+            var currentUserId = await GetActiveCurrentUserIdAsync(
+                principal,
+                currentUserAccessor,
+                dbContext);
             if (!currentUserId.HasValue)
             {
                 return Results.Unauthorized();
             }
 
-            var userExists = await dbContext.Users
-                .AsNoTracking()
-                .AnyAsync(user => user.Id == currentUserId.Value && user.IsActive);
-            if (!userExists)
+            var stateValidationErrors = ValidateState(state, currentUserId.Value, dataProtectionProvider);
+            if (stateValidationErrors.Count > 0)
             {
-                return Results.Unauthorized();
+                return Results.ValidationProblem(stateValidationErrors);
             }
 
             if (!string.IsNullOrWhiteSpace(error))
@@ -45,7 +103,7 @@ public static class GoogleDriveIntegrationEndpoints
                     statusCode: StatusCodes.Status400BadRequest);
             }
 
-            var validationErrors = ValidateCallback(code, state);
+            var validationErrors = ValidateCallback(code);
             if (validationErrors.Count > 0)
             {
                 return Results.ValidationProblem(validationErrors);
@@ -56,13 +114,137 @@ public static class GoogleDriveIntegrationEndpoints
                 "Received Google Drive OAuth callback for user {UserId}.",
                 currentUserId.Value);
 
-            return Results.Redirect("/?integration=google-drive&status=callback-received");
+            if (string.IsNullOrWhiteSpace(settings.GoogleClientId) ||
+                string.IsNullOrWhiteSpace(settings.GoogleClientSecret))
+            {
+                return Results.Problem(
+                    detail: "Google OAuth is not configured. Set Authentication:Google:ClientId and ClientSecret.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+
+            var tokenResponse = await tokenExchanger.ExchangeCodeAsync(
+                code!,
+                BuildCallbackUri(httpContext),
+                settings.GoogleClientId,
+                settings.GoogleClientSecret,
+                cancellationToken);
+
+            if (settings.IsDevelopment)
+            {
+                logger.LogInformation(
+                    "Google Drive OAuth token response ({StatusCode}): {TokenResponse}",
+                    tokenResponse.StatusCode,
+                    tokenResponse.ResponseBody);
+            }
+
+            if (!tokenResponse.IsSuccess)
+            {
+                return Results.Problem(
+                    title: "Google Drive token exchange failed.",
+                    detail: settings.IsDevelopment
+                        ? tokenResponse.ResponseBody
+                        : "Google rejected the Drive authorization code.",
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+
+            return Results.Redirect(BuildIntegrationStatusRedirectUri(settings));
         });
 
         return app;
     }
 
-    private static Dictionary<string, string[]> ValidateCallback(string? code, string? state)
+    private static async Task<Guid?> GetActiveCurrentUserIdAsync(
+        ClaimsPrincipal principal,
+        ICurrentUserAccessor currentUserAccessor,
+        AppDbContext dbContext)
+    {
+        var currentUserId = currentUserAccessor.TryGetUserId(principal);
+        if (!currentUserId.HasValue)
+        {
+            return null;
+        }
+
+        var userExists = await dbContext.Users
+            .AsNoTracking()
+            .AnyAsync(user => user.Id == currentUserId.Value && user.IsActive);
+
+        return userExists ? currentUserId.Value : null;
+    }
+
+    private static string BuildCallbackUri(HttpContext httpContext)
+    {
+        var request = httpContext.Request;
+        return $"{request.Scheme}://{request.Host}{request.PathBase}/integrations/google-drive/callback";
+    }
+
+    private static string BuildIntegrationStatusRedirectUri(StartupSettings settings)
+    {
+        const string integrationStatusPath = "/?integration=google-drive&status=callback-received";
+
+        if (!settings.IsDevelopment || settings.AllowedCorsOrigins.Length == 0)
+        {
+            return integrationStatusPath;
+        }
+
+        var frontendOrigin = settings.AllowedCorsOrigins
+            .FirstOrDefault(origin => origin.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            ?? settings.AllowedCorsOrigins[0];
+
+        return $"{frontendOrigin.TrimEnd('/')}{integrationStatusPath}";
+    }
+
+    private static string CreateStateToken(
+        Guid userId,
+        IDataProtectionProvider dataProtectionProvider)
+    {
+        var protector = dataProtectionProvider
+            .CreateProtector(StateProtectionPurpose)
+            .ToTimeLimitedDataProtector();
+        var state = new GoogleDriveOAuthState(userId, DateTime.UtcNow);
+
+        return protector.Protect(
+            JsonSerializer.Serialize(state, JsonOptions),
+            lifetime: TimeSpan.FromMinutes(15));
+    }
+
+    private static Dictionary<string, string[]> ValidateState(
+        string? state,
+        Guid expectedUserId,
+        IDataProtectionProvider dataProtectionProvider)
+    {
+        if (string.IsNullOrWhiteSpace(state))
+        {
+            return new Dictionary<string, string[]>
+            {
+                ["state"] = ["Google Drive OAuth state is required."]
+            };
+        }
+
+        try
+        {
+            var protector = dataProtectionProvider
+                .CreateProtector(StateProtectionPurpose)
+                .ToTimeLimitedDataProtector();
+            var payloadJson = protector.Unprotect(state, out _);
+            var payload = JsonSerializer.Deserialize<GoogleDriveOAuthState>(payloadJson, JsonOptions);
+
+            if (payload?.UserId == expectedUserId)
+            {
+                return [];
+            }
+        }
+        catch
+        {
+            // Invalid state is expected when a callback is forged, expired, or belongs to another app instance.
+        }
+
+        return new Dictionary<string, string[]>
+        {
+            ["state"] = ["Google Drive OAuth state is invalid or expired."]
+        };
+    }
+
+    private static Dictionary<string, string[]> ValidateCallback(string? code)
     {
         var errors = new Dictionary<string, string[]>();
 
@@ -71,11 +253,8 @@ public static class GoogleDriveIntegrationEndpoints
             errors["code"] = ["Google Drive authorization code is required."];
         }
 
-        if (string.IsNullOrWhiteSpace(state))
-        {
-            errors["state"] = ["Google Drive OAuth state is required."];
-        }
-
         return errors;
     }
+
+    private sealed record GoogleDriveOAuthState(Guid UserId, DateTime CreatedUtc);
 }

--- a/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
@@ -78,6 +78,7 @@ internal static class GoogleDriveIntegrationEndpoints
             AppDbContext dbContext,
             IDataProtectionProvider dataProtectionProvider,
             IGoogleDriveOAuthTokenExchanger tokenExchanger,
+            IGoogleDriveTokenProtector tokenProtector,
             ILoggerFactory loggerFactory,
             CancellationToken cancellationToken) =>
         {
@@ -161,6 +162,7 @@ internal static class GoogleDriveIntegrationEndpoints
                 dbContext,
                 currentUserId.Value,
                 tokenResponse.TokenResponse,
+                tokenProtector,
                 cancellationToken);
 
             return Results.Redirect(BuildIntegrationStatusRedirectUri(settings));
@@ -213,6 +215,7 @@ internal static class GoogleDriveIntegrationEndpoints
         AppDbContext dbContext,
         Guid userId,
         GoogleDriveOAuthTokenResponse tokenResponse,
+        IGoogleDriveTokenProtector tokenProtector,
         CancellationToken cancellationToken)
     {
         var now = DateTimeOffset.UtcNow;
@@ -231,11 +234,11 @@ internal static class GoogleDriveIntegrationEndpoints
             dbContext.GoogleDriveConnections.Add(connection);
         }
 
-        connection.AccessToken = tokenResponse.AccessToken;
+        connection.EncryptedAccessToken = tokenProtector.Protect(tokenResponse.AccessToken);
 
         if (!string.IsNullOrWhiteSpace(tokenResponse.RefreshToken))
         {
-            connection.RefreshToken = tokenResponse.RefreshToken;
+            connection.EncryptedRefreshToken = tokenProtector.Protect(tokenResponse.RefreshToken);
             connection.RefreshTokenExpiresAtUtc = tokenResponse.RefreshTokenExpiresIn is { } refreshSeconds
                 ? now.AddSeconds(refreshSeconds)
                 : null;

--- a/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GoogleDriveIntegrationEndpoints.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using Glovelly.Api.Auth;
+using Glovelly.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Glovelly.Api.Endpoints;
+
+public static class GoogleDriveIntegrationEndpoints
+{
+    public static IEndpointRouteBuilder MapGoogleDriveIntegrationEndpoints(this IEndpointRouteBuilder app)
+    {
+        var googleDrive = app.MapGroup("/integrations/google-drive")
+            .WithTags("Integrations")
+            .RequireAuthorization(GlovellyPolicies.GlovellyUser);
+
+        googleDrive.MapGet("/callback", async (
+            string? code,
+            string? state,
+            string? error,
+            string? error_description,
+            ClaimsPrincipal principal,
+            ICurrentUserAccessor currentUserAccessor,
+            AppDbContext dbContext,
+            ILoggerFactory loggerFactory) =>
+        {
+            var currentUserId = currentUserAccessor.TryGetUserId(principal);
+            if (!currentUserId.HasValue)
+            {
+                return Results.Unauthorized();
+            }
+
+            var userExists = await dbContext.Users
+                .AsNoTracking()
+                .AnyAsync(user => user.Id == currentUserId.Value && user.IsActive);
+            if (!userExists)
+            {
+                return Results.Unauthorized();
+            }
+
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                return Results.Problem(
+                    title: "Google Drive connection was not approved.",
+                    detail: string.IsNullOrWhiteSpace(error_description) ? error : error_description,
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var validationErrors = ValidateCallback(code, state);
+            if (validationErrors.Count > 0)
+            {
+                return Results.ValidationProblem(validationErrors);
+            }
+
+            var logger = loggerFactory.CreateLogger(nameof(GoogleDriveIntegrationEndpoints));
+            logger.LogInformation(
+                "Received Google Drive OAuth callback for user {UserId}.",
+                currentUserId.Value);
+
+            return Results.Redirect("/?integration=google-drive&status=callback-received");
+        });
+
+        return app;
+    }
+
+    private static Dictionary<string, string[]> ValidateCallback(string? code, string? state)
+    {
+        var errors = new Dictionary<string, string[]>();
+
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            errors["code"] = ["Google Drive authorization code is required."];
+        }
+
+        if (string.IsNullOrWhiteSpace(state))
+        {
+            errors["state"] = ["Google Drive OAuth state is required."];
+        }
+
+        return errors;
+    }
+}

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -447,6 +447,95 @@ public static class InvoiceEndpoints
             return Results.Ok(invoice);
         });
 
+        group.MapPost("/{id:guid}/publish/google-drive", async (
+            Guid id,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IInvoiceDeliveryService invoiceDeliveryService,
+            ILoggerFactory loggerFactory,
+            CancellationToken cancellationToken) =>
+        {
+            var logger = loggerFactory.CreateLogger("InvoiceEndpoints");
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
+                .Include(value => value.Client)
+                .Include(value => value.Lines)
+                .FirstOrDefaultAsync(value => value.Id == id, cancellationToken);
+
+            if (invoice is null)
+            {
+                return Results.NotFound();
+            }
+
+            if (invoice.Client is null)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["clientId"] = ["Client does not exist."]
+                });
+            }
+
+            if (invoice.PdfBlob is null || invoice.PdfBlob.Length == 0)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["pdf"] = ["Invoice PDF is missing."]
+                });
+            }
+
+            var userDefaultPattern = userId.HasValue
+                ? await db.Users
+                    .AsNoTracking()
+                    .Where(value => value.Id == userId.Value && value.IsActive)
+                    .Select(value => value.InvoiceFilenamePattern)
+                    .FirstOrDefaultAsync(cancellationToken)
+                : null;
+            var attachmentFileName = InvoicePdfFilenameBuilder.Build(
+                invoice,
+                invoice.Client,
+                userDefaultPattern);
+
+            try
+            {
+                await invoiceDeliveryService.DeliverAsync(
+                    InvoiceDeliveryChannel.GoogleDrive,
+                    invoice,
+                    invoice.Client,
+                    userId,
+                    message: null,
+                    attachmentFileName,
+                    InvoiceEmailSenderIdentityBuilder.Build(null),
+                    cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(
+                    exception,
+                    "Failed to publish invoice {InvoiceId} ({InvoiceNumber}) to Google Drive.",
+                    invoice.Id,
+                    invoice.InvoiceNumber);
+                return Results.Problem(
+                    title: "Unable to publish invoice to Google Drive",
+                    detail: exception.Message,
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+
+            EndpointSupport.StampUpdate(invoice, userId);
+            await db.SaveChangesAsync(cancellationToken);
+
+            logger.LogInformation(
+                "Invoice {InvoiceId} ({InvoiceNumber}) delivered by {Channel} to {Recipient} by user {UserId}.",
+                invoice.Id,
+                invoice.InvoiceNumber,
+                invoice.LastDeliveryChannel,
+                invoice.LastDeliveryRecipient,
+                userId);
+
+            return Results.Ok(invoice);
+        });
+
         group.MapPost("/{id:guid}/adjustments", async (
             Guid id,
             InvoiceAdjustmentCreateRequest request,

--- a/backend/Glovelly.Api/Glovelly.Api.csproj
+++ b/backend/Glovelly.Api/Glovelly.Api.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />

--- a/backend/Glovelly.Api/Models/GoogleDriveConnection.cs
+++ b/backend/Glovelly.Api/Models/GoogleDriveConnection.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Glovelly.Api.Models;
+
+public sealed class GoogleDriveConnection
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTimeOffset AccessTokenExpiresAtUtc { get; set; }
+    public DateTimeOffset? RefreshTokenExpiresAtUtc { get; set; }
+    public string Scope { get; set; } = string.Empty;
+    public string TokenType { get; set; } = "Bearer";
+    public DateTimeOffset ConnectedAtUtc { get; set; }
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public DateTimeOffset? RevokedAtUtc { get; set; }
+
+    [JsonIgnore]
+    public User? User { get; set; }
+}

--- a/backend/Glovelly.Api/Models/GoogleDriveConnection.cs
+++ b/backend/Glovelly.Api/Models/GoogleDriveConnection.cs
@@ -6,8 +6,8 @@ public sealed class GoogleDriveConnection
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }
-    public string AccessToken { get; set; } = string.Empty;
-    public string RefreshToken { get; set; } = string.Empty;
+    public string EncryptedAccessToken { get; set; } = string.Empty;
+    public string EncryptedRefreshToken { get; set; } = string.Empty;
     public DateTimeOffset AccessTokenExpiresAtUtc { get; set; }
     public DateTimeOffset? RefreshTokenExpiresAtUtc { get; set; }
     public string Scope { get; set; } = string.Empty;

--- a/backend/Glovelly.Api/Models/User.cs
+++ b/backend/Glovelly.Api/Models/User.cs
@@ -39,4 +39,6 @@ public sealed class User
     public ICollection<SellerProfile> SellerProfilesUpdated { get; set; } = new List<SellerProfile>();
     [JsonIgnore]
     public SellerProfile? SellerProfile { get; set; }
+    [JsonIgnore]
+    public GoogleDriveConnection? GoogleDriveConnection { get; set; }
 }

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -15,6 +15,7 @@ app.UseGlovellyHttpPipeline(startupSettings);
 app.MapAppMetadataEndpoints(startupSettings);
 app.MapAuthEndpoints(startupSettings);
 app.MapAccessEndpoints(startupSettings);
+app.MapGoogleDriveIntegrationEndpoints();
 app.MapCrudEndpoints();
 app.MapAdminEndpoints();
 app.MapFallbackToFile("index.html");

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -15,7 +15,7 @@ app.UseGlovellyHttpPipeline(startupSettings);
 app.MapAppMetadataEndpoints(startupSettings);
 app.MapAuthEndpoints(startupSettings);
 app.MapAccessEndpoints(startupSettings);
-app.MapGoogleDriveIntegrationEndpoints();
+app.MapGoogleDriveIntegrationEndpoints(startupSettings);
 app.MapCrudEndpoints();
 app.MapAdminEndpoints();
 app.MapFallbackToFile("index.html");

--- a/backend/Glovelly.Api/Services/GoogleDriveAccessTokenRefreshResult.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveAccessTokenRefreshResult.cs
@@ -1,0 +1,7 @@
+namespace Glovelly.Api.Services;
+
+public sealed record GoogleDriveAccessTokenRefreshResult(
+    bool IsSuccess,
+    int StatusCode,
+    string ResponseBody,
+    GoogleDriveOAuthTokenResponse? TokenResponse = null);

--- a/backend/Glovelly.Api/Services/GoogleDriveApiClient.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveApiClient.cs
@@ -1,0 +1,122 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Glovelly.Api.Services;
+
+public sealed class GoogleDriveApiClient(HttpClient httpClient) : IGoogleDriveApiClient
+{
+    private const string GoogleTokenEndpoint = "https://oauth2.googleapis.com/token";
+    private const string GoogleDriveUploadEndpoint =
+        "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,webViewLink";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<GoogleDriveAccessTokenRefreshResult> RefreshAccessTokenAsync(
+        string refreshToken,
+        string clientId,
+        string clientSecret,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, GoogleTokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["client_id"] = clientId,
+                ["client_secret"] = clientSecret,
+                ["refresh_token"] = refreshToken,
+                ["grant_type"] = "refresh_token",
+            }),
+        };
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        GoogleDriveOAuthTokenResponse? tokenResponse = null;
+        if (response.IsSuccessStatusCode)
+        {
+            try
+            {
+                tokenResponse = JsonSerializer.Deserialize<GoogleDriveOAuthTokenResponse>(
+                    responseBody,
+                    JsonOptions);
+            }
+            catch (JsonException)
+            {
+                tokenResponse = null;
+            }
+        }
+
+        return new GoogleDriveAccessTokenRefreshResult(
+            response.IsSuccessStatusCode,
+            (int)response.StatusCode,
+            responseBody,
+            tokenResponse);
+    }
+
+    public async Task<GoogleDriveUploadResult> UploadPdfAsync(
+        string accessToken,
+        string fileName,
+        byte[] content,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, GoogleDriveUploadEndpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = BuildMultipartContent(fileName, content);
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Google Drive upload failed with HTTP {(int)response.StatusCode}: {responseBody}");
+        }
+
+        var uploadResponse = JsonSerializer.Deserialize<GoogleDriveUploadResponse>(
+            responseBody,
+            JsonOptions);
+        if (uploadResponse is null || string.IsNullOrWhiteSpace(uploadResponse.Id))
+        {
+            throw new InvalidOperationException("Google Drive upload response did not include a file id.");
+        }
+
+        return new GoogleDriveUploadResult(
+            uploadResponse.Id,
+            uploadResponse.Name ?? fileName,
+            uploadResponse.WebViewLink);
+    }
+
+    private static MultipartContent BuildMultipartContent(string fileName, byte[] content)
+    {
+        var multipart = new MultipartContent("related");
+        var metadata = JsonSerializer.Serialize(
+            new
+            {
+                name = fileName,
+                mimeType = "application/pdf",
+            },
+            JsonOptions);
+
+        multipart.Add(new StringContent(metadata, Encoding.UTF8, "application/json"));
+        multipart.Add(new ByteArrayContent(content)
+        {
+            Headers =
+            {
+                ContentType = new MediaTypeHeaderValue("application/pdf"),
+            },
+        });
+
+        return multipart;
+    }
+
+    private sealed class GoogleDriveUploadResponse
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("webViewLink")]
+        public string? WebViewLink { get; set; }
+    }
+}

--- a/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchangeResult.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchangeResult.cs
@@ -1,0 +1,6 @@
+namespace Glovelly.Api.Services;
+
+public sealed record GoogleDriveOAuthTokenExchangeResult(
+    bool IsSuccess,
+    int StatusCode,
+    string ResponseBody);

--- a/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchangeResult.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchangeResult.cs
@@ -3,4 +3,5 @@ namespace Glovelly.Api.Services;
 public sealed record GoogleDriveOAuthTokenExchangeResult(
     bool IsSuccess,
     int StatusCode,
-    string ResponseBody);
+    string ResponseBody,
+    GoogleDriveOAuthTokenResponse? TokenResponse = null);

--- a/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchanger.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchanger.cs
@@ -1,8 +1,11 @@
+using System.Text.Json;
+
 namespace Glovelly.Api.Services;
 
 public sealed class GoogleDriveOAuthTokenExchanger(HttpClient httpClient) : IGoogleDriveOAuthTokenExchanger
 {
     private const string GoogleTokenEndpoint = "https://oauth2.googleapis.com/token";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public async Task<GoogleDriveOAuthTokenExchangeResult> ExchangeCodeAsync(
         string code,
@@ -25,10 +28,25 @@ public sealed class GoogleDriveOAuthTokenExchanger(HttpClient httpClient) : IGoo
 
         using var response = await httpClient.SendAsync(request, cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        GoogleDriveOAuthTokenResponse? tokenResponse = null;
+        if (response.IsSuccessStatusCode)
+        {
+            try
+            {
+                tokenResponse = JsonSerializer.Deserialize<GoogleDriveOAuthTokenResponse>(
+                    responseBody,
+                    JsonOptions);
+            }
+            catch (JsonException)
+            {
+                tokenResponse = null;
+            }
+        }
 
         return new GoogleDriveOAuthTokenExchangeResult(
             response.IsSuccessStatusCode,
             (int)response.StatusCode,
-            responseBody);
+            responseBody,
+            tokenResponse);
     }
 }

--- a/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchanger.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenExchanger.cs
@@ -1,0 +1,34 @@
+namespace Glovelly.Api.Services;
+
+public sealed class GoogleDriveOAuthTokenExchanger(HttpClient httpClient) : IGoogleDriveOAuthTokenExchanger
+{
+    private const string GoogleTokenEndpoint = "https://oauth2.googleapis.com/token";
+
+    public async Task<GoogleDriveOAuthTokenExchangeResult> ExchangeCodeAsync(
+        string code,
+        string redirectUri,
+        string clientId,
+        string clientSecret,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, GoogleTokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["code"] = code,
+                ["client_id"] = clientId,
+                ["client_secret"] = clientSecret,
+                ["redirect_uri"] = redirectUri,
+                ["grant_type"] = "authorization_code",
+            }),
+        };
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        return new GoogleDriveOAuthTokenExchangeResult(
+            response.IsSuccessStatusCode,
+            (int)response.StatusCode,
+            responseBody);
+    }
+}

--- a/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenResponse.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveOAuthTokenResponse.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Glovelly.Api.Services;
+
+public sealed class GoogleDriveOAuthTokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; set; }
+
+    [JsonPropertyName("refresh_token_expires_in")]
+    public int? RefreshTokenExpiresIn { get; set; }
+
+    [JsonPropertyName("scope")]
+    public string Scope { get; set; } = string.Empty;
+
+    [JsonPropertyName("token_type")]
+    public string TokenType { get; set; } = "Bearer";
+}

--- a/backend/Glovelly.Api/Services/GoogleDriveTokenProtector.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveTokenProtector.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Glovelly.Api.Services;
+
+public sealed class GoogleDriveTokenProtector(IDataProtectionProvider dataProtectionProvider)
+    : IGoogleDriveTokenProtector
+{
+    private readonly IDataProtector _protector =
+        dataProtectionProvider.CreateProtector("Glovelly.GoogleDriveTokens.v1");
+
+    public string Protect(string token)
+    {
+        return _protector.Protect(token);
+    }
+
+    public string Unprotect(string encryptedToken)
+    {
+        return _protector.Unprotect(encryptedToken);
+    }
+}

--- a/backend/Glovelly.Api/Services/GoogleDriveUploadResult.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveUploadResult.cs
@@ -1,0 +1,6 @@
+namespace Glovelly.Api.Services;
+
+public sealed record GoogleDriveUploadResult(
+    string Id,
+    string Name,
+    string? WebViewLink);

--- a/backend/Glovelly.Api/Services/IGoogleDriveApiClient.cs
+++ b/backend/Glovelly.Api/Services/IGoogleDriveApiClient.cs
@@ -1,0 +1,16 @@
+namespace Glovelly.Api.Services;
+
+public interface IGoogleDriveApiClient
+{
+    Task<GoogleDriveAccessTokenRefreshResult> RefreshAccessTokenAsync(
+        string refreshToken,
+        string clientId,
+        string clientSecret,
+        CancellationToken cancellationToken);
+
+    Task<GoogleDriveUploadResult> UploadPdfAsync(
+        string accessToken,
+        string fileName,
+        byte[] content,
+        CancellationToken cancellationToken);
+}

--- a/backend/Glovelly.Api/Services/IGoogleDriveOAuthTokenExchanger.cs
+++ b/backend/Glovelly.Api/Services/IGoogleDriveOAuthTokenExchanger.cs
@@ -1,0 +1,11 @@
+namespace Glovelly.Api.Services;
+
+public interface IGoogleDriveOAuthTokenExchanger
+{
+    Task<GoogleDriveOAuthTokenExchangeResult> ExchangeCodeAsync(
+        string code,
+        string redirectUri,
+        string clientId,
+        string clientSecret,
+        CancellationToken cancellationToken);
+}

--- a/backend/Glovelly.Api/Services/IGoogleDriveTokenProtector.cs
+++ b/backend/Glovelly.Api/Services/IGoogleDriveTokenProtector.cs
@@ -1,0 +1,7 @@
+namespace Glovelly.Api.Services;
+
+public interface IGoogleDriveTokenProtector
+{
+    string Protect(string token);
+    string Unprotect(string encryptedToken);
+}

--- a/backend/Glovelly.Api/Services/IInvoiceDeliveryChannel.cs
+++ b/backend/Glovelly.Api/Services/IInvoiceDeliveryChannel.cs
@@ -4,5 +4,7 @@ public interface IInvoiceDeliveryChannel
 {
     InvoiceDeliveryChannel Channel { get; }
 
-    Task DeliverAsync(InvoiceDeliveryRequest request, CancellationToken cancellationToken = default);
+    Task<InvoiceDeliveryResult> DeliverAsync(
+        InvoiceDeliveryRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/backend/Glovelly.Api/Services/InvoiceDeliveryChannel.cs
+++ b/backend/Glovelly.Api/Services/InvoiceDeliveryChannel.cs
@@ -3,4 +3,5 @@ namespace Glovelly.Api.Services;
 public enum InvoiceDeliveryChannel
 {
     Email,
+    GoogleDrive,
 }

--- a/backend/Glovelly.Api/Services/InvoiceDeliveryResult.cs
+++ b/backend/Glovelly.Api/Services/InvoiceDeliveryResult.cs
@@ -1,0 +1,3 @@
+namespace Glovelly.Api.Services;
+
+public sealed record InvoiceDeliveryResult(string Recipient);

--- a/backend/Glovelly.Api/Services/InvoiceDeliveryService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceDeliveryService.cs
@@ -19,13 +19,13 @@ public sealed class InvoiceDeliveryService(
         var deliveryChannel = deliveryChannels.FirstOrDefault(value => value.Channel == channel)
             ?? throw new InvalidOperationException($"Invoice delivery channel {channel} is not registered.");
 
-        await deliveryChannel.DeliverAsync(
+        var result = await deliveryChannel.DeliverAsync(
             new InvoiceDeliveryRequest(invoice, client, userId, message, attachmentFileName, senderIdentity),
             cancellationToken);
 
         invoice.DeliveryCount += 1;
         invoice.LastDeliveryChannel = channel.ToString();
-        invoice.LastDeliveryRecipient = client.Email.Trim();
+        invoice.LastDeliveryRecipient = result.Recipient;
         invoice.LastDeliveredUtc = timeProvider.GetUtcNow();
         invoice.LastDeliveredByUserId = userId;
     }

--- a/backend/Glovelly.Api/Services/InvoiceEmailDeliveryChannel.cs
+++ b/backend/Glovelly.Api/Services/InvoiceEmailDeliveryChannel.cs
@@ -10,7 +10,7 @@ public sealed class InvoiceEmailDeliveryChannel(
 {
     public InvoiceDeliveryChannel Channel => InvoiceDeliveryChannel.Email;
 
-    public async Task DeliverAsync(
+    public async Task<InvoiceDeliveryResult> DeliverAsync(
         InvoiceDeliveryRequest request,
         CancellationToken cancellationToken = default)
     {
@@ -53,6 +53,8 @@ public sealed class InvoiceEmailDeliveryChannel(
                         invoice.PdfBlob)
                 ]),
             cancellationToken);
+
+        return new InvoiceDeliveryResult(client.Email.Trim());
     }
 
     private static string BuildPlainTextBody(Invoice invoice, string? message)

--- a/backend/Glovelly.Api/Services/InvoiceGoogleDriveDeliveryChannel.cs
+++ b/backend/Glovelly.Api/Services/InvoiceGoogleDriveDeliveryChannel.cs
@@ -1,0 +1,108 @@
+using Glovelly.Api.Configuration;
+using Glovelly.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Glovelly.Api.Services;
+
+internal sealed class InvoiceGoogleDriveDeliveryChannel(
+    AppDbContext dbContext,
+    IGoogleDriveApiClient googleDriveApiClient,
+    IGoogleDriveTokenProtector tokenProtector,
+    StartupSettings settings) : IInvoiceDeliveryChannel
+{
+    public InvoiceDeliveryChannel Channel => InvoiceDeliveryChannel.GoogleDrive;
+
+    public async Task<InvoiceDeliveryResult> DeliverAsync(
+        InvoiceDeliveryRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!request.UserId.HasValue)
+        {
+            throw new InvalidOperationException("A signed-in user is required to publish invoices to Google Drive.");
+        }
+
+        var invoice = request.Invoice;
+        if (invoice.PdfBlob is null || invoice.PdfBlob.Length == 0)
+        {
+            throw new InvalidOperationException("Invoice PDF is missing.");
+        }
+
+        var connection = await dbContext.GoogleDriveConnections
+            .SingleOrDefaultAsync(
+                value => value.UserId == request.UserId.Value && value.RevokedAtUtc == null,
+                cancellationToken)
+            ?? throw new InvalidOperationException("Google Drive is not connected.");
+
+        if (connection.RefreshTokenExpiresAtUtc is not null &&
+            connection.RefreshTokenExpiresAtUtc <= DateTimeOffset.UtcNow)
+        {
+            throw new InvalidOperationException("Google Drive connection has expired. Reconnect Google Drive.");
+        }
+
+        var accessToken = tokenProtector.Unprotect(connection.EncryptedAccessToken);
+        if (connection.AccessTokenExpiresAtUtc <= DateTimeOffset.UtcNow.AddMinutes(1))
+        {
+            accessToken = await RefreshAccessTokenAsync(connection, cancellationToken);
+        }
+
+        var upload = await googleDriveApiClient.UploadPdfAsync(
+            accessToken,
+            request.AttachmentFileName,
+            invoice.PdfBlob,
+            cancellationToken);
+
+        return new InvoiceDeliveryResult(
+            string.IsNullOrWhiteSpace(upload.WebViewLink)
+                ? $"Google Drive file {upload.Id}"
+                : upload.WebViewLink);
+    }
+
+    private async Task<string> RefreshAccessTokenAsync(
+        Models.GoogleDriveConnection connection,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(settings.GoogleClientId) ||
+            string.IsNullOrWhiteSpace(settings.GoogleClientSecret))
+        {
+            throw new InvalidOperationException("Google OAuth is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(connection.EncryptedRefreshToken))
+        {
+            throw new InvalidOperationException("Google Drive refresh token is missing. Reconnect Google Drive.");
+        }
+
+        var refreshToken = tokenProtector.Unprotect(connection.EncryptedRefreshToken);
+        var refreshResult = await googleDriveApiClient.RefreshAccessTokenAsync(
+            refreshToken,
+            settings.GoogleClientId,
+            settings.GoogleClientSecret,
+            cancellationToken);
+        if (!refreshResult.IsSuccess ||
+            refreshResult.TokenResponse is null ||
+            string.IsNullOrWhiteSpace(refreshResult.TokenResponse.AccessToken))
+        {
+            connection.RevokedAtUtc = DateTimeOffset.UtcNow;
+            await dbContext.SaveChangesAsync(cancellationToken);
+            throw new InvalidOperationException("Google Drive connection could not be refreshed. Reconnect Google Drive.");
+        }
+
+        var tokenResponse = refreshResult.TokenResponse;
+        var now = DateTimeOffset.UtcNow;
+        connection.EncryptedAccessToken = tokenProtector.Protect(tokenResponse.AccessToken);
+        connection.AccessTokenExpiresAtUtc = now.AddSeconds(tokenResponse.ExpiresIn);
+        connection.Scope = string.IsNullOrWhiteSpace(tokenResponse.Scope)
+            ? connection.Scope
+            : tokenResponse.Scope;
+        connection.TokenType = string.IsNullOrWhiteSpace(tokenResponse.TokenType)
+            ? connection.TokenType
+            : tokenResponse.TokenType;
+        connection.UpdatedAtUtc = now;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return tokenResponse.AccessToken;
+    }
+}

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -14,12 +14,14 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInvoiceWorkflowService, InvoiceWorkflowService>();
         services.AddScoped<IInvoiceDeliveryService, InvoiceDeliveryService>();
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceEmailDeliveryChannel>();
+        services.AddScoped<IInvoiceDeliveryChannel, InvoiceGoogleDriveDeliveryChannel>();
         services.AddOptions<ResendClientOptions>()
             .Configure<IOptions<EmailSettings>>((resendOptions, emailOptions) =>
             {
                 resendOptions.ApiToken = emailOptions.Value.Resend.ApiKey ?? string.Empty;
             });
         services.AddHttpClient<ResendClient>();
+        services.AddHttpClient<IGoogleDriveApiClient, GoogleDriveApiClient>();
         services.AddScoped<IResend, ResendClient>();
         services.AddScoped<IEmailSender>(provider =>
         {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -2275,6 +2275,52 @@ function App({ appMetadata }: AppProps) {
     }
   }
 
+  const handlePublishInvoiceGoogleDrive = async (invoice: Invoice) => {
+    const shouldProceed = window.confirm(
+      `Publish ${invoice.invoiceNumber} to your connected Google Drive?`
+    )
+    if (!shouldProceed) {
+      return
+    }
+
+    setIsInvoiceLoading(true)
+    setInvoiceStatus(`Publishing ${invoice.invoiceNumber} to Google Drive...`)
+
+    try {
+      const response = await fetchWithSession(
+        buildApiUrl(`/invoices/${invoice.id}/publish/google-drive`),
+        {
+          method: 'POST',
+        }
+      )
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const pdfError = problem?.errors?.pdf?.[0]
+        throw new Error(
+          pdfError ??
+            problem?.detail ??
+            problem?.title ??
+            'Unable to publish invoice to Google Drive.'
+        )
+      }
+
+      const updatedInvoice = (await response.json()) as Invoice
+      setInvoices((current) =>
+        current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
+      )
+      setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} published to Google Drive.`)
+    } catch (error) {
+      setInvoiceStatus(
+        error instanceof Error
+          ? error.message
+          : 'Unable to publish invoice to Google Drive.'
+      )
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
   const handleAddInvoiceAdjustment = async (invoice: Invoice) => {
     const amount = Number.parseFloat(adjustmentAmount)
     if (!Number.isFinite(amount) || amount === 0) {
@@ -2500,6 +2546,7 @@ function App({ appMetadata }: AppProps) {
         invoiceStatus={invoiceStatus}
         invoices={invoices}
         issuedInvoiceCount={issuedInvoiceCount}
+        isGoogleDriveConnected={authUser?.isGoogleDriveConnected ?? false}
         isInvoiceLoading={isInvoiceLoading}
         isSellerProfileConfigured={sellerProfile.isConfigured}
         onAdjustmentAmountChange={setAdjustmentAmount}
@@ -2510,6 +2557,7 @@ function App({ appMetadata }: AppProps) {
         onDownloadPdf={handleDownloadInvoicePdf}
         onInvoiceStatusChange={handleInvoiceStatusChange}
         onOpenSellerProfile={openSellerProfile}
+        onPublishGoogleDrive={handlePublishInvoiceGoogleDrive}
         onReissue={handleInvoiceReissue}
         onSendEmail={handleSendInvoiceEmail}
         onSearchQueryChange={setInvoiceSearchQuery}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -2577,6 +2577,13 @@ function App({ appMetadata }: AppProps) {
                             : 'Seller profile not set up'}
                       </span>
                     </div>
+                    <div className="profile-meta">
+                      <span>
+                        {authUser?.isGoogleDriveConnected
+                          ? 'Connected to Google Drive'
+                          : 'Google Drive not connected'}
+                      </span>
+                    </div>
                     <label className="theme-field" htmlFor="theme-preference-select">
                       <span>Theme</span>
                       <select
@@ -2607,7 +2614,9 @@ function App({ appMetadata }: AppProps) {
                       type="button"
                       disabled={isLoading || isAdminLoading}
                     >
-                      Connect Google Drive
+                      {authUser?.isGoogleDriveConnected
+                        ? 'Reconnect Google Drive'
+                        : 'Connect Google Drive'}
                     </button>
                     <button
                       className="ghost-button profile-settings"

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1214,6 +1214,10 @@ function App({ appMetadata }: AppProps) {
     setIsUserSettingsOpen(true)
   }
 
+  const connectGoogleDrive = () => {
+    window.location.assign(buildApiUrl('/integrations/google-drive/connect'))
+  }
+
   const openSellerProfile = () => {
     setSellerProfileForm(toSellerProfileForm(sellerProfile))
     setSellerProfileStatus(
@@ -2595,6 +2599,15 @@ function App({ appMetadata }: AppProps) {
                       disabled={isLoading || isAdminLoading || isSellerProfileSaving}
                     >
                       Seller profile
+                    </button>
+                    <button
+                      className="ghost-button profile-settings"
+                      onClick={connectGoogleDrive}
+                      role="menuitem"
+                      type="button"
+                      disabled={isLoading || isAdminLoading}
+                    >
+                      Connect Google Drive
                     </button>
                     <button
                       className="ghost-button profile-settings"

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -1501,6 +1501,7 @@ type InvoicesSectionProps = {
   invoiceStatus: string
   invoices: Invoice[]
   issuedInvoiceCount: number
+  isGoogleDriveConnected: boolean
   isInvoiceLoading: boolean
   isSellerProfileConfigured: boolean
   onAdjustmentAmountChange: (value: string) => void
@@ -1511,6 +1512,7 @@ type InvoicesSectionProps = {
   onDownloadPdf: (invoice: Invoice) => Promise<void>
   onInvoiceStatusChange: (invoice: Invoice, status: InvoiceStatus) => Promise<void>
   onOpenSellerProfile: () => void
+  onPublishGoogleDrive: (invoice: Invoice) => Promise<void>
   onReissue: (invoice: Invoice) => Promise<void>
   onSendEmail: (invoice: Invoice) => Promise<void>
   onSearchQueryChange: (value: string) => void
@@ -1531,6 +1533,7 @@ export function InvoicesSection({
   invoiceStatus,
   invoices,
   issuedInvoiceCount,
+  isGoogleDriveConnected,
   isInvoiceLoading,
   isSellerProfileConfigured,
   onAdjustmentAmountChange,
@@ -1541,6 +1544,7 @@ export function InvoicesSection({
   onDownloadPdf,
   onInvoiceStatusChange,
   onOpenSellerProfile,
+  onPublishGoogleDrive,
   onReissue,
   onSendEmail,
   onSearchQueryChange,
@@ -1649,6 +1653,19 @@ export function InvoicesSection({
                 }
               >
                 {selectedInvoice?.status === 'Draft' ? 'Redraft' : 'Re-issue'}
+              </button>
+              <button
+                className="ghost-button"
+                onClick={() => selectedInvoice && void onPublishGoogleDrive(selectedInvoice)}
+                type="button"
+                disabled={!selectedInvoice || isInvoiceLoading || !isGoogleDriveConnected}
+                title={
+                  isGoogleDriveConnected
+                    ? undefined
+                    : 'Connect Google Drive from your profile menu first.'
+                }
+              >
+                Publish to Drive
               </button>
               <button
                 className="ghost-button"

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -33,6 +33,7 @@ export type AuthUser = {
   passengerMileageRate: number | null
   invoiceFilenamePattern: string | null
   invoiceReplyToEmail: string | null
+  isGoogleDriveConnected: boolean
 }
 
 export type AdminUser = {

--- a/frontend/glovelly-web/vite.config.ts
+++ b/frontend/glovelly-web/vite.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
         target: 'http://localhost:5153',
         changeOrigin: true,
       },
+      '/integrations': {
+        target: 'http://localhost:5153',
+        changeOrigin: true,
+      },
       '/seller-profile': {
         target: 'http://localhost:5153',
         changeOrigin: true,


### PR DESCRIPTION
## Summary

Adds the first Google Drive integration slice for invoices:

- adds a separate Google Drive OAuth connect/callback flow using the existing Google app credentials
- persists encrypted Google Drive OAuth tokens against the signed-in user
- stores Data Protection keys in the application DB when running with Postgres
- exposes Google Drive connected state through `/auth/me` and the profile UI
- adds a Google Drive invoice delivery channel that uploads generated invoice PDFs to Drive
- adds `POST /invoices/{id}/publish/google-drive` and a `Publish to Drive` button in the invoice UI

## Notes

- Google Drive uploads currently go to the user’s default Drive/root location. Folder selection can be added as a follow-up slice.
- I generated the one-off DB script outside the repo at `/private/tmp/glovelly-google-drive-connection-migration.sql`; it is intentionally not committed.
- NuGet audit still reports existing Microsoft Data Protection/Crypto package advisories during restore on the current 10.0.5 package baseline.

## Validation

- `dotnet test glovelly.sln` passes: 77/77
- `npm run build` passes in `frontend/glovelly-web`