### PR TITLE
[codex] Include expense receipts in invoice emails

### DIFF
--- a/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text;
@@ -86,6 +87,90 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
         Assert.Equal("bookings@foxandfinch.co.uk", updatedInvoice.GetProperty("lastDeliveryRecipient").GetString());
         Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("lastDeliveredByUserId").GetGuid());
         Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("lastDeliveredUtc").ValueKind);
+    }
+
+    [Fact]
+    public async Task SendEmail_WhenReceiptInclusionRequested_AttachesReceiptZip()
+    {
+        var (invoiceId, receiptBytes) = await SeedInvoiceWithReceiptAsync(
+            "GLV-SEND-RECEIPTS",
+            "Taxi - airport",
+            "taxi/receipt.jpg",
+            "image/jpeg",
+            Encoding.ASCII.GetBytes("receipt image bytes"));
+
+        var response = await _client.PostAsJsonAsync($"/invoices/{invoiceId}/send-email", new
+        {
+            message = "Receipt attached too.",
+            includeReceipts = true,
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var message = Assert.Single(_factory.Emails.SentEmails);
+        Assert.Equal(2, message.Attachments.Count);
+        var pdfAttachment = Assert.Single(message.Attachments, attachment => attachment.ContentType == "application/pdf");
+        Assert.Equal("GLV-SEND-RECEIPTS.pdf", pdfAttachment.FileName);
+
+        var zipAttachment = Assert.Single(message.Attachments, attachment => attachment.ContentType == "application/zip");
+        Assert.Equal("Invoice-GLV-SEND-RECEIPTS-Receipts.zip", zipAttachment.FileName);
+        using var zipStream = new MemoryStream(zipAttachment.Content);
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var entry = Assert.Single(archive.Entries);
+        Assert.Equal("Taxi - airport-taxi-receipt.jpg", entry.FullName);
+        using var entryStream = entry.Open();
+        using var entryMemory = new MemoryStream();
+        await entryStream.CopyToAsync(entryMemory);
+        Assert.Equal(receiptBytes, entryMemory.ToArray());
+    }
+
+    [Fact]
+    public async Task SendEmail_WhenReceiptInclusionOmitted_DoesNotAttachReceiptZip()
+    {
+        var (invoiceId, _) = await SeedInvoiceWithReceiptAsync(
+            "GLV-SEND-NO-RECEIPTS",
+            "Parking",
+            "parking.pdf",
+            "application/pdf",
+            Encoding.ASCII.GetBytes("%PDF-1.4 receipt"));
+
+        var response = await _client.PostAsJsonAsync($"/invoices/{invoiceId}/send-email", new
+        {
+            message = "No receipt pack please.",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var message = Assert.Single(_factory.Emails.SentEmails);
+        var attachment = Assert.Single(message.Attachments);
+        Assert.Equal("GLV-SEND-NO-RECEIPTS.pdf", attachment.FileName);
+    }
+
+    [Fact]
+    public async Task SendEmail_WhenReceiptPackExceedsConfiguredLimit_ReturnsValidationProblem()
+    {
+        using var factory = CreateFactoryWithEmailAttachmentLimit(maxTotalAttachmentBytes: 32);
+        var client = factory.CreateClient();
+        var (invoiceId, _) = await SeedInvoiceWithReceiptAsync(
+            factory,
+            "GLV-SEND-TOO-LARGE",
+            "Hotel",
+            "hotel.pdf",
+            "application/pdf",
+            Encoding.ASCII.GetBytes("%PDF-1.4 oversized receipt content"));
+
+        var response = await client.PostAsJsonAsync($"/invoices/{invoiceId}/send-email", new
+        {
+            includeReceipts = true,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(_factory.Emails.SentEmails);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Contains(
+            "exceeding the configured",
+            problem.GetProperty("errors").GetProperty("attachments")[0].GetString());
     }
 
     [Fact]
@@ -490,6 +575,124 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
                 services.AddSingleton<IGoogleDriveApiClient>(driveClient);
             });
         });
+    }
+
+    private WebApplicationFactory<Program> CreateFactoryWithEmailAttachmentLimit(long maxTotalAttachmentBytes)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.PostConfigure<EmailSettings>(settings =>
+                {
+                    settings.MaxTotalAttachmentBytes = maxTotalAttachmentBytes;
+                });
+            });
+        });
+    }
+
+    private Task<(Guid InvoiceId, byte[] ReceiptBytes)> SeedInvoiceWithReceiptAsync(
+        string invoiceNumber,
+        string expenseDescription,
+        string receiptFileName,
+        string receiptContentType,
+        byte[] receiptBytes)
+    {
+        return SeedInvoiceWithReceiptAsync(
+            _factory,
+            invoiceNumber,
+            expenseDescription,
+            receiptFileName,
+            receiptContentType,
+            receiptBytes);
+    }
+
+    private static async Task<(Guid InvoiceId, byte[] ReceiptBytes)> SeedInvoiceWithReceiptAsync(
+        WebApplicationFactory<Program> factory,
+        string invoiceNumber,
+        string expenseDescription,
+        string receiptFileName,
+        string receiptContentType,
+        byte[] receiptBytes)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var attachmentStore = scope.ServiceProvider.GetRequiredService<IExpenseAttachmentStore>();
+        var invoiceId = Guid.NewGuid();
+        var gigId = Guid.NewGuid();
+        var expenseId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var storageKey = $"tests/{attachmentId}";
+
+        await using (var receiptStream = new MemoryStream(receiptBytes))
+        {
+            await attachmentStore.SaveAsync(storageKey, receiptStream, receiptContentType);
+        }
+
+        dbContext.Invoices.Add(new Invoice
+        {
+            Id = invoiceId,
+            InvoiceNumber = invoiceNumber,
+            ClientId = TestData.FoxAndFinchId,
+            InvoiceDate = new DateOnly(2026, 4, 20),
+            DueDate = new DateOnly(2026, 5, 4),
+            Status = InvoiceStatus.Issued,
+            Description = "Receipt delivery test.",
+            PdfBlob = Encoding.ASCII.GetBytes("%PDF-1.4 invoice content"),
+            CreatedByUserId = TestAuthContext.UserId,
+            UpdatedByUserId = TestAuthContext.UserId,
+        });
+        dbContext.Gigs.Add(new Gig
+        {
+            Id = gigId,
+            ClientId = TestData.FoxAndFinchId,
+            InvoiceId = invoiceId,
+            Title = "Receipt gig",
+            Date = new DateOnly(2026, 4, 19),
+            Venue = "Test venue",
+            Status = GigStatus.Confirmed,
+            CreatedByUserId = TestAuthContext.UserId,
+            UpdatedByUserId = TestAuthContext.UserId,
+            Expenses =
+            [
+                new GigExpense
+                {
+                    Id = expenseId,
+                    SortOrder = 1,
+                    Description = expenseDescription,
+                    Amount = 42m,
+                    Attachments =
+                    [
+                        new ExpenseAttachment
+                        {
+                            Id = attachmentId,
+                            FileName = receiptFileName,
+                            ContentType = receiptContentType,
+                            SizeBytes = receiptBytes.Length,
+                            StorageKey = storageKey,
+                            CreatedAt = DateTimeOffset.UtcNow,
+                        }
+                    ],
+                }
+            ],
+        });
+        dbContext.InvoiceLines.Add(new InvoiceLine
+        {
+            Id = Guid.NewGuid(),
+            InvoiceId = invoiceId,
+            SortOrder = 1,
+            Type = InvoiceLineType.MiscExpense,
+            Description = expenseDescription,
+            Quantity = 1m,
+            UnitPrice = 42m,
+            GigId = gigId,
+            IsSystemGenerated = true,
+            CreatedByUserId = TestAuthContext.UserId,
+            CreatedUtc = DateTimeOffset.UtcNow,
+        });
+        await dbContext.SaveChangesAsync();
+
+        return (invoiceId, receiptBytes);
     }
 
     private sealed class FakeGoogleDriveApiClient : IGoogleDriveApiClient

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -428,6 +428,9 @@ public static class InvoiceEndpoints
                 sendingUser?.InvoiceEmailSubjectPattern,
                 periodDate);
             var senderIdentity = InvoiceEmailSenderIdentityBuilder.Build(sendingUser);
+            IReadOnlyList<InvoiceExpenseReceiptAttachment> receiptAttachments = request?.IncludeReceipts is true
+                ? await BuildInvoiceReceiptAttachmentsAsync(db, invoice, cancellationToken)
+                : [];
 
             try
             {
@@ -440,7 +443,18 @@ public static class InvoiceEndpoints
                     emailSubject,
                     attachmentFileName,
                     senderIdentity,
-                    cancellationToken);
+                    cancellationToken,
+                    receiptAttachments);
+            }
+            catch (InvoiceEmailAttachmentLimitExceededException exception)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["attachments"] =
+                    [
+                        $"Invoice email attachments total {FormatBytes(exception.TotalAttachmentBytes)}, exceeding the configured {FormatBytes(exception.MaxTotalAttachmentBytes)} limit."
+                    ]
+                });
             }
             catch (Exception exception)
             {
@@ -688,9 +702,66 @@ public static class InvoiceEndpoints
             : new DateOnly(firstGigDate.Year, firstGigDate.Month, 1);
     }
 
+    private static async Task<IReadOnlyList<InvoiceExpenseReceiptAttachment>> BuildInvoiceReceiptAttachmentsAsync(
+        AppDbContext db,
+        Invoice invoice,
+        CancellationToken cancellationToken)
+    {
+        var expenseLineKeys = invoice.Lines
+            .Where(line => line.Type is InvoiceLineType.MiscExpense && line.GigId.HasValue)
+            .Select(line => new
+            {
+                GigId = line.GigId!.Value,
+                Description = line.Description.Trim(),
+                Amount = line.UnitPrice,
+            })
+            .ToList();
+
+        if (expenseLineKeys.Count == 0)
+        {
+            return [];
+        }
+
+        var gigIds = expenseLineKeys
+            .Select(line => line.GigId)
+            .Distinct()
+            .ToList();
+        var expenses = await db.GigExpenses
+            .AsNoTracking()
+            .Include(expense => expense.Attachments)
+            .Where(expense => gigIds.Contains(expense.GigId))
+            .OrderBy(expense => expense.SortOrder)
+            .ThenBy(expense => expense.Description)
+            .ToListAsync(cancellationToken);
+
+        return expenses
+            .Where(expense => expense.Attachments.Count > 0)
+            .Where(expense => expenseLineKeys.Any(line =>
+                line.GigId == expense.GigId &&
+                string.Equals(line.Description, expense.Description.Trim(), StringComparison.Ordinal) &&
+                line.Amount == expense.Amount))
+            .SelectMany(expense => expense.Attachments
+                .OrderBy(attachment => attachment.CreatedAt)
+                .Select(attachment => new InvoiceExpenseReceiptAttachment(
+                    expense.Description,
+                    attachment.FileName,
+                    attachment.ContentType,
+                    attachment.SizeBytes,
+                    attachment.StorageKey)))
+            .ToList();
+    }
+
+    private static string FormatBytes(long byteCount)
+    {
+        const decimal oneMegabyte = 1024m * 1024m;
+        return byteCount < oneMegabyte
+            ? $"{byteCount} bytes"
+            : $"{byteCount / oneMegabyte:0.##} MB";
+    }
+
     private sealed record InvoiceStatusUpdateRequest(InvoiceStatus Status);
     private sealed record InvoiceAdjustmentCreateRequest(decimal Amount, string Reason);
-    private sealed record InvoiceEmailDeliveryRequest(string? Message);
+    private sealed record InvoiceEmailDeliveryRequest(string? Message, bool IncludeReceipts = false);
     private sealed record InvoiceGoogleDrivePublishResponse(
         Invoice Invoice,
         string? FileId,

--- a/backend/Glovelly.Api/Services/EmailSettings.cs
+++ b/backend/Glovelly.Api/Services/EmailSettings.cs
@@ -3,6 +3,7 @@ namespace Glovelly.Api.Services;
 public sealed class EmailSettings
 {
     public string Mode { get; set; } = EmailModes.Log;
+    public long MaxTotalAttachmentBytes { get; set; } = 25 * 1024 * 1024;
     public EmailSenderIdentitySettings AccessRequests { get; set; } = new();
     public EmailSenderIdentitySettings Invoices { get; set; } = new();
     public ResendEmailSettings Resend { get; set; } = new();

--- a/backend/Glovelly.Api/Services/IInvoiceDeliveryService.cs
+++ b/backend/Glovelly.Api/Services/IInvoiceDeliveryService.cs
@@ -13,5 +13,6 @@ public interface IInvoiceDeliveryService
         string emailSubject,
         string attachmentFileName,
         InvoiceEmailSenderIdentity senderIdentity,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<InvoiceExpenseReceiptAttachment>? expenseReceiptAttachments = null);
 }

--- a/backend/Glovelly.Api/Services/InvoiceDeliveryRequest.cs
+++ b/backend/Glovelly.Api/Services/InvoiceDeliveryRequest.cs
@@ -9,4 +9,12 @@ public sealed record InvoiceDeliveryRequest(
     string? Message,
     string EmailSubject,
     string AttachmentFileName,
-    InvoiceEmailSenderIdentity SenderIdentity);
+    InvoiceEmailSenderIdentity SenderIdentity,
+    IReadOnlyList<InvoiceExpenseReceiptAttachment> ExpenseReceiptAttachments);
+
+public sealed record InvoiceExpenseReceiptAttachment(
+    string ExpenseDescription,
+    string FileName,
+    string ContentType,
+    long SizeBytes,
+    string StorageKey);

--- a/backend/Glovelly.Api/Services/InvoiceDeliveryService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceDeliveryService.cs
@@ -15,13 +15,22 @@ public sealed class InvoiceDeliveryService(
         string emailSubject,
         string attachmentFileName,
         InvoiceEmailSenderIdentity senderIdentity,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<InvoiceExpenseReceiptAttachment>? expenseReceiptAttachments = null)
     {
         var deliveryChannel = deliveryChannels.FirstOrDefault(value => value.Channel == channel)
             ?? throw new InvalidOperationException($"Invoice delivery channel {channel} is not registered.");
 
         var result = await deliveryChannel.DeliverAsync(
-            new InvoiceDeliveryRequest(invoice, client, userId, message, emailSubject, attachmentFileName, senderIdentity),
+            new InvoiceDeliveryRequest(
+                invoice,
+                client,
+                userId,
+                message,
+                emailSubject,
+                attachmentFileName,
+                senderIdentity,
+                expenseReceiptAttachments ?? []),
             cancellationToken);
 
         invoice.DeliveryCount += 1;

--- a/backend/Glovelly.Api/Services/InvoiceEmailDeliveryChannel.cs
+++ b/backend/Glovelly.Api/Services/InvoiceEmailDeliveryChannel.cs
@@ -1,11 +1,13 @@
 using Glovelly.Api.Models;
 using Microsoft.Extensions.Options;
+using System.IO.Compression;
 using System.Text;
 
 namespace Glovelly.Api.Services;
 
 public sealed class InvoiceEmailDeliveryChannel(
     IEmailSender emailSender,
+    IExpenseAttachmentStore expenseAttachmentStore,
     IOptions<EmailSettings> emailSettingsAccessor) : IInvoiceDeliveryChannel
 {
     public InvoiceDeliveryChannel Channel => InvoiceDeliveryChannel.Email;
@@ -31,6 +33,7 @@ public sealed class InvoiceEmailDeliveryChannel(
         var configuredFrom = EmailSenderSupport.ResolveConfiguredFromAddress(
             emailSettingsAccessor.Value,
             EmailUseCase.Invoices);
+        var attachments = await BuildAttachmentsAsync(request, cancellationToken);
 
         await emailSender.SendAsync(
             new EmailMessage(
@@ -45,16 +48,119 @@ public sealed class InvoiceEmailDeliveryChannel(
                     : new EmailAddress(
                         request.SenderIdentity.ReplyToEmail!,
                         request.SenderIdentity.ReplyToDisplayName),
-                Attachments:
-                [
-                    new EmailAttachment(
-                        request.AttachmentFileName,
-                        "application/pdf",
-                        invoice.PdfBlob)
-                ]),
+                Attachments: attachments),
             cancellationToken);
 
         return new InvoiceDeliveryResult(client.Email.Trim());
+    }
+
+    private async Task<IReadOnlyList<EmailAttachment>> BuildAttachmentsAsync(
+        InvoiceDeliveryRequest request,
+        CancellationToken cancellationToken)
+    {
+        var attachments = new List<EmailAttachment>
+        {
+            new(
+                request.AttachmentFileName,
+                "application/pdf",
+                request.Invoice.PdfBlob!)
+        };
+
+        if (request.ExpenseReceiptAttachments.Count > 0)
+        {
+            attachments.Add(await BuildReceiptZipAttachmentAsync(request, cancellationToken));
+        }
+
+        var maxTotalAttachmentBytes = emailSettingsAccessor.Value.MaxTotalAttachmentBytes;
+        var totalAttachmentBytes = attachments.Sum(attachment => (long)attachment.Content.Length);
+        if (maxTotalAttachmentBytes > 0 && totalAttachmentBytes > maxTotalAttachmentBytes)
+        {
+            throw new InvoiceEmailAttachmentLimitExceededException(
+                totalAttachmentBytes,
+                maxTotalAttachmentBytes);
+        }
+
+        return attachments;
+    }
+
+    private async Task<EmailAttachment> BuildReceiptZipAttachmentAsync(
+        InvoiceDeliveryRequest request,
+        CancellationToken cancellationToken)
+    {
+        using var zipStream = new MemoryStream();
+        using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var usedEntryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var receipt in request.ExpenseReceiptAttachments)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var entryName = BuildUniqueZipEntryName(receipt, usedEntryNames);
+                var entry = archive.CreateEntry(entryName, CompressionLevel.SmallestSize);
+                await using var entryStream = entry.Open();
+                var content = await expenseAttachmentStore.OpenReadAsync(receipt.StorageKey, cancellationToken);
+                await using (content.Content)
+                {
+                    await content.Content.CopyToAsync(entryStream, cancellationToken);
+                }
+            }
+        }
+
+        return new EmailAttachment(
+            $"Invoice-{SanitizeFileNamePart(request.Invoice.InvoiceNumber, "Invoice")}-Receipts.zip",
+            "application/zip",
+            zipStream.ToArray());
+    }
+
+    private static string BuildUniqueZipEntryName(
+        InvoiceExpenseReceiptAttachment receipt,
+        HashSet<string> usedEntryNames)
+    {
+        var expenseDescription = SanitizeFileNamePart(receipt.ExpenseDescription, "Expense");
+        var originalFileName = SanitizeFileNamePart(receipt.FileName, "receipt");
+        var baseName = TrimFileNamePart($"{expenseDescription}-{originalFileName}", 180);
+        var candidate = baseName;
+        var suffix = 2;
+
+        while (!usedEntryNames.Add(candidate))
+        {
+            var extension = Path.GetExtension(baseName);
+            var nameWithoutExtension = string.IsNullOrWhiteSpace(extension)
+                ? baseName
+                : baseName[..^extension.Length];
+            candidate = $"{TrimFileNamePart(nameWithoutExtension, 170)}-{suffix++}{extension}";
+        }
+
+        return candidate;
+    }
+
+    private static string SanitizeFileNamePart(string value, string fallback)
+    {
+        var trimmed = value.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            trimmed = fallback;
+        }
+
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(trimmed.Length);
+        foreach (var character in trimmed)
+        {
+            builder.Append(invalidCharacters.Contains(character) || char.IsControl(character)
+                ? '-'
+                : character);
+        }
+
+        var sanitized = builder.ToString().Trim(' ', '.', '-');
+        return string.IsNullOrWhiteSpace(sanitized)
+            ? fallback
+            : sanitized;
+    }
+
+    private static string TrimFileNamePart(string value, int maxLength)
+    {
+        return value.Length <= maxLength
+            ? value
+            : value[..maxLength].Trim(' ', '.', '-');
     }
 
     private static string BuildPlainTextBody(Invoice invoice, string? message)
@@ -75,4 +181,14 @@ public sealed class InvoiceEmailDeliveryChannel(
 
         return builder.ToString();
     }
+}
+
+public sealed class InvoiceEmailAttachmentLimitExceededException(
+    long totalAttachmentBytes,
+    long maxTotalAttachmentBytes)
+    : InvalidOperationException(
+        $"Invoice email attachments total {totalAttachmentBytes} bytes, exceeding the {maxTotalAttachmentBytes} byte limit.")
+{
+    public long TotalAttachmentBytes { get; } = totalAttachmentBytes;
+    public long MaxTotalAttachmentBytes { get; } = maxTotalAttachmentBytes;
 }

--- a/backend/Glovelly.Api/appsettings.Development.json
+++ b/backend/Glovelly.Api/appsettings.Development.json
@@ -12,7 +12,8 @@
     }
   },
   "Email": {
-    "Mode": "Log"
+    "Mode": "Log",
+    "MaxTotalAttachmentBytes": 26214400
   },
   "Cors": {
     "AllowedOrigins": [

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -13,6 +13,7 @@
   },
   "Email": {
     "Mode": "Log",
+    "MaxTotalAttachmentBytes": 26214400,
     "AccessRequests": {
       "FromAddress": "",
       "FromDisplayName": ""

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -2419,6 +2419,9 @@ function App({ appMetadata }: AppProps) {
     if (message === null) {
       return
     }
+    const includeReceipts = window.confirm(
+      `Include any expense receipt attachments for ${invoice.invoiceNumber}?`
+    )
 
     setIsInvoiceLoading(true)
     setInvoiceStatus(`Sending ${invoice.invoiceNumber} to client...`)
@@ -2431,6 +2434,7 @@ function App({ appMetadata }: AppProps) {
         },
         body: JSON.stringify({
           message: message.trim() || null,
+          includeReceipts,
         }),
       })
 
@@ -2438,9 +2442,11 @@ function App({ appMetadata }: AppProps) {
         const problem = await parseProblemDetails(response)
         const recipientError = problem?.errors?.recipient?.[0]
         const pdfError = problem?.errors?.pdf?.[0]
+        const attachmentError = problem?.errors?.attachments?.[0]
         throw new Error(
           recipientError ??
             pdfError ??
+            attachmentError ??
             problem?.detail ??
             problem?.title ??
             'Unable to send invoice email.'


### PR DESCRIPTION
## Summary

Adds optional receipt attachment support to invoice email delivery. When requested, matching expense receipt files for the invoice's generated expense lines are bundled into a single `Invoice-{InvoiceNumber}-Receipts.zip` attachment alongside the invoice PDF.

## Details

- Adds `includeReceipts` to the invoice email request.
- Collects receipts only for expenses represented on the invoice.
- Streams stored receipt content into a zip attachment with sanitized entry names.
- Enforces configurable `Email:MaxTotalAttachmentBytes` limits and returns a validation error when exceeded.
- Adds a frontend confirmation before including receipt attachments.
- Covers zip inclusion, opt-out behavior, and size-limit failure with endpoint tests.

## Validation

- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj`
- `npm run build` from `frontend/glovelly-web`