### PR TITLE
[codex] Preserve client invoice patterns on edit

### DIFF
--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1622,15 +1622,19 @@ function App({ appMetadata }: AppProps) {
       },
     }
 
-    const clientRates =
+    const preservedClientSettings =
       mode === 'edit' && selectedClient
         ? {
             mileageRate: selectedClient.mileageRate,
             passengerMileageRate: selectedClient.passengerMileageRate,
+            invoiceFilenamePattern: selectedClient.invoiceFilenamePattern,
+            invoiceEmailSubjectPattern: selectedClient.invoiceEmailSubjectPattern,
           }
         : {
             mileageRate: null,
             passengerMileageRate: null,
+            invoiceFilenamePattern: null,
+            invoiceEmailSubjectPattern: null,
           }
 
     if (
@@ -1656,7 +1660,7 @@ function App({ appMetadata }: AppProps) {
         : buildApiUrl('/clients')
       const requestBody = JSON.stringify({
         ...payload,
-        ...clientRates,
+        ...preservedClientSettings,
       })
 
       const response = await fetchWithSession(endpoint, {


### PR DESCRIPTION
## Summary

Fixes issue #84 by preserving client-specific invoice filename and email subject patterns when saving changes from the main edit-client form.

## Root Cause

The edit-client submit path carried forward client mileage settings, but did not include the existing invoice filename or email subject overrides. Because `PUT /clients/{id}` treats missing fields as `null`, saving ordinary client details cleared those custom patterns.

## Impact

Users can now update client contact or billing details without losing client-specific invoice filename and email subject settings. The dedicated client settings modal still controls setting or clearing those overrides.

## Validation

- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj --filter ClientEndpointsTests`
- `npm run build`
- `npm run lint`