### PR TITLE
[codex] Add expense receipt attachments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,7 @@ jobs:
             Email__Mode=Resend
             Email__AccessRequests__FromDisplayName=Glovelly
             Email__Invoices__FromDisplayName=Glovelly
+            ExpenseAttachments__BucketName=glovelly-storage-production
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest
@@ -161,6 +162,7 @@ jobs:
             Email__Mode=Resend
             Email__AccessRequests__FromDisplayName=Glovelly
             Email__Invoices__FromDisplayName=Glovelly
+            ExpenseAttachments__BucketName=glovelly-storage-staging
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using Glovelly.Api.Tests.Infrastructure;
 using Xunit;
@@ -255,6 +256,119 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Contains(lines, line => line.GetProperty("description").GetString() == "Performance fee for Expense refresh test (2026-06-08)");
         Assert.Contains(lines, line => line.GetProperty("description").GetString() == "Tolls");
         Assert.Contains(lines, line => line.GetProperty("description").GetString() == "Parking");
+    }
+
+    [Fact]
+    public async Task ExpenseAttachmentFlow_UploadsListsDownloadsAndDeletesReceipt()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Receipt test",
+            date = "2026-06-09",
+            venue = "Station",
+            fee = 120.00m,
+            travelMiles = 0.00m,
+            notes = "Receipt test",
+            wasDriving = true,
+            status = 1,
+            expenses = new[]
+            {
+                new
+                {
+                    description = "Taxi",
+                    amount = 38.42m,
+                },
+            },
+            invoicedAt = (string?)null,
+        });
+
+        createResponse.EnsureSuccessStatusCode();
+
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var gigId = createdGig.GetProperty("id").GetGuid();
+        var expenseId = createdGig.GetProperty("expenses")[0].GetProperty("id").GetGuid();
+
+        using var form = new MultipartFormDataContent();
+        using var file = new ByteArrayContent("receipt evidence"u8.ToArray());
+        file.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        form.Add(file, "file", "uber-receipt.pdf");
+
+        var uploadResponse = await _client.PostAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments", form);
+
+        Assert.Equal(HttpStatusCode.Created, uploadResponse.StatusCode);
+
+        var attachment = await uploadResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var attachmentId = attachment.GetProperty("id").GetGuid();
+        Assert.Equal("uber-receipt.pdf", attachment.GetProperty("fileName").GetString());
+        Assert.Equal("application/pdf", attachment.GetProperty("contentType").GetString());
+        Assert.Equal("receipt evidence"u8.Length, attachment.GetProperty("sizeBytes").GetInt64());
+        Assert.False(attachment.TryGetProperty("storageKey", out _));
+
+        var gigResponse = await _client.GetAsync($"/gigs/{gigId}");
+        gigResponse.EnsureSuccessStatusCode();
+
+        var gig = await gigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var attachments = gig.GetProperty("expenses")[0].GetProperty("attachments").EnumerateArray().ToArray();
+        Assert.Single(attachments);
+        Assert.Equal(attachmentId, attachments[0].GetProperty("id").GetGuid());
+
+        var downloadResponse = await _client.GetAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}");
+
+        Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
+        Assert.Equal("application/pdf", downloadResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("receipt evidence", await downloadResponse.Content.ReadAsStringAsync());
+
+        var deleteResponse = await _client.DeleteAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}");
+
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var missingDownloadResponse = await _client.GetAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}");
+        Assert.Equal(HttpStatusCode.NotFound, missingDownloadResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task UploadExpenseAttachment_WithUnsupportedType_ReturnsValidationProblem()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Receipt validation test",
+            date = "2026-06-10",
+            venue = "Station",
+            fee = 120.00m,
+            travelMiles = 0.00m,
+            notes = "Receipt test",
+            wasDriving = true,
+            status = 1,
+            expenses = new[]
+            {
+                new
+                {
+                    description = "Taxi",
+                    amount = 38.42m,
+                },
+            },
+            invoicedAt = (string?)null,
+        });
+
+        createResponse.EnsureSuccessStatusCode();
+
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var gigId = createdGig.GetProperty("id").GetGuid();
+        var expenseId = createdGig.GetProperty("expenses")[0].GetProperty("id").GetGuid();
+
+        using var form = new MultipartFormDataContent();
+        using var file = new ByteArrayContent("bad"u8.ToArray());
+        file.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        form.Add(file, "file", "receipt.txt");
+
+        var response = await _client.PostAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments", form);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Receipt files must be PDF, JPG, PNG, WebP or HEIC.", problem.GetProperty("errors").GetProperty("file")[0].GetString());
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -29,9 +29,11 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
             services.RemoveAll<DbContextOptions<AppDbContext>>();
             services.RemoveAll<IPolicyEvaluator>();
             services.RemoveAll<IEmailSender>();
+            services.RemoveAll<IExpenseAttachmentStore>();
 
             services.AddSingleton<IPolicyEvaluator, TestPolicyEvaluator>();
             services.AddSingleton<IEmailSender>(_fakeEmailSender);
+            services.AddSingleton<IExpenseAttachmentStore, InMemoryExpenseAttachmentStore>();
             services.PostConfigure<EmailSettings>(settings =>
             {
                 settings.AccessRequests.FromAddress = "access@glovelly.test";

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -12,6 +12,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<Client> Clients => Set<Client>();
     public DbSet<Gig> Gigs => Set<Gig>();
     public DbSet<GigExpense> GigExpenses => Set<GigExpense>();
+    public DbSet<ExpenseAttachment> ExpenseAttachments => Set<ExpenseAttachment>();
     public DbSet<Invoice> Invoices => Set<Invoice>();
     public DbSet<InvoiceLine> InvoiceLines => Set<InvoiceLine>();
     public DbSet<SellerProfile> SellerProfiles => Set<SellerProfile>();
@@ -182,6 +183,29 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
                 .HasMaxLength(500);
             entity.Property(expense => expense.Amount)
                 .HasPrecision(18, 2);
+            entity.HasMany(expense => expense.Attachments)
+                .WithOne(attachment => attachment.Expense)
+                .HasForeignKey(attachment => attachment.GigExpenseId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ExpenseAttachment>(entity =>
+        {
+            entity.HasKey(attachment => attachment.Id);
+            entity.Property(attachment => attachment.FileName)
+                .IsRequired()
+                .HasMaxLength(255);
+            entity.Property(attachment => attachment.ContentType)
+                .IsRequired()
+                .HasMaxLength(100);
+            entity.Property(attachment => attachment.StorageKey)
+                .IsRequired()
+                .HasMaxLength(600);
+            entity.Property(attachment => attachment.CreatedAt)
+                .IsRequired();
+            entity.HasIndex(attachment => attachment.GigExpenseId);
+            entity.HasIndex(attachment => attachment.StorageKey)
+                .IsUnique();
         });
 
         modelBuilder.Entity<Invoice>(entity =>

--- a/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
@@ -3,6 +3,7 @@ using Glovelly.Api.Data;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using System.Security.Claims;
 
 namespace Glovelly.Api.Endpoints;
@@ -110,6 +111,7 @@ public static class GigEndpoints
                 .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .Include(gig => gig.Expenses)
+                    .ThenInclude(expense => expense.Attachments)
                 .OrderBy(gig => gig.Date)
                 .ThenBy(gig => gig.Title)
                 .ToListAsync();
@@ -124,6 +126,7 @@ public static class GigEndpoints
                 .WhereVisibleTo(userId)
                 .AsNoTracking()
                 .Include(value => value.Expenses)
+                    .ThenInclude(expense => expense.Attachments)
                 .FirstOrDefaultAsync(gig => gig.Id == id);
 
             return gig is null ? Results.NotFound() : Results.Ok(gig);
@@ -243,12 +246,14 @@ public static class GigEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IExpenseAttachmentStore attachmentStore,
             IInvoiceWorkflowService invoiceWorkflowService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
                 .WhereVisibleTo(userId)
                 .Include(value => value.Expenses)
+                    .ThenInclude(expense => expense.Attachments)
                 .FirstOrDefaultAsync(value => value.Id == id);
 
             if (gig is null)
@@ -334,6 +339,11 @@ public static class GigEndpoints
             if (existingExpenses.Count > normalizedExpenses.Count)
             {
                 var expensesToRemove = existingExpenses.Skip(normalizedExpenses.Count).ToList();
+                foreach (var attachment in expensesToRemove.SelectMany(expense => expense.Attachments).ToList())
+                {
+                    await attachmentStore.DeleteAsync(attachment.StorageKey);
+                }
+
                 db.GigExpenses.RemoveRange(expensesToRemove);
             }
 
@@ -347,6 +357,7 @@ public static class GigEndpoints
 
             gig = await db.Gigs
                 .Include(value => value.Expenses)
+                    .ThenInclude(expense => expense.Attachments)
                 .FirstAsync(value => value.Id == id);
 
             await invoiceWorkflowService.SyncGeneratedInvoiceLinesForGigAsync(gig, userId);
@@ -360,16 +371,23 @@ public static class GigEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IExpenseAttachmentStore attachmentStore,
             IInvoiceWorkflowService invoiceWorkflowService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
                 .WhereVisibleTo(userId)
                 .Include(value => value.Expenses)
+                    .ThenInclude(expense => expense.Attachments)
                 .FirstOrDefaultAsync(gig => gig.Id == id);
             if (gig is null)
             {
                 return Results.NotFound();
+            }
+
+            foreach (var attachment in gig.Expenses.SelectMany(expense => expense.Attachments).ToList())
+            {
+                await attachmentStore.DeleteAsync(attachment.StorageKey);
             }
 
             _ = await invoiceWorkflowService.RemoveSystemGeneratedInvoiceLinesForGigAsync(gig.Id);
@@ -379,7 +397,221 @@ public static class GigEndpoints
             return Results.NoContent();
         });
 
+        group.MapGet("/{gigId:guid}/expenses/{expenseId:guid}/attachments", async (
+            Guid gigId,
+            Guid expenseId,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var expense = await FindVisibleExpenseAsync(db, userId, gigId, expenseId, asNoTracking: true);
+
+            return expense is null
+                ? Results.NotFound()
+                : Results.Ok(expense.Attachments.OrderBy(attachment => attachment.CreatedAt));
+        });
+
+        group.MapPost("/{gigId:guid}/expenses/{expenseId:guid}/attachments", async (
+            Guid gigId,
+            Guid expenseId,
+            HttpRequest request,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IExpenseAttachmentStore attachmentStore,
+            IOptions<ExpenseAttachmentSettings> attachmentOptions) =>
+        {
+            if (!request.HasFormContentType)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["file"] = ["Upload a receipt file."]
+                });
+            }
+
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var expense = await FindVisibleExpenseAsync(db, userId, gigId, expenseId, asNoTracking: false);
+            if (expense is null)
+            {
+                return Results.NotFound();
+            }
+
+            var form = await request.ReadFormAsync();
+            var file = form.Files.GetFile("file") ?? form.Files.FirstOrDefault();
+            var validation = ValidateAttachmentFile(file, attachmentOptions.Value);
+            if (validation is not null)
+            {
+                return validation;
+            }
+
+            var attachmentId = Guid.NewGuid();
+            var storageKey = BuildAttachmentStorageKey(userId, gigId, expenseId, attachmentId);
+            await using var stream = file!.OpenReadStream();
+            await attachmentStore.SaveAsync(storageKey, stream, file.ContentType);
+
+            var displayFileName = Path.GetFileName(file.FileName);
+            if (string.IsNullOrWhiteSpace(displayFileName))
+            {
+                displayFileName = "receipt";
+            }
+
+            var attachment = new ExpenseAttachment
+            {
+                Id = attachmentId,
+                GigExpenseId = expenseId,
+                FileName = displayFileName,
+                ContentType = file.ContentType,
+                SizeBytes = file.Length,
+                StorageKey = storageKey,
+                CreatedAt = DateTimeOffset.UtcNow,
+            };
+
+            db.ExpenseAttachments.Add(attachment);
+            await db.SaveChangesAsync();
+
+            return Results.Created($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachment.Id}", attachment);
+        });
+
+        group.MapGet("/{gigId:guid}/expenses/{expenseId:guid}/attachments/{attachmentId:guid}", async (
+            Guid gigId,
+            Guid expenseId,
+            Guid attachmentId,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IExpenseAttachmentStore attachmentStore) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var attachment = await FindVisibleAttachmentAsync(db, userId, gigId, expenseId, attachmentId, asNoTracking: true);
+            if (attachment is null)
+            {
+                return Results.NotFound();
+            }
+
+            try
+            {
+                var content = await attachmentStore.OpenReadAsync(attachment.StorageKey);
+                return Results.File(
+                    content.Content,
+                    content.ContentType ?? attachment.ContentType,
+                    attachment.FileName,
+                    enableRangeProcessing: true);
+            }
+            catch (FileNotFoundException)
+            {
+                return Results.NotFound();
+            }
+        });
+
+        group.MapDelete("/{gigId:guid}/expenses/{expenseId:guid}/attachments/{attachmentId:guid}", async (
+            Guid gigId,
+            Guid expenseId,
+            Guid attachmentId,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IExpenseAttachmentStore attachmentStore) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var attachment = await FindVisibleAttachmentAsync(db, userId, gigId, expenseId, attachmentId, asNoTracking: false);
+            if (attachment is null)
+            {
+                return Results.NotFound();
+            }
+
+            await attachmentStore.DeleteAsync(attachment.StorageKey);
+            db.ExpenseAttachments.Remove(attachment);
+            await db.SaveChangesAsync();
+
+            return Results.NoContent();
+        });
+
         return group;
+    }
+
+    private static Task<GigExpense?> FindVisibleExpenseAsync(
+        AppDbContext db,
+        Guid? userId,
+        Guid gigId,
+        Guid expenseId,
+        bool asNoTracking)
+    {
+        var query = db.GigExpenses
+            .Include(expense => expense.Attachments)
+            .Include(expense => expense.Gig)
+            .Where(expense => expense.Id == expenseId && expense.GigId == gigId)
+            .Where(expense => expense.Gig != null
+                && (expense.Gig.CreatedByUserId == null || expense.Gig.CreatedByUserId == userId));
+
+        if (asNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        return query.FirstOrDefaultAsync();
+    }
+
+    private static Task<ExpenseAttachment?> FindVisibleAttachmentAsync(
+        AppDbContext db,
+        Guid? userId,
+        Guid gigId,
+        Guid expenseId,
+        Guid attachmentId,
+        bool asNoTracking)
+    {
+        var query = db.ExpenseAttachments
+            .Include(attachment => attachment.Expense)
+                .ThenInclude(expense => expense!.Gig)
+            .Where(attachment => attachment.Id == attachmentId
+                && attachment.GigExpenseId == expenseId
+                && attachment.Expense != null
+                && attachment.Expense.GigId == gigId
+                && attachment.Expense.Gig != null
+                && (attachment.Expense.Gig.CreatedByUserId == null
+                    || attachment.Expense.Gig.CreatedByUserId == userId));
+
+        if (asNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        return query.FirstOrDefaultAsync();
+    }
+
+    private static IResult? ValidateAttachmentFile(IFormFile? file, ExpenseAttachmentSettings settings)
+    {
+        if (file is null || file.Length == 0)
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["file"] = ["Upload a receipt file."]
+            });
+        }
+
+        if (file.Length > settings.MaxFileSizeBytes)
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["file"] = [$"Receipt files must be {settings.MaxFileSizeBytes / 1024 / 1024} MB or smaller."]
+            });
+        }
+
+        if (!settings.AllowedContentTypes.Contains(file.ContentType, StringComparer.OrdinalIgnoreCase))
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["file"] = ["Receipt files must be PDF, JPG, PNG, WebP or HEIC."]
+            });
+        }
+
+        return null;
+    }
+
+    private static string BuildAttachmentStorageKey(Guid? userId, Guid gigId, Guid expenseId, Guid attachmentId)
+    {
+        var owner = userId?.ToString("N") ?? "system";
+        return $"users/{owner}/gigs/{gigId:N}/expenses/{expenseId:N}/attachments/{attachmentId:N}";
     }
 
     private sealed record GenerateInvoiceFromGigSelectionRequest(IReadOnlyList<Guid> GigIds);

--- a/backend/Glovelly.Api/Glovelly.Api.csproj
+++ b/backend/Glovelly.Api/Glovelly.Api.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />

--- a/backend/Glovelly.Api/Models/ExpenseAttachment.cs
+++ b/backend/Glovelly.Api/Models/ExpenseAttachment.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Glovelly.Api.Models;
+
+public sealed class ExpenseAttachment
+{
+    public Guid Id { get; set; }
+    public Guid GigExpenseId { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public string ContentType { get; set; } = string.Empty;
+    public long SizeBytes { get; set; }
+    [JsonIgnore]
+    public string StorageKey { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonIgnore]
+    public GigExpense? Expense { get; set; }
+}

--- a/backend/Glovelly.Api/Models/GigExpense.cs
+++ b/backend/Glovelly.Api/Models/GigExpense.cs
@@ -9,6 +9,7 @@ public sealed class GigExpense
     public int SortOrder { get; set; }
     public string Description { get; set; } = string.Empty;
     public decimal Amount { get; set; }
+    public ICollection<ExpenseAttachment> Attachments { get; set; } = new List<ExpenseAttachment>();
 
     [JsonIgnore]
     public Gig? Gig { get; set; }

--- a/backend/Glovelly.Api/Services/ExpenseAttachmentSettings.cs
+++ b/backend/Glovelly.Api/Services/ExpenseAttachmentSettings.cs
@@ -1,0 +1,18 @@
+namespace Glovelly.Api.Services;
+
+public sealed class ExpenseAttachmentSettings
+{
+    public const string SectionName = "ExpenseAttachments";
+
+    public string? BucketName { get; set; }
+    public long MaxFileSizeBytes { get; set; } = 10 * 1024 * 1024;
+    public string[] AllowedContentTypes { get; set; } =
+    [
+        "application/pdf",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "image/heic",
+        "image/heif"
+    ];
+}

--- a/backend/Glovelly.Api/Services/GcsExpenseAttachmentStore.cs
+++ b/backend/Glovelly.Api/Services/GcsExpenseAttachmentStore.cs
@@ -1,0 +1,53 @@
+using Google;
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Options;
+
+namespace Glovelly.Api.Services;
+
+public sealed class GcsExpenseAttachmentStore(
+    StorageClient storageClient,
+    IOptions<ExpenseAttachmentSettings> options) : IExpenseAttachmentStore
+{
+    private readonly string _bucketName = options.Value.BucketName
+        ?? throw new InvalidOperationException("Expense attachment bucket is not configured.");
+
+    public async Task SaveAsync(
+        string storageKey,
+        Stream content,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        await storageClient.UploadObjectAsync(
+            _bucketName,
+            storageKey,
+            contentType,
+            content,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<ExpenseAttachmentContent> OpenReadAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default)
+    {
+        var memory = new MemoryStream();
+        var obj = await storageClient.DownloadObjectAsync(
+            _bucketName,
+            storageKey,
+            memory,
+            cancellationToken: cancellationToken);
+
+        memory.Position = 0;
+        return new ExpenseAttachmentContent(memory, obj.ContentType);
+    }
+
+    public async Task DeleteAsync(string storageKey, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await storageClient.DeleteObjectAsync(_bucketName, storageKey, cancellationToken: cancellationToken);
+        }
+        catch (GoogleApiException exception) when (exception.Error?.Code == StatusCodes.Status404NotFound)
+        {
+        }
+    }
+}

--- a/backend/Glovelly.Api/Services/IExpenseAttachmentStore.cs
+++ b/backend/Glovelly.Api/Services/IExpenseAttachmentStore.cs
@@ -1,0 +1,10 @@
+namespace Glovelly.Api.Services;
+
+public interface IExpenseAttachmentStore
+{
+    Task SaveAsync(string storageKey, Stream content, string contentType, CancellationToken cancellationToken = default);
+    Task<ExpenseAttachmentContent> OpenReadAsync(string storageKey, CancellationToken cancellationToken = default);
+    Task DeleteAsync(string storageKey, CancellationToken cancellationToken = default);
+}
+
+public sealed record ExpenseAttachmentContent(Stream Content, string? ContentType);

--- a/backend/Glovelly.Api/Services/InMemoryExpenseAttachmentStore.cs
+++ b/backend/Glovelly.Api/Services/InMemoryExpenseAttachmentStore.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+
+namespace Glovelly.Api.Services;
+
+public sealed class InMemoryExpenseAttachmentStore : IExpenseAttachmentStore
+{
+    private readonly ConcurrentDictionary<string, StoredAttachment> _attachments = new();
+
+    public async Task SaveAsync(
+        string storageKey,
+        Stream content,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        using var memory = new MemoryStream();
+        await content.CopyToAsync(memory, cancellationToken);
+        _attachments[storageKey] = new StoredAttachment(memory.ToArray(), contentType);
+    }
+
+    public Task<ExpenseAttachmentContent> OpenReadAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_attachments.TryGetValue(storageKey, out var attachment))
+        {
+            throw new FileNotFoundException("Expense attachment blob was not found.", storageKey);
+        }
+
+        return Task.FromResult(new ExpenseAttachmentContent(
+            new MemoryStream(attachment.Content, writable: false),
+            attachment.ContentType));
+    }
+
+    public Task DeleteAsync(string storageKey, CancellationToken cancellationToken = default)
+    {
+        _attachments.TryRemove(storageKey, out _);
+        return Task.CompletedTask;
+    }
+
+    private sealed record StoredAttachment(byte[] Content, string ContentType);
+}

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-using Microsoft.Extensions.DependencyInjection;
+using Google.Cloud.Storage.V1;
+using Glovelly.Api.Configuration;
 using Microsoft.Extensions.Options;
 using Resend;
 
@@ -15,6 +16,25 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInvoiceDeliveryService, InvoiceDeliveryService>();
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceEmailDeliveryChannel>();
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceGoogleDriveDeliveryChannel>();
+        services.AddOptions<ExpenseAttachmentSettings>()
+            .BindConfiguration(ExpenseAttachmentSettings.SectionName);
+        services.AddSingleton<IExpenseAttachmentStore>(provider =>
+        {
+            var settings = provider.GetRequiredService<IOptions<ExpenseAttachmentSettings>>().Value;
+            if (string.IsNullOrWhiteSpace(settings.BucketName))
+            {
+                var startupSettings = provider.GetRequiredService<StartupSettings>();
+                if (!startupSettings.IsDevelopment)
+                {
+                    throw new InvalidOperationException(
+                        "Expense attachment storage requires ExpenseAttachments:BucketName outside local development.");
+                }
+
+                return new InMemoryExpenseAttachmentStore();
+            }
+
+            return ActivatorUtilities.CreateInstance<GcsExpenseAttachmentStore>(provider, StorageClient.Create());
+        });
         services.AddOptions<ResendClientOptions>()
             .Configure<IOptions<EmailSettings>>((resendOptions, emailOptions) =>
             {

--- a/backend/Glovelly.Api/appsettings.Development.json
+++ b/backend/Glovelly.Api/appsettings.Development.json
@@ -30,5 +30,9 @@
     "GlobalNotificationWindow": "1.00:00:00",
     "RetentionWindow": "180.00:00:00",
     "CleanupSlack": "2.00:00:00"
+  },
+  "ExpenseAttachments": {
+    "BucketName": "",
+    "MaxFileSizeBytes": 10485760
   }
 }

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -39,5 +39,9 @@
     "RetentionWindow": "180.00:00:00",
     "CleanupSlack": "2.00:00:00"
   },
+  "ExpenseAttachments": {
+    "BucketName": "",
+    "MaxFileSizeBytes": 10485760
+  },
   "AllowedHosts": "*"
 }

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -806,6 +806,64 @@
   justify-self: start;
 }
 
+.expense-attachments {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.expense-attachment-header,
+.expense-attachment-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.expense-attachment-list {
+  display: grid;
+  gap: 8px;
+}
+
+.expense-attachment-item {
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--surface-soft);
+}
+
+.expense-attachment-item button {
+  grid-column: auto;
+}
+
+.file-button {
+  position: relative;
+  overflow: hidden;
+}
+
+.file-button input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.attachment-helper {
+  margin: 0;
+  color: var(--muted);
+}
+
+.link-button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--link);
+  cursor: pointer;
+  text-align: left;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .invoice-adjustment-form {
   display: grid;
   gap: 10px;

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -981,6 +981,7 @@ function App({ appMetadata }: AppProps) {
           sortOrder: current.expenses.length + 1,
           description,
           amount: gigExpenseAmount,
+          attachments: [],
         },
       ],
     }))
@@ -1017,6 +1018,134 @@ function App({ appMetadata }: AppProps) {
           sortOrder: expenseIndex + 1,
         })),
     }))
+  }
+
+  const mergeSavedGig = (savedGig: Gig) => {
+    setGigs((current) => current.map((gig) => (gig.id === savedGig.id ? savedGig : gig)))
+    setGigForm((current) => ({
+      ...current,
+      expenses: savedGig.expenses
+        .slice()
+        .sort((left, right) => left.sortOrder - right.sortOrder)
+        .map(toGigExpenseForm),
+    }))
+  }
+
+  const refreshGig = async (gigId: string) => {
+    const response = await fetchWithSession(buildApiUrl(`/gigs/${gigId}`))
+
+    if (response.status === 401) {
+      setIsAuthenticated(false)
+      setAuthUser(null)
+      setIsApiConnected(false)
+      setStatus('Your session expired. Sign in again to keep managing gigs.')
+      return null
+    }
+
+    if (!response.ok) {
+      throw new Error('Unable to refresh gig receipts.')
+    }
+
+    const savedGig = (await response.json()) as Gig
+    mergeSavedGig(savedGig)
+    return savedGig
+  }
+
+  const uploadExpenseAttachment = async (index: number, file: File) => {
+    const expense = gigForm.expenses[index]
+    if (!selectedGig || !expense?.id) {
+      setGigStatus('Save the gig before adding receipts.')
+      return
+    }
+
+    const formData = new FormData()
+    formData.append('file', file)
+    setIsGigLoading(true)
+
+    try {
+      const response = await fetchWithSession(
+        buildApiUrl(`/gigs/${selectedGig.id}/expenses/${expense.id}/attachments`),
+        {
+          method: 'POST',
+          body: formData,
+        }
+      )
+
+      if (response.status === 401) {
+        setIsAuthenticated(false)
+        setAuthUser(null)
+        setIsApiConnected(false)
+        setStatus('Your session expired. Sign in again to keep managing gigs.')
+        return
+      }
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const validationMessages = problem?.errors
+          ? Object.values(problem.errors).flat().join(' ')
+          : problem?.detail ?? problem?.title
+
+        throw new Error(validationMessages || 'Unable to upload receipt.')
+      }
+
+      await refreshGig(selectedGig.id)
+      setGigStatus('Receipt uploaded.')
+    } catch (error) {
+      setGigStatus(error instanceof Error ? error.message : 'Unable to upload receipt.')
+    } finally {
+      setIsGigLoading(false)
+    }
+  }
+
+  const downloadExpenseAttachment = (expense: GigExpenseForm, attachmentId: string) => {
+    if (!selectedGig || !expense.id) {
+      return
+    }
+
+    window.open(
+      buildApiUrl(`/gigs/${selectedGig.id}/expenses/${expense.id}/attachments/${attachmentId}`),
+      '_blank',
+      'noopener,noreferrer'
+    )
+  }
+
+  const deleteExpenseAttachment = async (
+    expense: GigExpenseForm,
+    attachmentId: string
+  ) => {
+    if (!selectedGig || !expense.id) {
+      return
+    }
+
+    setIsGigLoading(true)
+
+    try {
+      const response = await fetchWithSession(
+        buildApiUrl(`/gigs/${selectedGig.id}/expenses/${expense.id}/attachments/${attachmentId}`),
+        {
+          method: 'DELETE',
+        }
+      )
+
+      if (response.status === 401) {
+        setIsAuthenticated(false)
+        setAuthUser(null)
+        setIsApiConnected(false)
+        setStatus('Your session expired. Sign in again to keep managing gigs.')
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error('Unable to delete receipt.')
+      }
+
+      await refreshGig(selectedGig.id)
+      setGigStatus('Receipt deleted.')
+    } catch (error) {
+      setGigStatus(error instanceof Error ? error.message : 'Unable to delete receipt.')
+    } finally {
+      setIsGigLoading(false)
+    }
   }
 
   const signIn = () => {
@@ -2585,8 +2714,11 @@ function App({ appMetadata }: AppProps) {
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateInvoice={handleGenerateInvoice}
+        onDownloadExpenseAttachment={downloadExpenseAttachment}
         onOpenLinkedInvoice={openSelectedGigInvoice}
         onOpenSellerProfile={openSellerProfile}
+        onUploadExpenseAttachment={uploadExpenseAttachment}
+        onDeleteExpenseAttachment={deleteExpenseAttachment}
         onRemoveGigExpense={removeGigExpense}
         onResetForm={startGigCreate}
         onSearchQueryChange={setGigSearchQuery}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -701,8 +701,11 @@ type GigsSectionProps = {
   onExpenseAmountChange: (value: string) => void
   onExpenseDescriptionChange: (value: string) => void
   onGenerateInvoice: () => void
+  onDownloadExpenseAttachment: (expense: GigExpenseForm, attachmentId: string) => void
   onOpenLinkedInvoice: () => void
   onOpenSellerProfile: () => void
+  onUploadExpenseAttachment: (index: number, file: File) => void
+  onDeleteExpenseAttachment: (expense: GigExpenseForm, attachmentId: string) => void
   onRemoveGigExpense: (index: number) => void
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
@@ -747,8 +750,11 @@ export function GigsSection({
   onExpenseAmountChange,
   onExpenseDescriptionChange,
   onGenerateInvoice,
+  onDownloadExpenseAttachment,
   onOpenLinkedInvoice,
   onOpenSellerProfile,
+  onUploadExpenseAttachment,
+  onDeleteExpenseAttachment,
   onRemoveGigExpense,
   onResetForm,
   onSearchQueryChange,
@@ -1141,6 +1147,58 @@ export function GigsSection({
                     >
                       Remove
                     </button>
+                    <div className="expense-attachments">
+                      <div className="expense-attachment-header">
+                        <span>
+                          {expense.attachments.length === 1
+                            ? '1 receipt'
+                            : `${expense.attachments.length} receipts`}
+                        </span>
+                        <label className="ghost-button file-button">
+                          Add receipt
+                          <input
+                            type="file"
+                            accept="application/pdf,image/jpeg,image/png,image/webp,image/heic,image/heif"
+                            disabled={isGigLoading || !expense.id}
+                            onChange={(event) => {
+                              const file = event.target.files?.[0]
+                              event.target.value = ''
+                              if (file) {
+                                onUploadExpenseAttachment(index, file)
+                              }
+                            }}
+                          />
+                        </label>
+                      </div>
+                      {expense.id ? (
+                        expense.attachments.length > 0 ? (
+                          <div className="expense-attachment-list">
+                            {expense.attachments.map((attachment) => (
+                              <div className="expense-attachment-item" key={attachment.id}>
+                                <button
+                                  className="link-button"
+                                  type="button"
+                                  onClick={() => onDownloadExpenseAttachment(expense, attachment.id)}
+                                  disabled={isGigLoading}
+                                >
+                                  {attachment.fileName}
+                                </button>
+                                <button
+                                  className="ghost-button"
+                                  type="button"
+                                  onClick={() => onDeleteExpenseAttachment(expense, attachment.id)}
+                                  disabled={isGigLoading}
+                                >
+                                  Delete
+                                </button>
+                              </div>
+                            ))}
+                          </div>
+                        ) : null
+                      ) : (
+                        <p className="attachment-helper">Save the gig before adding receipts.</p>
+                      )}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -116,11 +116,21 @@ export type SellerProfileForm = {
 
 export type GigStatus = 'Draft' | 'Confirmed' | 'Completed' | 'Cancelled'
 
+export type ExpenseAttachment = {
+  id: string
+  gigExpenseId: string
+  fileName: string
+  contentType: string
+  sizeBytes: number
+  createdAt: string
+}
+
 export type GigExpense = {
   id: string
   sortOrder: number
   description: string
   amount: number
+  attachments: ExpenseAttachment[]
 }
 
 export type GigExpenseForm = {
@@ -128,6 +138,7 @@ export type GigExpenseForm = {
   sortOrder: number
   description: string
   amount: string
+  attachments: ExpenseAttachment[]
 }
 
 export type Gig = {
@@ -507,6 +518,7 @@ export function toGigExpenseForm(expense: GigExpense): GigExpenseForm {
     sortOrder: expense.sortOrder,
     description: expense.description,
     amount: formatEditableAmount(expense.amount),
+    attachments: expense.attachments ?? [],
   }
 }
 


### PR DESCRIPTION
## Summary

Adds receipt/screenshot attachments for gig expense rows.

## What changed

- Added an `ExpenseAttachment` model linked to `GigExpense`, including filename, content type, size, created timestamp, and private storage key metadata.
- Added authenticated upload, list, download, and delete endpoints for expense attachments.
- Added a storage abstraction with Google Cloud Storage backing when `ExpenseAttachments:BucketName` is configured.
- Restricted the in-memory attachment store to local development, with tests opting in explicitly.
- Updated the gig expense UI to show receipt counts and support upload, download, and deletion.
- Added deployment bucket configuration for staging and production.

## Validation

- `dotnet test glovelly.sln`
- `npm run build`