### PR TITLE
[codex] Configure Google Drive invoice upload settings

### DIFF
--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -90,6 +90,67 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task UpdateSettings_WhenGoogleDriveConnected_PersistsInvoiceUploadFolderId()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            dbContext.GoogleDriveConnections.Add(new GoogleDriveConnection
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                EncryptedAccessToken = "encrypted-access-token",
+                EncryptedRefreshToken = "encrypted-refresh-token",
+                AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(30),
+                RefreshTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(1),
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+                ConnectedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            invoiceFilenamePattern = "{InvoiceNumber}",
+            invoiceReplyToEmail = (string?)null,
+            invoiceUploadFolderId = "  drive-folder-id  ",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("drive-folder-id", payload.GetProperty("invoiceUploadFolderId").GetString());
+
+        var meResponse = await _client.GetAsync("/auth/me");
+        var mePayload = await meResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("drive-folder-id", mePayload.GetProperty("invoiceUploadFolderId").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateSettings_WithInvoiceUploadFolderIdWhenGoogleDriveDisconnected_ReturnsValidationProblem()
+    {
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            invoiceFilenamePattern = "{InvoiceNumber}",
+            invoiceReplyToEmail = (string?)null,
+            invoiceUploadFolderId = "drive-folder-id",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Connect Google Drive before setting an invoice upload folder.",
+            problem.GetProperty("errors").GetProperty("invoiceUploadFolderId")[0].GetString());
+    }
+
+    [Fact]
     public async Task UpdateSettings_PersistsInvoiceFilenamePatternAndReplyToEmail()
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new

--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -40,6 +40,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
+            defaultPaymentWindowDays = 30,
             invoiceFilenamePattern = "{MonthName} {Year} {InvoiceNumber}",
             invoiceReplyToEmail = "billing@example.com",
         });
@@ -56,6 +57,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(
             "billing@example.com",
             payload.GetProperty("invoiceReplyToEmail").GetString());
+        Assert.Equal(30, payload.GetProperty("defaultPaymentWindowDays").GetInt32());
         Assert.False(payload.GetProperty("isGoogleDriveConnected").GetBoolean());
     }
 
@@ -115,6 +117,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
+            defaultPaymentWindowDays = 14,
             invoiceFilenamePattern = "{InvoiceNumber}",
             invoiceReplyToEmail = (string?)null,
             invoiceUploadFolderId = "  drive-folder-id  ",
@@ -137,6 +140,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
+            defaultPaymentWindowDays = 14,
             invoiceFilenamePattern = "{InvoiceNumber}",
             invoiceReplyToEmail = (string?)null,
             invoiceUploadFolderId = "drive-folder-id",
@@ -157,6 +161,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
+            defaultPaymentWindowDays = 21,
             invoiceFilenamePattern = "  {ClientName} {InvoiceNumber}  ",
             invoiceReplyToEmail = "  accounts@example.com  ",
         });
@@ -170,6 +175,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(
             "accounts@example.com",
             payload.GetProperty("invoiceReplyToEmail").GetString());
+        Assert.Equal(21, payload.GetProperty("defaultPaymentWindowDays").GetInt32());
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
+++ b/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
@@ -157,6 +157,49 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
     }
 
     [Fact]
+    public async Task GenerateInvoice_FromGig_UsesUserDefaultPaymentWindow()
+    {
+        var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            defaultPaymentWindowDays = 30,
+            invoiceFilenamePattern = "{InvoiceNumber}",
+            invoiceReplyToEmail = (string?)null,
+        });
+        updateSettingsResponse.EnsureSuccessStatusCode();
+
+        var createGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Payment window booking",
+            date = "2026-06-21",
+            venue = "The Hall",
+            fee = 300.00m,
+            travelMiles = 0m,
+            passengerCount = 0,
+            notes = "",
+            wasDriving = false,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        createGigResponse.EnsureSuccessStatusCode();
+
+        var createdGig = await createGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var generateResponse = await _client.PostAsync(
+            $"/gigs/{createdGig.GetProperty("id").GetGuid()}/generate-invoice",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.Created, generateResponse.StatusCode);
+
+        var invoice = await generateResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var expectedInvoiceDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        Assert.Equal(
+            expectedInvoiceDate.AddDays(30).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            invoice.GetProperty("dueDate").GetString());
+    }
+
+    [Fact]
     public async Task GenerateInvoice_FromSelectedGigs_CreatesCombinedInvoiceOrderedByDate()
     {
         var firstGigResponse = await _client.PostAsJsonAsync("/gigs", new

--- a/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
@@ -232,6 +232,7 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
         Assert.Equal("access-token", driveClient.AccessToken);
         Assert.Equal("GLV-DRIVE-001.pdf", driveClient.FileName);
         Assert.Equal(pdfBytes, driveClient.Content);
+        Assert.Null(driveClient.ParentFolderId);
         Assert.Equal("drive-file-id", publishResult.GetProperty("fileId").GetString());
         Assert.Equal("GLV-DRIVE-001.pdf", publishResult.GetProperty("fileName").GetString());
         Assert.Equal(
@@ -243,6 +244,55 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
             "https://drive.google.com/file/d/drive-file-id/view",
             updatedInvoice.GetProperty("lastDeliveryRecipient").GetString());
         Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("lastDeliveredByUserId").GetGuid());
+    }
+
+    [Fact]
+    public async Task PublishGoogleDrive_WhenConnectionHasUploadFolder_UsesFolder()
+    {
+        var driveClient = new FakeGoogleDriveApiClient();
+        using var factory = CreateFactoryWithGoogleDriveClient(driveClient);
+        var client = factory.CreateClient();
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var tokenProtector = scope.ServiceProvider.GetRequiredService<IGoogleDriveTokenProtector>();
+            dbContext.GoogleDriveConnections.Add(new GoogleDriveConnection
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                EncryptedAccessToken = tokenProtector.Protect("access-token"),
+                EncryptedRefreshToken = tokenProtector.Protect("refresh-token"),
+                AccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(30),
+                RefreshTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(1),
+                Scope = "https://www.googleapis.com/auth/drive.file",
+                TokenType = "Bearer",
+                InvoiceUploadFolderId = "drive-folder-id",
+                ConnectedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        var createInvoiceResponse = await client.PostAsJsonAsync("/invoices", new
+        {
+            invoiceNumber = "GLV-DRIVE-FOLDER",
+            clientId = TestData.FoxAndFinchId,
+            invoiceDate = "2026-04-20",
+            dueDate = "2026-05-04",
+            status = "Issued",
+            description = "Drive folder delivery test.",
+            pdfBlob = Convert.ToBase64String(Encoding.ASCII.GetBytes("%PDF-1.4 invoice content")),
+        });
+        createInvoiceResponse.EnsureSuccessStatusCode();
+        var createdInvoice = await createInvoiceResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await client.PostAsync(
+            $"/invoices/{createdInvoice.GetProperty("id").GetGuid()}/publish/google-drive",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("drive-folder-id", driveClient.ParentFolderId);
     }
 
     [Fact]
@@ -355,6 +405,7 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
         public string? ContentText { get; private set; }
         public byte[]? Content { get; private set; }
         public string? FileName { get; private set; }
+        public string? ParentFolderId { get; private set; }
         public string? RefreshToken { get; private set; }
         public string RefreshedAccessToken { get; set; } = "refreshed-access-token";
 
@@ -384,12 +435,14 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
             string accessToken,
             string fileName,
             byte[] content,
+            string? parentFolderId,
             CancellationToken cancellationToken)
         {
             AccessToken = accessToken;
             FileName = fileName;
             Content = content;
             ContentText = Encoding.ASCII.GetString(content);
+            ParentFolderId = parentFolderId;
 
             return Task.FromResult(new GoogleDriveUploadResult(
                 "drive-file-id",

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -103,6 +103,34 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
     }
 
     [Fact]
+    public async Task UpdateStatus_WhenFirstIssued_UsesUserDefaultPaymentWindow()
+    {
+        var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            defaultPaymentWindowDays = 30,
+            invoiceFilenamePattern = "{InvoiceNumber}",
+            invoiceReplyToEmail = (string?)null,
+        });
+        updateSettingsResponse.EnsureSuccessStatusCode();
+
+        var expectedInvoiceDate = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var response = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/status", new
+        {
+            status = "Issued",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            expectedInvoiceDate.AddDays(30).ToString("yyyy-MM-dd"),
+            updatedInvoice.GetProperty("dueDate").GetString());
+    }
+
+    [Fact]
     public async Task Reissue_WhenInvoiceExists_RegeneratesPdfAndLogsActionWithoutChangingFinancials()
     {
         var expectedInvoiceDate = DateOnly.FromDateTime(DateTime.UtcNow);

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -83,6 +83,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
                 .HasMaxLength(500);
             entity.Property(connection => connection.TokenType)
                 .HasMaxLength(50);
+            entity.Property(connection => connection.InvoiceUploadFolderId)
+                .HasMaxLength(200);
             entity.Property(connection => connection.ConnectedAtUtc)
                 .IsRequired();
             entity.Property(connection => connection.UpdatedAtUtc)

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -57,6 +57,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
                 .HasPrecision(18, 2);
             entity.Property(user => user.PassengerMileageRate)
                 .HasPrecision(18, 2);
+            entity.Property(user => user.DefaultPaymentWindowDays);
             entity.Property(user => user.InvoiceFilenamePattern)
                 .HasMaxLength(200);
             entity.Property(user => user.InvoiceReplyToEmail)

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -60,13 +60,14 @@ internal static class AuthEndpoints
             }
 
             var now = DateTimeOffset.UtcNow;
-            var isGoogleDriveConnected = await dbContext.GoogleDriveConnections
+            var googleDriveConnection = await dbContext.GoogleDriveConnections
                 .AsNoTracking()
-                .AnyAsync(connection =>
+                .FirstOrDefaultAsync(connection =>
                     connection.UserId == userId.Value &&
                     connection.RevokedAtUtc == null &&
                     (connection.RefreshTokenExpiresAtUtc == null ||
                      connection.RefreshTokenExpiresAtUtc > now));
+            var isGoogleDriveConnected = googleDriveConnection is not null;
 
             return Results.Ok(new
             {
@@ -79,6 +80,7 @@ internal static class AuthEndpoints
                 passengerMileageRate = localUser.PassengerMileageRate,
                 invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
                 invoiceReplyToEmail = localUser.InvoiceReplyToEmail,
+                invoiceUploadFolderId = googleDriveConnection?.InvoiceUploadFolderId,
                 isGoogleDriveConnected,
             });
         });
@@ -112,6 +114,33 @@ internal static class AuthEndpoints
             localUser.InvoiceFilenamePattern = request.InvoiceFilenamePattern?.Trim();
             localUser.InvoiceReplyToEmail = request.InvoiceReplyToEmail?.Trim();
 
+            var invoiceUploadFolderId = request.InvoiceUploadFolderId?.Trim();
+            if (string.IsNullOrEmpty(invoiceUploadFolderId))
+            {
+                invoiceUploadFolderId = null;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var googleDriveConnection = await dbContext.GoogleDriveConnections
+                .FirstOrDefaultAsync(connection =>
+                    connection.UserId == userId.Value &&
+                    connection.RevokedAtUtc == null &&
+                    (connection.RefreshTokenExpiresAtUtc == null ||
+                     connection.RefreshTokenExpiresAtUtc > now));
+            if (invoiceUploadFolderId is not null && googleDriveConnection is null)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["invoiceUploadFolderId"] = ["Connect Google Drive before setting an invoice upload folder."]
+                });
+            }
+
+            if (googleDriveConnection is not null)
+            {
+                googleDriveConnection.InvoiceUploadFolderId = invoiceUploadFolderId;
+                googleDriveConnection.UpdatedAtUtc = now;
+            }
+
             await dbContext.SaveChangesAsync();
 
             return Results.Ok(new
@@ -120,6 +149,7 @@ internal static class AuthEndpoints
                 passengerMileageRate = localUser.PassengerMileageRate,
                 invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
                 invoiceReplyToEmail = localUser.InvoiceReplyToEmail,
+                invoiceUploadFolderId = googleDriveConnection?.InvoiceUploadFolderId,
             });
         });
 
@@ -185,6 +215,14 @@ internal static class AuthEndpoints
             };
         }
 
+        if (request.InvoiceUploadFolderId is not null && string.IsNullOrWhiteSpace(request.InvoiceUploadFolderId))
+        {
+            return new Dictionary<string, string[]>
+            {
+                ["invoiceUploadFolderId"] = ["Google Drive folder ID cannot be empty or whitespace."]
+            };
+        }
+
         var validationResults = new List<ValidationResult>();
         var validationContext = new ValidationContext(request);
         var isValid = Validator.TryValidateObject(request, validationContext, validationResults, validateAllProperties: true);
@@ -217,5 +255,7 @@ internal static class AuthEndpoints
         decimal? PassengerMileageRate,
         string? InvoiceFilenamePattern,
         [property: EmailAddress(ErrorMessage = "Reply-to email must be a valid email address.")]
-        string? InvoiceReplyToEmail);
+        string? InvoiceReplyToEmail,
+        [property: StringLength(200, ErrorMessage = "Google Drive folder ID must be 200 characters or fewer.")]
+        string? InvoiceUploadFolderId);
 }

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -78,6 +78,7 @@ internal static class AuthEndpoints
                 profileImageUrl = user.FindFirstValue("picture") ?? user.FindFirstValue("profile") ?? string.Empty,
                 mileageRate = localUser.MileageRate,
                 passengerMileageRate = localUser.PassengerMileageRate,
+                defaultPaymentWindowDays = localUser.DefaultPaymentWindowDays,
                 invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
                 invoiceReplyToEmail = localUser.InvoiceReplyToEmail,
                 invoiceUploadFolderId = googleDriveConnection?.InvoiceUploadFolderId,
@@ -111,6 +112,7 @@ internal static class AuthEndpoints
 
             localUser.MileageRate = request.MileageRate;
             localUser.PassengerMileageRate = request.PassengerMileageRate;
+            localUser.DefaultPaymentWindowDays = request.DefaultPaymentWindowDays;
             localUser.InvoiceFilenamePattern = request.InvoiceFilenamePattern?.Trim();
             localUser.InvoiceReplyToEmail = request.InvoiceReplyToEmail?.Trim();
 
@@ -147,6 +149,7 @@ internal static class AuthEndpoints
             {
                 mileageRate = localUser.MileageRate,
                 passengerMileageRate = localUser.PassengerMileageRate,
+                defaultPaymentWindowDays = localUser.DefaultPaymentWindowDays,
                 invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
                 invoiceReplyToEmail = localUser.InvoiceReplyToEmail,
                 invoiceUploadFolderId = googleDriveConnection?.InvoiceUploadFolderId,
@@ -253,6 +256,8 @@ internal static class AuthEndpoints
         decimal? MileageRate,
         [Range(0, double.MaxValue, ErrorMessage = "Passenger mileage rate cannot be negative.")]
         decimal? PassengerMileageRate,
+        [property: Range(0, 3650, ErrorMessage = "Default payment window must be between 0 and 3650 days.")]
+        int? DefaultPaymentWindowDays,
         string? InvoiceFilenamePattern,
         [property: EmailAddress(ErrorMessage = "Reply-to email must be a valid email address.")]
         string? InvoiceReplyToEmail,

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -9,6 +9,8 @@ namespace Glovelly.Api.Endpoints;
 
 public static class InvoiceEndpoints
 {
+    private const int DefaultPaymentWindowDays = 14;
+
     public static RouteGroupBuilder MapInvoiceEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/", async (AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
@@ -84,11 +86,18 @@ public static class InvoiceEndpoints
             }
 
             var issuedOn = DateOnly.FromDateTime(DateTime.UtcNow);
+            var paymentWindowDays = userId.HasValue
+                ? await db.Users
+                    .AsNoTracking()
+                    .Where(value => value.Id == userId.Value && value.IsActive)
+                    .Select(value => value.DefaultPaymentWindowDays)
+                    .FirstOrDefaultAsync() ?? DefaultPaymentWindowDays
+                : DefaultPaymentWindowDays;
 
             invoice.Id = Guid.NewGuid();
             invoice.InvoiceNumber = invoice.InvoiceNumber.Trim();
             invoice.InvoiceDate = issuedOn;
-            invoice.DueDate = issuedOn.AddDays(14);
+            invoice.DueDate = issuedOn.AddDays(paymentWindowDays);
             invoice.Description = invoice.Description?.Trim();
             invoice.Client = null;
             invoice.Lines = new List<InvoiceLine>();

--- a/backend/Glovelly.Api/Models/GoogleDriveConnection.cs
+++ b/backend/Glovelly.Api/Models/GoogleDriveConnection.cs
@@ -12,6 +12,7 @@ public sealed class GoogleDriveConnection
     public DateTimeOffset? RefreshTokenExpiresAtUtc { get; set; }
     public string Scope { get; set; } = string.Empty;
     public string TokenType { get; set; } = "Bearer";
+    public string? InvoiceUploadFolderId { get; set; }
     public DateTimeOffset ConnectedAtUtc { get; set; }
     public DateTimeOffset UpdatedAtUtc { get; set; }
     public DateTimeOffset? RevokedAtUtc { get; set; }

--- a/backend/Glovelly.Api/Models/User.cs
+++ b/backend/Glovelly.Api/Models/User.cs
@@ -11,6 +11,7 @@ public sealed class User
     public string? DisplayName { get; set; }
     public decimal? MileageRate { get; set; }
     public decimal? PassengerMileageRate { get; set; }
+    public int? DefaultPaymentWindowDays { get; set; }
     public string? InvoiceFilenamePattern { get; set; }
     public string? InvoiceReplyToEmail { get; set; }
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/backend/Glovelly.Api/Services/GoogleDriveApiClient.cs
+++ b/backend/Glovelly.Api/Services/GoogleDriveApiClient.cs
@@ -57,18 +57,22 @@ public sealed class GoogleDriveApiClient(HttpClient httpClient) : IGoogleDriveAp
         string accessToken,
         string fileName,
         byte[] content,
+        string? parentFolderId,
         CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, GoogleDriveUploadEndpoint);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        request.Content = BuildMultipartContent(fileName, content);
+        request.Content = BuildMultipartContent(fileName, content, parentFolderId);
 
         using var response = await httpClient.SendAsync(request, cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
+            var folderHint = string.IsNullOrWhiteSpace(parentFolderId)
+                ? string.Empty
+                : " Check that the configured Google Drive folder ID exists and is accessible.";
             throw new InvalidOperationException(
-                $"Google Drive upload failed with HTTP {(int)response.StatusCode}: {responseBody}");
+                $"Google Drive upload failed with HTTP {(int)response.StatusCode}.{folderHint} {responseBody}".Trim());
         }
 
         var uploadResponse = JsonSerializer.Deserialize<GoogleDriveUploadResponse>(
@@ -85,15 +89,27 @@ public sealed class GoogleDriveApiClient(HttpClient httpClient) : IGoogleDriveAp
             uploadResponse.WebViewLink);
     }
 
-    private static MultipartContent BuildMultipartContent(string fileName, byte[] content)
+    private static MultipartContent BuildMultipartContent(
+        string fileName,
+        byte[] content,
+        string? parentFolderId)
     {
         var multipart = new MultipartContent("related");
-        var metadata = JsonSerializer.Serialize(
-            new
+        object metadataValue = string.IsNullOrWhiteSpace(parentFolderId)
+            ? new
             {
                 name = fileName,
                 mimeType = "application/pdf",
-            },
+            }
+            : new
+            {
+                name = fileName,
+                mimeType = "application/pdf",
+                parents = new[] { parentFolderId.Trim() },
+            };
+
+        var metadata = JsonSerializer.Serialize(
+            metadataValue,
             JsonOptions);
 
         multipart.Add(new StringContent(metadata, Encoding.UTF8, "application/json"));

--- a/backend/Glovelly.Api/Services/IGoogleDriveApiClient.cs
+++ b/backend/Glovelly.Api/Services/IGoogleDriveApiClient.cs
@@ -12,5 +12,6 @@ public interface IGoogleDriveApiClient
         string accessToken,
         string fileName,
         byte[] content,
+        string? parentFolderId,
         CancellationToken cancellationToken);
 }

--- a/backend/Glovelly.Api/Services/InvoiceGoogleDriveDeliveryChannel.cs
+++ b/backend/Glovelly.Api/Services/InvoiceGoogleDriveDeliveryChannel.cs
@@ -51,6 +51,7 @@ internal sealed class InvoiceGoogleDriveDeliveryChannel(
             accessToken,
             request.AttachmentFileName,
             invoice.PdfBlob,
+            connection.InvoiceUploadFolderId,
             cancellationToken);
 
         var webViewLink = string.IsNullOrWhiteSpace(upload.WebViewLink)

--- a/backend/Glovelly.Api/Services/InvoiceWorkflowService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceWorkflowService.cs
@@ -8,6 +8,8 @@ namespace Glovelly.Api.Services;
 
 public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWorkflowService
 {
+    private const int DefaultPaymentWindowDays = 14;
+
     public async Task<Invoice> GenerateInvoiceForGigAsync(
         Gig gig,
         Client client,
@@ -15,13 +17,14 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
         CancellationToken cancellationToken = default)
     {
         var invoiceDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var paymentWindowDays = await ResolvePaymentWindowDaysAsync(userId, cancellationToken);
         var invoice = new Invoice
         {
             Id = Guid.NewGuid(),
             InvoiceNumber = await GenerateInvoiceNumberAsync(invoiceDate, cancellationToken),
             ClientId = gig.ClientId,
             InvoiceDate = invoiceDate,
-            DueDate = invoiceDate.AddDays(14),
+            DueDate = invoiceDate.AddDays(paymentWindowDays),
             Status = InvoiceStatus.Draft,
             Description = BuildInvoiceDescription(gig),
             Client = null,
@@ -98,8 +101,9 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
     {
         var issuedUtc = DateTimeOffset.UtcNow;
         var invoiceDate = DateOnly.FromDateTime(issuedUtc.UtcDateTime);
+        var paymentWindowDays = await ResolvePaymentWindowDaysAsync(userId, cancellationToken);
         invoice.InvoiceDate = invoiceDate;
-        invoice.DueDate = invoiceDate.AddDays(14);
+        invoice.DueDate = invoiceDate.AddDays(paymentWindowDays);
         invoice.Status = InvoiceStatus.Issued;
         invoice.StatusUpdatedUtc = issuedUtc;
 
@@ -122,8 +126,9 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
     {
         var reissuedUtc = DateTimeOffset.UtcNow;
         var invoiceDate = DateOnly.FromDateTime(reissuedUtc.UtcDateTime);
+        var paymentWindowDays = await ResolvePaymentWindowDaysAsync(userId, cancellationToken);
         invoice.InvoiceDate = invoiceDate;
-        invoice.DueDate = invoiceDate.AddDays(14);
+        invoice.DueDate = invoiceDate.AddDays(paymentWindowDays);
         var sellerProfile = await ResolveSellerProfileAsync(userId, cancellationToken);
         invoice.PdfBlob = GenerateInvoicePdf(invoice, client, null, invoice.Lines.ToList(), sellerProfile);
         invoice.Status = InvoiceStatus.Draft;
@@ -142,12 +147,29 @@ public sealed class InvoiceWorkflowService(AppDbContext dbContext) : IInvoiceWor
     {
         var redraftedUtc = DateTimeOffset.UtcNow;
         var invoiceDate = DateOnly.FromDateTime(redraftedUtc.UtcDateTime);
+        var paymentWindowDays = await ResolvePaymentWindowDaysAsync(userId, cancellationToken);
         invoice.InvoiceDate = invoiceDate;
-        invoice.DueDate = invoiceDate.AddDays(14);
+        invoice.DueDate = invoiceDate.AddDays(paymentWindowDays);
         var sellerProfile = await ResolveSellerProfileAsync(userId, cancellationToken);
         invoice.PdfBlob = GenerateInvoicePdf(invoice, client, null, invoice.Lines.ToList(), sellerProfile);
         invoice.Status = InvoiceStatus.Draft;
         StampUpdate(invoice, userId);
+    }
+
+    private async Task<int> ResolvePaymentWindowDaysAsync(
+        Guid? userId,
+        CancellationToken cancellationToken)
+    {
+        if (!userId.HasValue)
+        {
+            return DefaultPaymentWindowDays;
+        }
+
+        return await dbContext.Users
+            .AsNoTracking()
+            .Where(user => user.Id == userId.Value && user.IsActive)
+            .Select(user => user.DefaultPaymentWindowDays)
+            .FirstOrDefaultAsync(cancellationToken) ?? DefaultPaymentWindowDays;
     }
 
     public async Task<InvoiceLine> CreateManualAdjustmentAsync(

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -333,6 +333,40 @@
   margin: 0;
 }
 
+.settings-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.drive-connection-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--surface-subtle);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
+  color: var(--muted-strong);
+  font-size: 0.86rem;
+}
+
+.drive-connection-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #a65f27;
+  box-shadow: 0 0 0 4px color-mix(in srgb, #a65f27 18%, transparent);
+}
+
+.drive-connection-indicator.connected {
+  background: #2b8c67;
+  box-shadow: 0 0 0 4px color-mix(in srgb, #2b8c67 18%, transparent);
+}
+
 .settings-form {
   display: grid;
   gap: 18px;
@@ -407,6 +441,15 @@
   background: var(--surface-subtle);
   border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
   color: var(--muted);
+}
+
+.invoice-filename-preview {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, #f47d2a 34%, var(--surface-border));
 }
 
 .hero-mascot {
@@ -1077,6 +1120,10 @@ button:disabled {
 
   .panel-heading {
     flex-direction: column;
+  }
+
+  .settings-header-actions {
+    justify-content: flex-start;
   }
 
   .status-pill {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1218,6 +1218,11 @@ function App({ appMetadata }: AppProps) {
         authUser?.passengerMileageRate === undefined
           ? ''
           : String(authUser.passengerMileageRate),
+      defaultPaymentWindowDays:
+        authUser?.defaultPaymentWindowDays === null ||
+        authUser?.defaultPaymentWindowDays === undefined
+          ? ''
+          : String(authUser.defaultPaymentWindowDays),
       invoiceFilenamePattern: authUser?.invoiceFilenamePattern ?? '',
       invoiceReplyToEmail: authUser?.invoiceReplyToEmail ?? '',
       invoiceUploadFolderId: authUser?.invoiceUploadFolderId ?? '',
@@ -1289,12 +1294,24 @@ function App({ appMetadata }: AppProps) {
     const passengerMileageRate = parseOptionalDecimal(
       userSettingsForm.passengerMileageRate
     )
+    const defaultPaymentWindowDaysText = userSettingsForm.defaultPaymentWindowDays.trim()
     const invoiceFilenamePattern = userSettingsForm.invoiceFilenamePattern.trim()
     const invoiceReplyToEmail = userSettingsForm.invoiceReplyToEmail.trim()
     const invoiceUploadFolderId = userSettingsForm.invoiceUploadFolderId.trim()
 
     if (Number.isNaN(mileageRate) || Number.isNaN(passengerMileageRate)) {
       setUserSettingsStatus('Rates must be valid numbers, for example 0.45.')
+      return
+    }
+
+    const defaultPaymentWindowDays = defaultPaymentWindowDaysText
+      ? Number(defaultPaymentWindowDaysText)
+      : null
+    if (
+      defaultPaymentWindowDays !== null &&
+      (!Number.isInteger(defaultPaymentWindowDays) || defaultPaymentWindowDays < 0)
+    ) {
+      setUserSettingsStatus('Payment window must be a whole number of days.')
       return
     }
 
@@ -1309,6 +1326,7 @@ function App({ appMetadata }: AppProps) {
         body: JSON.stringify({
           mileageRate,
           passengerMileageRate,
+          defaultPaymentWindowDays,
           invoiceFilenamePattern: invoiceFilenamePattern || null,
           invoiceReplyToEmail: invoiceReplyToEmail || null,
           invoiceUploadFolderId: invoiceUploadFolderId || null,
@@ -1336,6 +1354,7 @@ function App({ appMetadata }: AppProps) {
       const savedSettings = (await response.json()) as {
         mileageRate: number | null
         passengerMileageRate: number | null
+        defaultPaymentWindowDays: number | null
         invoiceFilenamePattern: string | null
         invoiceReplyToEmail: string | null
         invoiceUploadFolderId: string | null
@@ -1347,6 +1366,7 @@ function App({ appMetadata }: AppProps) {
               ...current,
               mileageRate: savedSettings.mileageRate,
               passengerMileageRate: savedSettings.passengerMileageRate,
+              defaultPaymentWindowDays: savedSettings.defaultPaymentWindowDays,
               invoiceFilenamePattern: savedSettings.invoiceFilenamePattern,
               invoiceReplyToEmail: savedSettings.invoiceReplyToEmail,
               invoiceUploadFolderId: savedSettings.invoiceUploadFolderId,
@@ -1360,6 +1380,10 @@ function App({ appMetadata }: AppProps) {
           savedSettings.passengerMileageRate === null
             ? ''
             : String(savedSettings.passengerMileageRate),
+        defaultPaymentWindowDays:
+          savedSettings.defaultPaymentWindowDays === null
+            ? ''
+            : String(savedSettings.defaultPaymentWindowDays),
         invoiceFilenamePattern: savedSettings.invoiceFilenamePattern ?? '',
         invoiceReplyToEmail: savedSettings.invoiceReplyToEmail ?? '',
         invoiceUploadFolderId: savedSettings.invoiceUploadFolderId ?? '',
@@ -2660,13 +2684,6 @@ function App({ appMetadata }: AppProps) {
                             : 'Seller profile not set up'}
                       </span>
                     </div>
-                    <div className="profile-meta">
-                      <span>
-                        {authUser?.isGoogleDriveConnected
-                          ? 'Connected to Google Drive'
-                          : 'Google Drive not connected'}
-                      </span>
-                    </div>
                     <label className="theme-field" htmlFor="theme-preference-select">
                       <span>Theme</span>
                       <select
@@ -2689,17 +2706,6 @@ function App({ appMetadata }: AppProps) {
                       disabled={isLoading || isAdminLoading || isSellerProfileSaving}
                     >
                       Seller profile
-                    </button>
-                    <button
-                      className="ghost-button profile-settings"
-                      onClick={connectGoogleDrive}
-                      role="menuitem"
-                      type="button"
-                      disabled={isLoading || isAdminLoading}
-                    >
-                      {authUser?.isGoogleDriveConnected
-                        ? 'Reconnect Google Drive'
-                        : 'Connect Google Drive'}
                     </button>
                     <button
                       className="ghost-button profile-settings"
@@ -2789,9 +2795,12 @@ function App({ appMetadata }: AppProps) {
           null
         )}
         invoiceFilenameTokens={invoiceFilenameTokens}
+        isGoogleDriveConnected={authUser?.isGoogleDriveConnected ?? false}
         isOpen={isUserSettingsOpen}
         isSaving={isUserSettingsSaving}
+        isGoogleDriveConnectDisabled={isLoading || isAdminLoading}
         onClose={closeUserSettings}
+        onConnectGoogleDrive={connectGoogleDrive}
         onSubmit={handleUserSettingsSubmit}
         onUpdateField={updateUserSettingsField}
         status={userSettingsStatus}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1220,6 +1220,7 @@ function App({ appMetadata }: AppProps) {
           : String(authUser.passengerMileageRate),
       invoiceFilenamePattern: authUser?.invoiceFilenamePattern ?? '',
       invoiceReplyToEmail: authUser?.invoiceReplyToEmail ?? '',
+      invoiceUploadFolderId: authUser?.invoiceUploadFolderId ?? '',
     })
     setUserSettingsStatus(
       'Set the defaults used when a client does not provide its own overrides.'
@@ -1290,6 +1291,7 @@ function App({ appMetadata }: AppProps) {
     )
     const invoiceFilenamePattern = userSettingsForm.invoiceFilenamePattern.trim()
     const invoiceReplyToEmail = userSettingsForm.invoiceReplyToEmail.trim()
+    const invoiceUploadFolderId = userSettingsForm.invoiceUploadFolderId.trim()
 
     if (Number.isNaN(mileageRate) || Number.isNaN(passengerMileageRate)) {
       setUserSettingsStatus('Rates must be valid numbers, for example 0.45.')
@@ -1309,6 +1311,7 @@ function App({ appMetadata }: AppProps) {
           passengerMileageRate,
           invoiceFilenamePattern: invoiceFilenamePattern || null,
           invoiceReplyToEmail: invoiceReplyToEmail || null,
+          invoiceUploadFolderId: invoiceUploadFolderId || null,
         }),
       })
 
@@ -1335,6 +1338,7 @@ function App({ appMetadata }: AppProps) {
         passengerMileageRate: number | null
         invoiceFilenamePattern: string | null
         invoiceReplyToEmail: string | null
+        invoiceUploadFolderId: string | null
       }
 
       setAuthUser((current) =>
@@ -1345,6 +1349,7 @@ function App({ appMetadata }: AppProps) {
               passengerMileageRate: savedSettings.passengerMileageRate,
               invoiceFilenamePattern: savedSettings.invoiceFilenamePattern,
               invoiceReplyToEmail: savedSettings.invoiceReplyToEmail,
+              invoiceUploadFolderId: savedSettings.invoiceUploadFolderId,
             }
           : current
       )
@@ -1357,6 +1362,7 @@ function App({ appMetadata }: AppProps) {
             : String(savedSettings.passengerMileageRate),
         invoiceFilenamePattern: savedSettings.invoiceFilenamePattern ?? '',
         invoiceReplyToEmail: savedSettings.invoiceReplyToEmail ?? '',
+        invoiceUploadFolderId: savedSettings.invoiceUploadFolderId ?? '',
       })
       setUserSettingsStatus('Settings updated.')
     } catch (error) {

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -2013,6 +2013,18 @@ export function UserSettingsModal({
                 }
               />
             </label>
+
+            <label>
+              <span>Google Drive invoice folder ID</span>
+              <input
+                placeholder="Drive folder ID"
+                type="text"
+                value={form.invoiceUploadFolderId}
+                onChange={(event) =>
+                  onUpdateField('invoiceUploadFolderId', event.target.value)
+                }
+              />
+            </label>
           </div>
 
           <div className="detail-grid client-settings-preview">
@@ -2027,6 +2039,7 @@ export function UserSettingsModal({
             Leave a rate blank if you do not want a personal default. Filename tokens:
             {` ${invoiceFilenameTokens.join(', ')}.`}
             {' '}Leave reply-to blank if replies should not be directed to a personal mailbox.
+            {' '}Leave the Drive folder ID blank to use Google Drive's default upload destination.
           </div>
 
           <div className="form-actions">

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -16,6 +16,7 @@ import type {
   SellerProfileForm,
   UserSettingsForm,
 } from './appShared'
+import { useState } from 'react'
 import {
   formatBuildMetadata,
   formatCurrency,
@@ -1917,9 +1918,12 @@ type UserSettingsModalProps = {
   form: UserSettingsForm
   invoiceFilenamePreview: string
   invoiceFilenameTokens: string[]
+  isGoogleDriveConnected: boolean
   isOpen: boolean
   isSaving: boolean
+  isGoogleDriveConnectDisabled: boolean
   onClose: () => void
+  onConnectGoogleDrive: () => void
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   onUpdateField: (field: keyof UserSettingsForm, value: string) => void
   status: string
@@ -1929,13 +1933,38 @@ export function UserSettingsModal({
   form,
   invoiceFilenamePreview,
   invoiceFilenameTokens,
+  isGoogleDriveConnected,
   isOpen,
   isSaving,
+  isGoogleDriveConnectDisabled,
   onClose,
+  onConnectGoogleDrive,
   onSubmit,
   onUpdateField,
   status,
 }: UserSettingsModalProps) {
+  const [focusedField, setFocusedField] = useState<keyof UserSettingsForm | null>(null)
+  const settingsNote =
+    focusedField === 'mileageRate'
+      ? 'Leave blank if you do not want a personal mileage default.'
+      : focusedField === 'passengerMileageRate'
+        ? 'Leave blank if you do not want a personal passenger mileage default.'
+        : focusedField === 'defaultPaymentWindowDays'
+          ? 'Leave blank to keep the standard 14 day payment window.'
+          : focusedField === 'invoiceFilenamePattern'
+            ? `Available filename tokens: ${invoiceFilenameTokens.join(', ')}.`
+            : focusedField === 'invoiceReplyToEmail'
+              ? 'Leave blank if replies should not be directed to a personal mailbox.'
+              : focusedField === 'invoiceUploadFolderId'
+                ? "Leave blank to use Google Drive's default upload destination."
+                : 'Choose a setting to see a short note here.'
+  const handleFocus = (field: keyof UserSettingsForm) => {
+    setFocusedField(field)
+  }
+  const handleBlur = () => {
+    setFocusedField(null)
+  }
+
   if (!isOpen) {
     return null
   }
@@ -1952,16 +1981,36 @@ export function UserSettingsModal({
         <div className="panel-heading">
           <div>
             <p className="section-label">User settings</p>
-            <h2 id="user-settings-title">Default invoice settings</h2>
+            <h2 id="user-settings-title">Your settings</h2>
           </div>
-          <button className="ghost-button" onClick={onClose} type="button">
-            Close
-          </button>
+          <div className="settings-header-actions">
+            <div className="drive-connection-state">
+              <span
+                aria-hidden="true"
+                className={`drive-connection-indicator ${
+                  isGoogleDriveConnected ? 'connected' : 'disconnected'
+                }`}
+              />
+              <span>
+                {isGoogleDriveConnected ? 'Drive connected' : 'Drive not connected'}
+              </span>
+            </div>
+            <button
+              className="ghost-button"
+              disabled={isGoogleDriveConnectDisabled}
+              onClick={onConnectGoogleDrive}
+              type="button"
+            >
+              {isGoogleDriveConnected ? 'Reconnect Drive' : 'Connect Drive'}
+            </button>
+            <button className="ghost-button" onClick={onClose} type="button">
+              Close
+            </button>
+          </div>
         </div>
 
         <p className="hero-text settings-intro">
-          These defaults are used when a client does not provide its own pricing
-          or invoice filename pattern, and invoice emails can reply back to your chosen address.
+          Set your personal defaults for rates, payment timing, invoice files, and connected services.
         </p>
 
         <form className="settings-form" onSubmit={onSubmit}>
@@ -1973,6 +2022,8 @@ export function UserSettingsModal({
                 placeholder="0.45"
                 type="text"
                 value={form.mileageRate}
+                onFocus={() => handleFocus('mileageRate')}
+                onBlur={handleBlur}
                 onChange={(event) => onUpdateField('mileageRate', event.target.value)}
               />
             </label>
@@ -1984,6 +2035,8 @@ export function UserSettingsModal({
                 placeholder="0.10"
                 type="text"
                 value={form.passengerMileageRate}
+                onFocus={() => handleFocus('passengerMileageRate')}
+                onBlur={handleBlur}
                 onChange={(event) =>
                   onUpdateField('passengerMileageRate', event.target.value)
                 }
@@ -1991,13 +2044,17 @@ export function UserSettingsModal({
             </label>
 
             <label>
-              <span>Default invoice filename pattern</span>
+              <span>Default payment window</span>
               <input
-                placeholder="{InvoiceNumber}"
-                type="text"
-                value={form.invoiceFilenamePattern}
+                inputMode="numeric"
+                min="0"
+                placeholder="14"
+                type="number"
+                value={form.defaultPaymentWindowDays}
+                onFocus={() => handleFocus('defaultPaymentWindowDays')}
+                onBlur={handleBlur}
                 onChange={(event) =>
-                  onUpdateField('invoiceFilenamePattern', event.target.value)
+                  onUpdateField('defaultPaymentWindowDays', event.target.value)
                 }
               />
             </label>
@@ -2008,8 +2065,24 @@ export function UserSettingsModal({
                 placeholder="you@example.com"
                 type="email"
                 value={form.invoiceReplyToEmail}
+                onFocus={() => handleFocus('invoiceReplyToEmail')}
+                onBlur={handleBlur}
                 onChange={(event) =>
                   onUpdateField('invoiceReplyToEmail', event.target.value)
+                }
+              />
+            </label>
+
+            <label>
+              <span>Default invoice filename pattern</span>
+              <input
+                placeholder="{InvoiceNumber}"
+                type="text"
+                value={form.invoiceFilenamePattern}
+                onFocus={() => handleFocus('invoiceFilenamePattern')}
+                onBlur={handleBlur}
+                onChange={(event) =>
+                  onUpdateField('invoiceFilenamePattern', event.target.value)
                 }
               />
             </label>
@@ -2020,27 +2093,24 @@ export function UserSettingsModal({
                 placeholder="Drive folder ID"
                 type="text"
                 value={form.invoiceUploadFolderId}
+                onFocus={() => handleFocus('invoiceUploadFolderId')}
+                onBlur={handleBlur}
                 onChange={(event) =>
                   onUpdateField('invoiceUploadFolderId', event.target.value)
                 }
               />
             </label>
+
+            {focusedField === 'invoiceFilenamePattern' ? (
+              <article className="setting-card override invoice-filename-preview">
+                <p className="detail-label">Preview</p>
+                <strong>{invoiceFilenamePreview}</strong>
+                <span>Using today's date and a sample invoice number.</span>
+              </article>
+            ) : null}
           </div>
 
-          <div className="detail-grid client-settings-preview">
-            <article className="setting-card override">
-              <p className="detail-label">Preview</p>
-              <strong>{invoiceFilenamePreview}</strong>
-              <span>Using today's date and a sample invoice number.</span>
-            </article>
-          </div>
-
-          <div className="settings-note">
-            Leave a rate blank if you do not want a personal default. Filename tokens:
-            {` ${invoiceFilenameTokens.join(', ')}.`}
-            {' '}Leave reply-to blank if replies should not be directed to a personal mailbox.
-            {' '}Leave the Drive folder ID blank to use Google Drive's default upload destination.
-          </div>
+          <div className="settings-note">{settingsNote}</div>
 
           <div className="form-actions">
             <button className="primary-button" type="submit" disabled={isSaving}>

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -33,6 +33,7 @@ export type AuthUser = {
   passengerMileageRate: number | null
   invoiceFilenamePattern: string | null
   invoiceReplyToEmail: string | null
+  invoiceUploadFolderId: string | null
   isGoogleDriveConnected: boolean
 }
 
@@ -61,6 +62,7 @@ export type UserSettingsForm = {
   passengerMileageRate: string
   invoiceFilenamePattern: string
   invoiceReplyToEmail: string
+  invoiceUploadFolderId: string
 }
 
 export type ClientSettingsForm = {
@@ -228,6 +230,7 @@ export const emptyUserSettingsForm = (): UserSettingsForm => ({
   passengerMileageRate: '',
   invoiceFilenamePattern: '',
   invoiceReplyToEmail: '',
+  invoiceUploadFolderId: '',
 })
 
 export const emptyClientSettingsForm = (): ClientSettingsForm => ({

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -14,6 +14,7 @@ export type Client = {
   billingAddress: Address
   mileageRate: number | null
   passengerMileageRate: number | null
+  defaultPaymentWindowDays: number | null
   invoiceFilenamePattern: string | null
 }
 
@@ -31,6 +32,7 @@ export type AuthUser = {
   profileImageUrl: string
   mileageRate: number | null
   passengerMileageRate: number | null
+  defaultPaymentWindowDays: number | null
   invoiceFilenamePattern: string | null
   invoiceReplyToEmail: string | null
   invoiceUploadFolderId: string | null
@@ -60,6 +62,7 @@ export type AdminUserForm = {
 export type UserSettingsForm = {
   mileageRate: string
   passengerMileageRate: string
+  defaultPaymentWindowDays: string
   invoiceFilenamePattern: string
   invoiceReplyToEmail: string
   invoiceUploadFolderId: string
@@ -228,6 +231,7 @@ export const emptyAdminForm = (): AdminUserForm => ({
 export const emptyUserSettingsForm = (): UserSettingsForm => ({
   mileageRate: '',
   passengerMileageRate: '',
+  defaultPaymentWindowDays: '',
   invoiceFilenamePattern: '',
   invoiceReplyToEmail: '',
   invoiceUploadFolderId: '',


### PR DESCRIPTION
## Summary

- Add a configurable Google Drive invoice upload folder ID to user settings and use it when publishing invoice PDFs to Drive.
- Keep the current default Drive upload destination when no folder ID is configured.
- Polish the user settings dialog so Drive connection status/actions live alongside Drive settings, helper notes react to the focused input, and filename preview appears only while editing the filename pattern.
- Add a user-level default payment window and apply it when creating, issuing, reissuing, or redrafting invoices.

## Validation

- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj`
- `npm run build`
- `git diff --check`

## Notes

GitHub reported an existing Dependabot vulnerability on the default branch during push; this PR does not change dependency versions.