### PR TITLE
Add quick-add parsing for gig expenses and handle missing invoice reissue time

### DIFF
--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -885,9 +885,19 @@
   justify-self: start;
 }
 
+
+.quick-add-button {
+  grid-column: auto;
+  justify-self: stretch;
+}
+
 @media (max-width: 1380px) {
   .invoice-adjustment-form {
     grid-template-columns: 1fr;
+  }
+
+  .quick-add-button {
+    grid-column: 1 / -1;
   }
 }
 

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -181,6 +181,7 @@ function App({ appMetadata }: AppProps) {
   const [isGigLoading, setIsGigLoading] = useState(false)
   const [gigExpenseAmount, setGigExpenseAmount] = useState('')
   const [gigExpenseDescription, setGigExpenseDescription] = useState('')
+  const [gigQuickAdd, setGigQuickAdd] = useState('')
   const [monthlyInvoiceMonth, setMonthlyInvoiceMonth] = useState(getCurrentMonthValue)
   const [monthlyInvoiceStatus, setMonthlyInvoiceStatus] = useState('')
   const [invoices, setInvoices] = useState<Invoice[]>([])
@@ -988,6 +989,36 @@ function App({ appMetadata }: AppProps) {
     setGigExpenseAmount('')
     setGigExpenseDescription('')
     setGigStatus('Expense added to the gig form. Save the gig to persist it.')
+  }
+
+
+  const handleQuickAddGigExpense = () => {
+    const quickAdd = gigQuickAdd.trim()
+    const match = quickAdd.match(/^(.*?)(?:\s+|\s*[-:]\s*)(\d+(?:\.\d{1,2})?)$/)
+
+    if (!match) {
+      setGigStatus('Use quick add format: "Description 12.50".')
+      return
+    }
+
+    const description = match[1].trim()
+    const amountText = match[2]
+    const amount = Number(amountText)
+
+    if (!description) {
+      setGigStatus('Quick add needs a description before the amount.')
+      return
+    }
+
+    if (!Number.isFinite(amount) || amount < 0) {
+      setGigStatus('Quick add amount must be a valid non-negative number.')
+      return
+    }
+
+    setGigExpenseDescription(description)
+    setGigExpenseAmount(amountText)
+    setGigQuickAdd('')
+    setGigStatus('Quick add parsed. Review or press Add expense to confirm.')
   }
 
   const updateGigExpenseField = (
@@ -2404,7 +2435,9 @@ function App({ appMetadata }: AppProps) {
       if (isRedraft) {
         setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} draft regenerated.`)
       } else {
-        const reissuedAt = formatDateTime(updatedInvoice.lastReissuedUtc)
+        const reissuedAt = updatedInvoice.lastReissuedUtc
+          ? formatDateTime(updatedInvoice.lastReissuedUtc)
+          : 'an unknown time'
         setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} re-issued at ${reissuedAt}.`)
       }
     } catch (error) {
@@ -2723,6 +2756,9 @@ function App({ appMetadata }: AppProps) {
         onCloseEditor={closeGigEditor}
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
+        gigQuickAdd={gigQuickAdd}
+        onQuickAddGigExpenseChange={setGigQuickAdd}
+        onQuickAddGigExpense={handleQuickAddGigExpense}
         onGenerateInvoice={handleGenerateInvoice}
         onDownloadExpenseAttachment={downloadExpenseAttachment}
         onOpenLinkedInvoice={openSelectedGigInvoice}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -688,6 +688,7 @@ type GigsSectionProps = {
   filteredGigs: Gig[]
   gigExpenseAmount: string
   gigExpenseDescription: string
+  gigQuickAdd: string
   gigForm: GigForm
   isEditorOpen: boolean
   gigMode: 'create' | 'edit'
@@ -700,6 +701,8 @@ type GigsSectionProps = {
   onCloseEditor: () => void
   onExpenseAmountChange: (value: string) => void
   onExpenseDescriptionChange: (value: string) => void
+  onQuickAddGigExpense: () => void
+  onQuickAddGigExpenseChange: (value: string) => void
   onGenerateInvoice: () => void
   onDownloadExpenseAttachment: (expense: GigExpenseForm, attachmentId: string) => void
   onOpenLinkedInvoice: () => void
@@ -737,6 +740,7 @@ export function GigsSection({
   filteredGigs,
   gigExpenseAmount,
   gigExpenseDescription,
+  gigQuickAdd,
   gigForm,
   isEditorOpen,
   gigMode,
@@ -749,6 +753,8 @@ export function GigsSection({
   onCloseEditor,
   onExpenseAmountChange,
   onExpenseDescriptionChange,
+  onQuickAddGigExpense,
+  onQuickAddGigExpenseChange,
   onGenerateInvoice,
   onDownloadExpenseAttachment,
   onOpenLinkedInvoice,
@@ -1085,6 +1091,23 @@ export function GigsSection({
             </div>
 
             <div className="invoice-adjustment-form">
+              <label className="full-width">
+                Quick add
+                <input
+                  value={gigQuickAdd}
+                  onChange={(event) => onQuickAddGigExpenseChange(event.target.value)}
+                  placeholder="Parking 12.50"
+                  disabled={isGigLoading}
+                />
+              </label>
+              <button
+                className="ghost-button"
+                onClick={onQuickAddGigExpense}
+                type="button"
+                disabled={isGigLoading}
+              >
+                Parse quick add
+              </button>
               <label>
                 Amount
                 <input

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -1101,12 +1101,12 @@ export function GigsSection({
                 />
               </label>
               <button
-                className="ghost-button"
+                className="primary-button quick-add-button"
                 onClick={onQuickAddGigExpense}
                 type="button"
                 disabled={isGigLoading}
               >
-                Parse quick add
+                Quick add expense
               </button>
               <label>
                 Amount


### PR DESCRIPTION
### Motivation

- Provide a faster way to add common expense entries by allowing a single-line "quick add" input for gig expenses.
- Avoid showing an invalid formatted time when an invoice `lastReissuedUtc` value is missing by falling back to a safe string.

### Description

- Added a `gigQuickAdd` state and a `handleQuickAddGigExpense` function in `App.tsx` which parses strings like `"Parking 12.50"` using a regex and validates description and amount. 
- When parsing succeeds the quick-add handler populates the expense description and amount fields, clears the quick-add input, and updates `gigStatus` with guidance. 
- Wired the new state and handler into `GigsSection` props and added a quick-add input and "Parse quick add" button to the gigs UI. 
- Updated invoice re-issue messaging to handle a missing `lastReissuedUtc` by using `formatDateTime(...)` only when present and otherwise displaying `"an unknown time"`.

### Testing

- Ran the frontend test suite with `yarn test` and the tests completed successfully. 
- Verified TypeScript checks and linting with `yarn build` (which includes type checking) and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8380009c8328a4bcc758283b95f5)