### PR TITLE
[codex] Surface Google Drive invoice upload links

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
@@ -226,11 +226,17 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
             content: null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var publishResult = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var updatedInvoice = publishResult.GetProperty("invoice");
 
         Assert.Equal("access-token", driveClient.AccessToken);
         Assert.Equal("GLV-DRIVE-001.pdf", driveClient.FileName);
         Assert.Equal(pdfBytes, driveClient.Content);
+        Assert.Equal("drive-file-id", publishResult.GetProperty("fileId").GetString());
+        Assert.Equal("GLV-DRIVE-001.pdf", publishResult.GetProperty("fileName").GetString());
+        Assert.Equal(
+            "https://drive.google.com/file/d/drive-file-id/view",
+            publishResult.GetProperty("webViewLink").GetString());
         Assert.Equal(1, updatedInvoice.GetProperty("deliveryCount").GetInt32());
         Assert.Equal("GoogleDrive", updatedInvoice.GetProperty("lastDeliveryChannel").GetString());
         Assert.Equal(

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -497,9 +497,10 @@ public static class InvoiceEndpoints
                 invoice.Client,
                 userDefaultPattern);
 
+            InvoiceDeliveryResult deliveryResult;
             try
             {
-                await invoiceDeliveryService.DeliverAsync(
+                deliveryResult = await invoiceDeliveryService.DeliverAsync(
                     InvoiceDeliveryChannel.GoogleDrive,
                     invoice,
                     invoice.Client,
@@ -533,7 +534,11 @@ public static class InvoiceEndpoints
                 invoice.LastDeliveryRecipient,
                 userId);
 
-            return Results.Ok(invoice);
+            return Results.Ok(new InvoiceGoogleDrivePublishResponse(
+                invoice,
+                deliveryResult.FileId,
+                deliveryResult.FileName,
+                deliveryResult.WebViewLink));
         });
 
         group.MapPost("/{id:guid}/adjustments", async (
@@ -635,4 +640,9 @@ public static class InvoiceEndpoints
     private sealed record InvoiceStatusUpdateRequest(InvoiceStatus Status);
     private sealed record InvoiceAdjustmentCreateRequest(decimal Amount, string Reason);
     private sealed record InvoiceEmailDeliveryRequest(string? Message);
+    private sealed record InvoiceGoogleDrivePublishResponse(
+        Invoice Invoice,
+        string? FileId,
+        string? FileName,
+        string? WebViewLink);
 }

--- a/backend/Glovelly.Api/Services/IInvoiceDeliveryService.cs
+++ b/backend/Glovelly.Api/Services/IInvoiceDeliveryService.cs
@@ -4,7 +4,7 @@ namespace Glovelly.Api.Services;
 
 public interface IInvoiceDeliveryService
 {
-    Task DeliverAsync(
+    Task<InvoiceDeliveryResult> DeliverAsync(
         InvoiceDeliveryChannel channel,
         Invoice invoice,
         Client client,

--- a/backend/Glovelly.Api/Services/InvoiceDeliveryResult.cs
+++ b/backend/Glovelly.Api/Services/InvoiceDeliveryResult.cs
@@ -1,3 +1,7 @@
 namespace Glovelly.Api.Services;
 
-public sealed record InvoiceDeliveryResult(string Recipient);
+public sealed record InvoiceDeliveryResult(
+    string Recipient,
+    string? FileId = null,
+    string? FileName = null,
+    string? WebViewLink = null);

--- a/backend/Glovelly.Api/Services/InvoiceDeliveryService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceDeliveryService.cs
@@ -6,7 +6,7 @@ public sealed class InvoiceDeliveryService(
     IEnumerable<IInvoiceDeliveryChannel> deliveryChannels,
     TimeProvider timeProvider) : IInvoiceDeliveryService
 {
-    public async Task DeliverAsync(
+    public async Task<InvoiceDeliveryResult> DeliverAsync(
         InvoiceDeliveryChannel channel,
         Invoice invoice,
         Client client,
@@ -28,5 +28,7 @@ public sealed class InvoiceDeliveryService(
         invoice.LastDeliveryRecipient = result.Recipient;
         invoice.LastDeliveredUtc = timeProvider.GetUtcNow();
         invoice.LastDeliveredByUserId = userId;
+
+        return result;
     }
 }

--- a/backend/Glovelly.Api/Services/InvoiceGoogleDriveDeliveryChannel.cs
+++ b/backend/Glovelly.Api/Services/InvoiceGoogleDriveDeliveryChannel.cs
@@ -53,10 +53,15 @@ internal sealed class InvoiceGoogleDriveDeliveryChannel(
             invoice.PdfBlob,
             cancellationToken);
 
+        var webViewLink = string.IsNullOrWhiteSpace(upload.WebViewLink)
+            ? null
+            : upload.WebViewLink;
+
         return new InvoiceDeliveryResult(
-            string.IsNullOrWhiteSpace(upload.WebViewLink)
-                ? $"Google Drive file {upload.Id}"
-                : upload.WebViewLink);
+            webViewLink ?? $"Google Drive file {upload.Id}",
+            upload.Id,
+            upload.Name,
+            webViewLink);
     }
 
     private async Task<string> RefreshAccessTokenAsync(

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -852,12 +852,21 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
   padding: 10px 14px;
   border-radius: 999px;
   background: color-mix(in srgb, #f47d2a 20%, transparent);
   color: var(--heading);
   font-size: 0.86rem;
   line-height: 1.2;
+}
+
+.status-pill a {
+  color: var(--heading);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .form-grid {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -56,6 +56,18 @@ import type {
 } from './appShared'
 import './App.css'
 
+type GoogleDrivePublishLink = {
+  href: string
+  fileName: string | null
+}
+
+type GoogleDrivePublishResponse = {
+  invoice: Invoice
+  fileId: string | null
+  fileName: string | null
+  webViewLink: string | null
+}
+
 function getCurrentMonthValue() {
   return new Date().toISOString().slice(0, 7)
 }
@@ -175,6 +187,8 @@ function App({ appMetadata }: AppProps) {
   const [isInvoiceEditorOpen, setIsInvoiceEditorOpen] = useState(false)
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
   const [invoiceStatus, setInvoiceStatus] = useState(defaultInvoiceStatus)
+  const [googleDrivePublishLink, setGoogleDrivePublishLink] =
+    useState<GoogleDrivePublishLink | null>(null)
   const [isInvoiceLoading, setIsInvoiceLoading] = useState(false)
   const [adjustmentAmount, setAdjustmentAmount] = useState('')
   const [adjustmentReason, setAdjustmentReason] = useState('')
@@ -2284,6 +2298,7 @@ function App({ appMetadata }: AppProps) {
     }
 
     setIsInvoiceLoading(true)
+    setGoogleDrivePublishLink(null)
     setInvoiceStatus(`Publishing ${invoice.invoiceNumber} to Google Drive...`)
 
     try {
@@ -2305,12 +2320,23 @@ function App({ appMetadata }: AppProps) {
         )
       }
 
-      const updatedInvoice = (await response.json()) as Invoice
+      const publishResult = (await response.json()) as GoogleDrivePublishResponse
+      const updatedInvoice = publishResult.invoice
       setInvoices((current) =>
         current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
       )
-      setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} published to Google Drive.`)
+      const driveLink = publishResult.webViewLink?.trim()
+      if (driveLink) {
+        setGoogleDrivePublishLink({
+          href: driveLink,
+          fileName: publishResult.fileName,
+        })
+        setInvoiceStatus(`Uploaded ${updatedInvoice.invoiceNumber} to Google Drive.`)
+      } else {
+        setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} published to Google Drive.`)
+      }
     } catch (error) {
+      setGoogleDrivePublishLink(null)
       setInvoiceStatus(
         error instanceof Error
           ? error.message
@@ -2544,6 +2570,9 @@ function App({ appMetadata }: AppProps) {
         isEditorOpen={isInvoiceEditorOpen}
         invoiceSearchQuery={invoiceSearchQuery}
         invoiceStatus={invoiceStatus}
+        googleDrivePublishLink={
+          invoiceStatus.startsWith('Uploaded ') ? googleDrivePublishLink : null
+        }
         invoices={invoices}
         issuedInvoiceCount={issuedInvoiceCount}
         isGoogleDriveConnected={authUser?.isGoogleDriveConnected ?? false}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -1496,6 +1496,7 @@ type InvoicesSectionProps = {
   clientNamesById: ReadonlyMap<string, string>
   draftInvoiceCount: number
   filteredInvoices: Invoice[]
+  googleDrivePublishLink: { href: string; fileName: string | null } | null
   isEditorOpen: boolean
   invoiceSearchQuery: string
   invoiceStatus: string
@@ -1528,6 +1529,7 @@ export function InvoicesSection({
   clientNamesById,
   draftInvoiceCount,
   filteredInvoices,
+  googleDrivePublishLink,
   isEditorOpen,
   invoiceSearchQuery,
   invoiceStatus,
@@ -1566,7 +1568,23 @@ export function InvoicesSection({
               <p className="section-label">Billing</p>
               <h2>Invoices</h2>
             </div>
-            <span className="status-pill">{invoiceStatus}</span>
+            <span className="status-pill">
+              <span>{invoiceStatus}</span>
+              {googleDrivePublishLink ? (
+                <a
+                  href={googleDrivePublishLink.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={
+                    googleDrivePublishLink.fileName
+                      ? `Open ${googleDrivePublishLink.fileName} in Google Drive`
+                      : 'Open file in Google Drive'
+                  }
+                >
+                  Open file
+                </a>
+              ) : null}
+            </span>
           </div>
 
           <label className="search-field">


### PR DESCRIPTION
## Summary
- Return structured Google Drive upload metadata from the invoice publish endpoint.
- Surface the uploaded file permalink in the invoice status UI with an `Open file` link.
- Clear and gate the Drive link so stale links are not shown after later failures or unrelated status changes.

## Why
Issue #79 asks for immediate feedback after publishing an invoice to Google Drive, including a clickable Drive permalink. The upload client already receives `webViewLink`, but the publish response only returned the updated invoice, so the frontend could not display a purpose-built link.

## Validation
- `dotnet test glovelly.sln`
- `npm run build` in `frontend/glovelly-web`

Closes #79