### PR TITLE
[codex] Add quick receipt capture flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ env:
 jobs:
   container:
     runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'pull_request' && 'staging' || 'production' }}
 
     steps:
       - name: Check out repository
@@ -132,7 +133,7 @@ jobs:
             Email__Mode=Resend
             Email__AccessRequests__FromDisplayName=Glovelly
             Email__Invoices__FromDisplayName=Glovelly
-            ExpenseAttachments__BucketName=glovelly-storage-production
+            ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest
@@ -162,7 +163,7 @@ jobs:
             Email__Mode=Resend
             Email__AccessRequests__FromDisplayName=Glovelly
             Email__Invoices__FromDisplayName=Glovelly
-            ExpenseAttachments__BucketName=glovelly-storage-staging
+            ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -372,6 +372,269 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task QuickReceiptDraft_WithNearbyGig_CreatesDraftExpenseAndAttachment()
+    {
+        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Yesterday receipt match",
+            date = today.AddDays(-1).ToString("yyyy-MM-dd"),
+            venue = "Station",
+            fee = 120.00m,
+            travelMiles = 0.00m,
+            notes = "Receipt draft test",
+            wasDriving = true,
+            status = 1,
+            expenses = Array.Empty<object>(),
+            invoicedAt = (string?)null,
+        });
+
+        createResponse.EnsureSuccessStatusCode();
+
+        using var form = BuildReceiptDraftForm("taxi receipt"u8.ToArray(), "taxi.jpg", "image/jpeg");
+
+        var response = await _client.PostAsync("/gigs/receipt-drafts", form);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.True(result.GetProperty("inferredGig").GetBoolean());
+
+        var gig = result.GetProperty("gig");
+        var expense = Assert.Single(gig.GetProperty("expenses").EnumerateArray());
+        Assert.Equal("Receipt draft", expense.GetProperty("description").GetString());
+        Assert.Equal(0m, expense.GetProperty("amount").GetDecimal());
+
+        var attachment = Assert.Single(expense.GetProperty("attachments").EnumerateArray());
+        Assert.Equal("taxi.jpg", attachment.GetProperty("fileName").GetString());
+        Assert.Equal("image/jpeg", attachment.GetProperty("contentType").GetString());
+        Assert.Equal("taxi receipt"u8.Length, attachment.GetProperty("sizeBytes").GetInt64());
+
+        var candidates = result.GetProperty("candidates").EnumerateArray().ToArray();
+        Assert.Single(candidates);
+        Assert.Equal(1, candidates[0].GetProperty("daysFromToday").GetInt32());
+        Assert.True(candidates[0].GetProperty("isSelected").GetBoolean());
+    }
+
+    [Fact]
+    public async Task QuickReceiptDraft_WithCandidateInsideAmbiguityWindow_FlagsNearbyCandidates()
+    {
+        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        foreach (var (title, offset) in new[] { ("Yesterday show", -1), ("Tomorrow show", 1), ("Next week show", 7) })
+        {
+            var createResponse = await _client.PostAsJsonAsync("/gigs", new
+            {
+                clientId = TestData.FoxAndFinchId,
+                title,
+                date = today.AddDays(offset).ToString("yyyy-MM-dd"),
+                venue = "Theatre",
+                fee = 120.00m,
+                travelMiles = 0.00m,
+                notes = "Ambiguous receipt draft test",
+                wasDriving = true,
+                status = 1,
+                expenses = Array.Empty<object>(),
+                invoicedAt = (string?)null,
+            });
+
+            createResponse.EnsureSuccessStatusCode();
+        }
+
+        using var form = BuildReceiptDraftForm("receipt"u8.ToArray(), "receipt.pdf", "application/pdf");
+
+        var response = await _client.PostAsync("/gigs/receipt-drafts", form);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.True(result.GetProperty("hasNearbyCandidates").GetBoolean());
+
+        var gig = result.GetProperty("gig");
+        Assert.Equal("Yesterday show", gig.GetProperty("title").GetString());
+
+        var candidates = result.GetProperty("candidates").EnumerateArray().ToArray();
+        Assert.Equal(3, candidates.Length);
+        Assert.Equal("Yesterday show", candidates[0].GetProperty("title").GetString());
+        Assert.True(candidates[0].GetProperty("isSelected").GetBoolean());
+    }
+
+    [Fact]
+    public async Task QuickReceiptDraft_WithCandidateOutsideAmbiguityWindow_DoesNotFlagNearbyCandidates()
+    {
+        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        foreach (var (title, offset) in new[] { ("Today show", 0), ("Last month show", -20) })
+        {
+            var createResponse = await _client.PostAsJsonAsync("/gigs", new
+            {
+                clientId = TestData.FoxAndFinchId,
+                title,
+                date = today.AddDays(offset).ToString("yyyy-MM-dd"),
+                venue = "Theatre",
+                fee = 120.00m,
+                travelMiles = 0.00m,
+                notes = "Distant ambiguity test",
+                wasDriving = true,
+                status = 1,
+                expenses = Array.Empty<object>(),
+                invoicedAt = (string?)null,
+            });
+
+            createResponse.EnsureSuccessStatusCode();
+        }
+
+        using var form = BuildReceiptDraftForm("receipt"u8.ToArray(), "receipt.pdf", "application/pdf");
+
+        var response = await _client.PostAsync("/gigs/receipt-drafts", form);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.False(result.GetProperty("hasNearbyCandidates").GetBoolean());
+
+        var candidates = result.GetProperty("candidates").EnumerateArray().ToArray();
+        Assert.Equal(2, candidates.Length);
+    }
+
+    [Fact]
+    public async Task QuickReceiptDraft_WithNoCandidateInsideWindow_ReturnsEmptyCandidates()
+    {
+        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        foreach (var (title, offset) in new[] { ("Old show", -45), ("Future show", 60) })
+        {
+            var createResponse = await _client.PostAsJsonAsync("/gigs", new
+            {
+                clientId = TestData.FoxAndFinchId,
+                title,
+                date = today.AddDays(offset).ToString("yyyy-MM-dd"),
+                venue = "Theatre",
+                fee = 120.00m,
+                travelMiles = 0.00m,
+                notes = "Distant receipt draft test",
+                wasDriving = true,
+                status = 1,
+                expenses = Array.Empty<object>(),
+                invoicedAt = (string?)null,
+            });
+
+            createResponse.EnsureSuccessStatusCode();
+        }
+
+        using var form = BuildReceiptDraftForm("receipt"u8.ToArray(), "receipt.pdf", "application/pdf");
+
+        var response = await _client.PostAsync("/gigs/receipt-drafts", form);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("No gig was within 30 days. Choose a gig before saving this receipt draft.", result.GetProperty("message").GetString());
+        Assert.Empty(result.GetProperty("candidates").EnumerateArray());
+        Assert.Equal(30, result.GetProperty("autoAttachWindowDays").GetInt32());
+    }
+
+    [Fact]
+    public async Task QuickReceiptDraft_WithExplicitGig_CreatesDraftWhenNearestIsOutsideWindow()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Future receipt target",
+            date = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime).AddDays(60).ToString("yyyy-MM-dd"),
+            venue = "Airport",
+            fee = 120.00m,
+            travelMiles = 0.00m,
+            notes = "Explicit receipt draft test",
+            wasDriving = true,
+            status = 1,
+            expenses = Array.Empty<object>(),
+            invoicedAt = (string?)null,
+        });
+
+        createResponse.EnsureSuccessStatusCode();
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var gigId = createdGig.GetProperty("id").GetGuid();
+
+        using var form = BuildReceiptDraftForm("receipt"u8.ToArray(), "receipt.pdf", "application/pdf", gigId);
+
+        var response = await _client.PostAsync("/gigs/receipt-drafts", form);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.False(result.GetProperty("inferredGig").GetBoolean());
+        Assert.Equal(gigId, result.GetProperty("gig").GetProperty("id").GetGuid());
+    }
+
+    [Fact]
+    public async Task UpdateQuickReceiptDraft_SavesDetailsAndMovesGig()
+    {
+        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var firstGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Receipt first target",
+            date = today.ToString("yyyy-MM-dd"),
+            venue = "Station",
+            fee = 120.00m,
+            travelMiles = 0.00m,
+            notes = "Receipt update test",
+            wasDriving = true,
+            status = 1,
+            expenses = Array.Empty<object>(),
+            invoicedAt = (string?)null,
+        });
+        firstGigResponse.EnsureSuccessStatusCode();
+
+        var secondGigResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Receipt corrected target",
+            date = today.AddDays(2).ToString("yyyy-MM-dd"),
+            venue = "Hotel",
+            fee = 120.00m,
+            travelMiles = 0.00m,
+            notes = "Receipt update test",
+            wasDriving = true,
+            status = 1,
+            expenses = Array.Empty<object>(),
+            invoicedAt = (string?)null,
+        });
+        secondGigResponse.EnsureSuccessStatusCode();
+
+        var secondGig = await secondGigResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var secondGigId = secondGig.GetProperty("id").GetGuid();
+
+        using var form = BuildReceiptDraftForm("receipt"u8.ToArray(), "receipt.pdf", "application/pdf");
+        var quickResponse = await _client.PostAsync("/gigs/receipt-drafts", form);
+        quickResponse.EnsureSuccessStatusCode();
+
+        var quickDraft = await quickResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var expenseId = quickDraft.GetProperty("expenseId").GetGuid();
+
+        var updateResponse = await _client.PatchAsJsonAsync($"/gigs/receipt-drafts/{expenseId}", new
+        {
+            gigId = secondGigId,
+            description = "Taxi from station",
+            amount = 18.75m,
+        });
+
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+
+        var result = await updateResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.True(result.GetProperty("moved").GetBoolean());
+
+        var targetGig = result.GetProperty("gig");
+        Assert.Equal(secondGigId, targetGig.GetProperty("id").GetGuid());
+        var expense = Assert.Single(targetGig.GetProperty("expenses").EnumerateArray());
+        Assert.Equal("Taxi from station", expense.GetProperty("description").GetString());
+        Assert.Equal(18.75m, expense.GetProperty("amount").GetDecimal());
+        Assert.Single(expense.GetProperty("attachments").EnumerateArray());
+
+        var previousGig = result.GetProperty("previousGig");
+        Assert.Empty(previousGig.GetProperty("expenses").EnumerateArray());
+    }
+
+    [Fact]
     public async Task CreateGig_WithInvoice_GeneratesMileagePassengerAndExpenseLines()
     {
         var response = await _client.PostAsJsonAsync("/gigs", new
@@ -437,6 +700,25 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(20.00m, lines[4].GetProperty("lineTotal").GetDecimal());
 
         Assert.Equal(340.61m, invoice.GetProperty("total").GetDecimal());
+    }
+
+    private static MultipartFormDataContent BuildReceiptDraftForm(
+        byte[] content,
+        string fileName,
+        string contentType,
+        Guid? gigId = null)
+    {
+        var form = new MultipartFormDataContent();
+        var file = new ByteArrayContent(content);
+        file.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        form.Add(file, "file", fileName);
+
+        if (gigId.HasValue)
+        {
+            form.Add(new StringContent(gigId.Value.ToString()), "gigId");
+        }
+
+        return form;
     }
 
     [Fact]

--- a/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
@@ -175,6 +175,246 @@ public static class GigEndpoints
             return Results.Created($"/invoices/{invoice.Id}", invoice);
         });
 
+        group.MapPost("/receipt-drafts", async (
+            HttpRequest request,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IExpenseAttachmentStore attachmentStore,
+            IOptions<ExpenseAttachmentSettings> attachmentOptions,
+            IOptions<QuickReceiptCaptureSettings> quickReceiptOptions,
+            TimeProvider timeProvider) =>
+        {
+            if (!request.HasFormContentType)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["file"] = ["Upload a receipt file."]
+                });
+            }
+
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var form = await request.ReadFormAsync();
+            var file = form.Files.GetFile("file") ?? form.Files.FirstOrDefault();
+            var validation = ValidateAttachmentFile(file, attachmentOptions.Value);
+            if (validation is not null)
+            {
+                return validation;
+            }
+
+            var gigId = TryReadGigId(form);
+            var today = DateOnly.FromDateTime(timeProvider.GetLocalNow().DateTime);
+            var settings = NormalizeQuickReceiptSettings(quickReceiptOptions.Value);
+            var candidates = await FindReceiptCandidatesAsync(
+                db,
+                userId,
+                today,
+                settings.CandidateCount,
+                settings.AutoAttachWindowDays);
+            Gig? gig;
+            if (gigId.HasValue)
+            {
+                gig = await db.Gigs
+                    .WhereVisibleTo(userId)
+                    .Include(value => value.Expenses)
+                    .FirstOrDefaultAsync(value => value.Id == gigId.Value);
+
+                if (gig is null)
+                {
+                    return Results.ValidationProblem(new Dictionary<string, string[]>
+                    {
+                        ["gigId"] = ["Gig does not exist."]
+                    });
+                }
+            }
+            else
+            {
+                var nearestCandidate = candidates.FirstOrDefault();
+                if (nearestCandidate is null)
+                {
+                    return Results.Conflict(new
+                    {
+                        message = $"No gig was within {settings.AutoAttachWindowDays} days. Choose a gig before saving this receipt draft.",
+                        candidates = candidates.Select(candidate => ToReceiptGigCandidate(candidate, nearestCandidate?.Id)),
+                        autoAttachWindowDays = settings.AutoAttachWindowDays,
+                    });
+                }
+
+                gig = await db.Gigs
+                    .WhereVisibleTo(userId)
+                    .Include(value => value.Expenses)
+                    .FirstAsync(value => value.Id == nearestCandidate.Id);
+            }
+
+            var expense = new GigExpense
+            {
+                Id = Guid.NewGuid(),
+                GigId = gig.Id,
+                SortOrder = gig.Expenses.Count == 0 ? 1 : gig.Expenses.Max(value => value.SortOrder) + 1,
+                Description = "Receipt draft",
+                Amount = 0m,
+            };
+
+            var attachmentId = Guid.NewGuid();
+            var storageKey = BuildAttachmentStorageKey(userId, gig.Id, expense.Id, attachmentId);
+            await using var stream = file!.OpenReadStream();
+            await attachmentStore.SaveAsync(storageKey, stream, file.ContentType);
+
+            var displayFileName = Path.GetFileName(file.FileName);
+            if (string.IsNullOrWhiteSpace(displayFileName))
+            {
+                displayFileName = "receipt";
+            }
+
+            expense.Attachments.Add(new ExpenseAttachment
+            {
+                Id = attachmentId,
+                GigExpenseId = expense.Id,
+                FileName = displayFileName,
+                ContentType = file.ContentType,
+                SizeBytes = file.Length,
+                StorageKey = storageKey,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+            db.GigExpenses.Add(expense);
+            EndpointSupport.StampUpdate(gig, userId);
+            await db.SaveChangesAsync();
+
+            var savedGig = await db.Gigs
+                .WhereVisibleTo(userId)
+                .Include(value => value.Expenses)
+                    .ThenInclude(value => value.Attachments)
+                .FirstAsync(value => value.Id == gig.Id);
+
+            return Results.Created($"/gigs/{savedGig.Id}", new
+            {
+                gig = savedGig,
+                expenseId = expense.Id,
+                attachmentId,
+                inferredGig = !gigId.HasValue,
+                candidates = candidates.Select(candidate => ToReceiptGigCandidate(candidate, gig.Id)),
+                autoAttachWindowDays = settings.AutoAttachWindowDays,
+                hasNearbyCandidates = candidates.Any(candidate =>
+                    candidate.Id != gig.Id &&
+                    candidate.DaysFromToday <= settings.AmbiguityWindowDays),
+            });
+        });
+
+        group.MapPatch("/receipt-drafts/{expenseId:guid}", async (
+            Guid expenseId,
+            QuickReceiptDraftUpdateRequest update,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IInvoiceWorkflowService invoiceWorkflowService) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var targetGig = await db.Gigs
+                .WhereVisibleTo(userId)
+                .Include(value => value.Expenses)
+                .FirstOrDefaultAsync(value => value.Id == update.GigId);
+
+            if (targetGig is null)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["gigId"] = ["Gig does not exist."]
+                });
+            }
+
+            var expense = await db.GigExpenses
+                .Include(value => value.Attachments)
+                .Include(value => value.Gig)
+                .Where(value => value.Id == expenseId)
+                .Where(value => value.Gig != null
+                    && (value.Gig.CreatedByUserId == null || value.Gig.CreatedByUserId == userId))
+                .FirstOrDefaultAsync();
+
+            if (expense is null)
+            {
+                return Results.NotFound();
+            }
+
+            var description = update.Description?.Trim() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["description"] = ["Expense description is required."]
+                });
+            }
+
+            if (update.Amount < 0)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["amount"] = ["Expense amount cannot be negative."]
+                });
+            }
+
+            var previousGigId = expense.GigId;
+            var moved = previousGigId != targetGig.Id;
+
+            expense.Description = description;
+            expense.Amount = update.Amount;
+            if (moved)
+            {
+                expense.GigId = targetGig.Id;
+                expense.Gig = targetGig;
+                expense.SortOrder = targetGig.Expenses.Count == 0
+                    ? 1
+                    : targetGig.Expenses.Max(value => value.SortOrder) + 1;
+                targetGig.Expenses.Add(expense);
+            }
+
+            if (expense.Gig is not null)
+            {
+                EndpointSupport.StampUpdate(expense.Gig, userId);
+            }
+
+            EndpointSupport.StampUpdate(targetGig, userId);
+            await db.SaveChangesAsync();
+
+            var affectedGigIds = moved
+                ? new[] { previousGigId, targetGig.Id }
+                : new[] { targetGig.Id };
+
+            var affectedGigs = await db.Gigs
+                .WhereVisibleTo(userId)
+                .Include(value => value.Expenses)
+                .Where(value => affectedGigIds.Contains(value.Id))
+                .ToListAsync();
+
+            foreach (var affectedGig in affectedGigs)
+            {
+                await invoiceWorkflowService.SyncGeneratedInvoiceLinesForGigAsync(affectedGig, userId);
+            }
+
+            await db.SaveChangesAsync();
+
+            var savedGigs = await db.Gigs
+                .WhereVisibleTo(userId)
+                .AsNoTracking()
+                .Include(value => value.Expenses)
+                    .ThenInclude(value => value.Attachments)
+                .Where(value => affectedGigIds.Contains(value.Id))
+                .ToListAsync();
+
+            var savedTargetGig = savedGigs.First(value => value.Id == targetGig.Id);
+            var previousGig = moved
+                ? savedGigs.FirstOrDefault(value => value.Id == previousGigId)
+                : null;
+
+            return Results.Ok(new
+            {
+                gig = savedTargetGig,
+                previousGig,
+                expenseId,
+                moved,
+            });
+        });
+
         group.MapPost("/", async (
             Gig gig,
             AppDbContext db,
@@ -614,5 +854,77 @@ public static class GigEndpoints
         return $"users/{owner}/gigs/{gigId:N}/expenses/{expenseId:N}/attachments/{attachmentId:N}";
     }
 
+    private static Guid? TryReadGigId(IFormCollection form)
+    {
+        var rawValue = form["gigId"].FirstOrDefault();
+        return Guid.TryParse(rawValue, out var gigId) && gigId != Guid.Empty ? gigId : null;
+    }
+
+    private static async Task<List<ReceiptGigCandidate>> FindReceiptCandidatesAsync(
+        AppDbContext db,
+        Guid? userId,
+        DateOnly today,
+        int candidateCount,
+        int autoAttachWindowDays)
+    {
+        var gigs = await db.Gigs
+            .WhereVisibleTo(userId)
+            .AsNoTracking()
+            .Where(value => value.Status != GigStatus.Cancelled)
+            .ToListAsync();
+
+        return gigs
+            .Select(gig => new ReceiptGigCandidate(
+                gig.Id,
+                gig.ClientId,
+                gig.Title,
+                gig.Date,
+                gig.Venue,
+                gig.Status,
+                Math.Abs(gig.Date.DayNumber - today.DayNumber)))
+            .Where(candidate => candidate.DaysFromToday <= autoAttachWindowDays)
+            .OrderBy(candidate => candidate.DaysFromToday)
+            .ThenBy(candidate => candidate.Date)
+            .ThenBy(candidate => candidate.Title)
+            .Take(candidateCount)
+            .ToList();
+    }
+
+    private static QuickReceiptCaptureSettings NormalizeQuickReceiptSettings(QuickReceiptCaptureSettings settings)
+    {
+        return new QuickReceiptCaptureSettings
+        {
+            CandidateCount = Math.Clamp(settings.CandidateCount, 1, 20),
+            AutoAttachWindowDays = Math.Clamp(settings.AutoAttachWindowDays, 0, 365),
+            AmbiguityWindowDays = Math.Clamp(settings.AmbiguityWindowDays, 0, 365),
+        };
+    }
+
+    private static object ToReceiptGigCandidate(ReceiptGigCandidate candidate, Guid? selectedGigId)
+    {
+        return new
+        {
+            candidate.Id,
+            candidate.ClientId,
+            candidate.Title,
+            candidate.Date,
+            candidate.Venue,
+            candidate.Status,
+            candidate.DaysFromToday,
+            IsSelected = candidate.Id == selectedGigId,
+        };
+    }
+
     private sealed record GenerateInvoiceFromGigSelectionRequest(IReadOnlyList<Guid> GigIds);
+
+    private sealed record QuickReceiptDraftUpdateRequest(Guid GigId, string Description, decimal Amount);
+
+    private sealed record ReceiptGigCandidate(
+        Guid Id,
+        Guid ClientId,
+        string Title,
+        DateOnly Date,
+        string Venue,
+        GigStatus Status,
+        int DaysFromToday);
 }

--- a/backend/Glovelly.Api/Services/QuickReceiptCaptureSettings.cs
+++ b/backend/Glovelly.Api/Services/QuickReceiptCaptureSettings.cs
@@ -1,0 +1,10 @@
+namespace Glovelly.Api.Services;
+
+public sealed class QuickReceiptCaptureSettings
+{
+    public const string SectionName = "QuickReceiptCapture";
+
+    public int CandidateCount { get; set; } = 5;
+    public int AutoAttachWindowDays { get; set; } = 30;
+    public int AmbiguityWindowDays { get; set; } = 2;
+}

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceGoogleDriveDeliveryChannel>();
         services.AddOptions<ExpenseAttachmentSettings>()
             .BindConfiguration(ExpenseAttachmentSettings.SectionName);
+        services.AddOptions<QuickReceiptCaptureSettings>()
+            .BindConfiguration(QuickReceiptCaptureSettings.SectionName);
         services.AddSingleton<IExpenseAttachmentStore>(provider =>
         {
             var settings = provider.GetRequiredService<IOptions<ExpenseAttachmentSettings>>().Value;

--- a/backend/Glovelly.Api/appsettings.Development.json
+++ b/backend/Glovelly.Api/appsettings.Development.json
@@ -35,5 +35,10 @@
   "ExpenseAttachments": {
     "BucketName": "",
     "MaxFileSizeBytes": 10485760
+  },
+  "QuickReceiptCapture": {
+    "CandidateCount": 5,
+    "AutoAttachWindowDays": 30,
+    "AmbiguityWindowDays": 2
   }
 }

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -44,5 +44,10 @@
     "BucketName": "",
     "MaxFileSizeBytes": 10485760
   },
+  "QuickReceiptCapture": {
+    "CandidateCount": 5,
+    "AutoAttachWindowDays": 30,
+    "AmbiguityWindowDays": 2
+  },
   "AllowedHosts": "*"
 }

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -83,6 +83,36 @@
   gap: 20px;
 }
 
+.header-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 12px;
+  min-width: fit-content;
+}
+
+.quick-receipt-button {
+  min-height: 52px;
+  padding-inline: 18px;
+  gap: 8px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.quick-receipt-button span {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.quick-receipt-button input,
+.file-button input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .content-header-copy,
 .content-header-aside {
   display: grid;
@@ -327,6 +357,88 @@
   max-height: min(100svh - 48px, 860px);
   overflow: auto;
   background: var(--surface-panel);
+}
+
+.quick-receipt-modal {
+  display: grid;
+  gap: 18px;
+}
+
+.quick-receipt-summary {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: var(--surface-accent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 88%, transparent);
+}
+
+.quick-receipt-summary strong {
+  color: var(--heading);
+  overflow-wrap: anywhere;
+}
+
+.quick-receipt-summary span {
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.quick-receipt-progress {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-border) 68%, transparent);
+}
+
+.quick-receipt-progress span {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--brand-gradient);
+  animation: quick-receipt-progress 1100ms ease-in-out infinite;
+}
+
+@keyframes quick-receipt-progress {
+  0% {
+    transform: translateX(-120%);
+  }
+
+  100% {
+    transform: translateX(260%);
+  }
+}
+
+.quick-receipt-warning {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: color-mix(in srgb, #f47d2a 16%, var(--surface-elevated));
+  border: 1px solid color-mix(in srgb, #f47d2a 42%, var(--surface-border));
+}
+
+.quick-receipt-warning strong {
+  color: var(--heading);
+}
+
+.quick-receipt-warning span {
+  color: var(--muted-strong);
+  line-height: 1.45;
+}
+
+.quick-receipt-select {
+  display: grid;
+  gap: 8px;
+}
+
+.quick-receipt-select span {
+  color: var(--muted-strong);
+  font-size: 0.86rem;
+}
+
+.quick-receipt-details {
+  grid-template-columns: minmax(120px, 0.5fr) minmax(0, 1fr);
 }
 
 .settings-intro {
@@ -1020,6 +1132,9 @@
   padding: 12px 18px;
   border: 1px solid transparent;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition:
     transform 180ms ease,
     box-shadow 180ms ease,
@@ -1208,6 +1323,16 @@ button:disabled {
 
   .content-header-top {
     flex-direction: column;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .quick-receipt-button {
+    flex: 1;
+    justify-content: center;
   }
 
   .content-header.panel {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -29,6 +29,7 @@ import {
   fetchWithSession,
   formatCurrency,
   formatBuildMetadata,
+  formatDate,
   formatDateTime,
   getStoredThemePreference,
   parseProblemDetails,
@@ -50,6 +51,9 @@ import type {
   GigForm,
   Invoice,
   InvoiceStatus,
+  QuickReceiptCandidate,
+  QuickReceiptDraftResponse,
+  QuickReceiptDraftUpdateResponse,
   SellerProfile,
   SellerProfileForm,
   ThemePreference,
@@ -191,6 +195,15 @@ function App({ appMetadata }: AppProps) {
   const [googleDrivePublishLink, setGoogleDrivePublishLink] =
     useState<GoogleDrivePublishLink | null>(null)
   const [isInvoiceLoading, setIsInvoiceLoading] = useState(false)
+  const [pendingReceiptFile, setPendingReceiptFile] = useState<File | null>(null)
+  const [quickReceiptDraft, setQuickReceiptDraft] =
+    useState<QuickReceiptDraftResponse | null>(null)
+  const [quickReceiptCandidates, setQuickReceiptCandidates] = useState<QuickReceiptCandidate[]>([])
+  const [quickReceiptSelectedGigId, setQuickReceiptSelectedGigId] = useState('')
+  const [quickReceiptAmount, setQuickReceiptAmount] = useState('')
+  const [quickReceiptDescription, setQuickReceiptDescription] = useState('')
+  const [quickReceiptStatus, setQuickReceiptStatus] = useState('')
+  const [isQuickReceiptSaving, setIsQuickReceiptSaving] = useState(false)
   const [adjustmentAmount, setAdjustmentAmount] = useState('')
   const [adjustmentReason, setAdjustmentReason] = useState('')
   const deferredSearchQuery = useDeferredValue(searchQuery)
@@ -305,6 +318,14 @@ function App({ appMetadata }: AppProps) {
       setIsInvoiceEditorOpen(false)
       setInvoiceSearchQuery('')
       setInvoiceStatus(defaultInvoiceStatus)
+      setPendingReceiptFile(null)
+      setQuickReceiptDraft(null)
+      setQuickReceiptCandidates([])
+      setQuickReceiptSelectedGigId('')
+      setQuickReceiptAmount('')
+      setQuickReceiptDescription('')
+      setQuickReceiptStatus('')
+      setIsQuickReceiptSaving(false)
       setIsClientSettingsOpen(false)
       setClientSettingsForm(emptyClientSettingsForm())
       setClientSettingsStatus(
@@ -1146,6 +1167,255 @@ function App({ appMetadata }: AppProps) {
     } finally {
       setIsGigLoading(false)
     }
+  }
+
+  const openGigReceiptDraft = (savedGig: Gig) => {
+    mergeSavedGig(savedGig)
+    setSelectedGigId(savedGig.id)
+    setActiveSection('gigs')
+    setGigMode('edit')
+    setGigForm({
+      clientId: savedGig.clientId,
+      title: savedGig.title,
+      date: savedGig.date,
+      venue: savedGig.venue,
+      fee: String(savedGig.fee),
+      notes: savedGig.notes ?? '',
+      wasDriving: savedGig.wasDriving,
+      status: savedGig.status,
+      expenses: savedGig.expenses
+        .slice()
+        .sort((left, right) => left.sortOrder - right.sortOrder)
+        .map(toGigExpenseForm),
+    })
+    setGigExpenseAmount('')
+    setGigExpenseDescription('')
+    setIsGigEditorOpen(true)
+  }
+
+  const promptForReceiptGig = (
+    file: File,
+    candidates: QuickReceiptCandidate[],
+    message: string
+  ) => {
+    setPendingReceiptFile(file)
+    setQuickReceiptDraft(null)
+    setQuickReceiptCandidates(candidates)
+    setQuickReceiptSelectedGigId(candidates[0]?.id ?? '')
+    setQuickReceiptAmount('')
+    setQuickReceiptDescription('Receipt draft')
+    setQuickReceiptStatus(message)
+  }
+
+  const clearQuickReceiptDialog = () => {
+    setPendingReceiptFile(null)
+    setQuickReceiptDraft(null)
+    setQuickReceiptCandidates([])
+    setQuickReceiptSelectedGigId('')
+    setQuickReceiptAmount('')
+    setQuickReceiptDescription('')
+    setQuickReceiptStatus('')
+  }
+
+  const uploadQuickReceiptDraft = async (file: File, gigId?: string) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    if (gigId) {
+      formData.append('gigId', gigId)
+    }
+
+    setIsQuickReceiptSaving(true)
+    setQuickReceiptStatus('Saving receipt draft...')
+    setPendingReceiptFile(file)
+    setQuickReceiptDraft(null)
+    if (!gigId) {
+      setQuickReceiptCandidates([])
+      setQuickReceiptSelectedGigId('')
+      setQuickReceiptAmount('')
+      setQuickReceiptDescription('')
+    }
+
+    try {
+      const response = await fetchWithSession(buildApiUrl('/gigs/receipt-drafts'), {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (response.status === 401) {
+        setIsAuthenticated(false)
+        setAuthUser(null)
+        setIsApiConnected(false)
+        setStatus('Your session expired. Sign in again to add receipts.')
+        return
+      }
+
+      if (response.status === 409) {
+        const conflict = (await response.json()) as {
+          message?: string
+          candidates?: QuickReceiptCandidate[]
+        }
+        promptForReceiptGig(
+          file,
+          conflict.candidates ?? [],
+          conflict.message ?? 'Choose a gig before saving this receipt draft.'
+        )
+        return
+      }
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const validationMessages = problem?.errors
+          ? Object.values(problem.errors).flat().join(' ')
+          : problem?.detail ?? problem?.title
+
+        throw new Error(validationMessages || 'Unable to save receipt draft.')
+      }
+
+      const receiptDraft = (await response.json()) as QuickReceiptDraftResponse
+      openGigReceiptDraft(receiptDraft.gig)
+      setPendingReceiptFile(null)
+      setQuickReceiptDraft(receiptDraft)
+      setQuickReceiptCandidates(receiptDraft.candidates)
+      setQuickReceiptSelectedGigId(receiptDraft.gig.id)
+      setQuickReceiptAmount('')
+      setQuickReceiptDescription('Receipt draft')
+      setQuickReceiptStatus(
+        receiptDraft.hasNearbyCandidates
+          ? 'Receipt saved. There are other nearby gigs, so please check the selected gig.'
+          : 'Receipt saved. Add details now or come back later.'
+      )
+      setGigStatus(
+        receiptDraft.inferredGig
+          ? 'Receipt draft saved to the nearest matching gig.'
+          : 'Receipt draft saved. Add the amount and description when you are ready.'
+      )
+    } catch (error) {
+      setQuickReceiptStatus(
+        error instanceof Error ? error.message : 'Unable to save receipt draft.'
+      )
+    } finally {
+      setIsQuickReceiptSaving(false)
+    }
+  }
+
+  const handleQuickReceiptFile = (file: File) => {
+    void uploadQuickReceiptDraft(file)
+  }
+
+  const savePendingReceiptToSelectedGig = () => {
+    if (!pendingReceiptFile || !quickReceiptSelectedGigId) {
+      setQuickReceiptStatus('Choose a gig before saving this receipt draft.')
+      return
+    }
+
+    void uploadQuickReceiptDraft(pendingReceiptFile, quickReceiptSelectedGigId)
+  }
+
+  const saveQuickReceiptDetails = async () => {
+    if (!quickReceiptDraft || !quickReceiptSelectedGigId) {
+      setQuickReceiptStatus('Choose a gig before saving this receipt draft.')
+      return
+    }
+
+    const description = quickReceiptDescription.trim()
+    const amount = Number(quickReceiptAmount || '0')
+
+    if (!description) {
+      setQuickReceiptStatus('Add a description before saving receipt details.')
+      return
+    }
+
+    if (!Number.isFinite(amount) || amount < 0) {
+      setQuickReceiptStatus('Receipt amount must be a valid non-negative number.')
+      return
+    }
+
+    setIsQuickReceiptSaving(true)
+    setQuickReceiptStatus('Saving receipt details...')
+
+    try {
+      const response = await fetchWithSession(
+        buildApiUrl(`/gigs/receipt-drafts/${quickReceiptDraft.expenseId}`),
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            gigId: quickReceiptSelectedGigId,
+            description,
+            amount,
+          }),
+        }
+      )
+
+      if (response.status === 401) {
+        setIsAuthenticated(false)
+        setAuthUser(null)
+        setIsApiConnected(false)
+        setStatus('Your session expired. Sign in again to add receipts.')
+        return
+      }
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const validationMessages = problem?.errors
+          ? Object.values(problem.errors).flat().join(' ')
+          : problem?.detail ?? problem?.title
+
+        throw new Error(validationMessages || 'Unable to save receipt details.')
+      }
+
+      const update = (await response.json()) as QuickReceiptDraftUpdateResponse
+      mergeSavedGig(update.gig)
+      if (update.previousGig) {
+        mergeSavedGig(update.previousGig)
+      }
+
+      setQuickReceiptDraft((current) =>
+        current
+          ? {
+              ...current,
+              gig: update.gig,
+              expenseId: update.expenseId,
+              inferredGig: false,
+            }
+          : current
+      )
+      setSelectedGigId(update.gig.id)
+      setQuickReceiptSelectedGigId(update.gig.id)
+      setGigStatus('Receipt details saved.')
+      setQuickReceiptStatus(
+        update.moved
+          ? 'Receipt moved and details saved.'
+          : 'Receipt details saved.'
+      )
+    } catch (error) {
+      setQuickReceiptStatus(
+        error instanceof Error ? error.message : 'Unable to save receipt details.'
+      )
+    } finally {
+      setIsQuickReceiptSaving(false)
+    }
+  }
+
+  const goToQuickReceiptGig = () => {
+    const targetGig =
+      gigsById.get(quickReceiptSelectedGigId) ?? quickReceiptDraft?.gig ?? null
+    if (!targetGig) {
+      return
+    }
+
+    openGigReceiptDraft(targetGig)
+    clearQuickReceiptDialog()
+  }
+
+  const closeQuickReceiptPrompt = () => {
+    if (isQuickReceiptSaving) {
+      return
+    }
+
+    clearQuickReceiptDialog()
   }
 
   const signIn = () => {
@@ -2796,92 +3066,111 @@ function App({ appMetadata }: AppProps) {
                 </p>
               </div>
 
-              <div className="profile-menu" ref={profileMenuRef}>
-                <button
-                  aria-expanded={isProfileMenuOpen}
-                  aria-haspopup="menu"
-                  aria-label="Open profile menu"
-                  className={`profile-trigger ${isProfileMenuOpen ? 'open' : ''}`}
-                  onClick={() => setIsProfileMenuOpen((current) => !current)}
-                  type="button"
-                >
-                  <span className="profile-avatar" aria-hidden="true">
-                    {profileImageUrl ? (
-                      <img
-                        className="profile-avatar-image"
-                        src={profileImageUrl}
-                        alt=""
-                        decoding="async"
-                        referrerPolicy="no-referrer"
-                      />
-                    ) : (
-                      profileInitials || 'U'
-                    )}
-                  </span>
-                </button>
+              <div className="header-actions">
+                <label className="primary-button quick-receipt-button">
+                  <span aria-hidden="true">+</span>
+                  Scan receipt
+                  <input
+                    type="file"
+                    accept="application/pdf,image/jpeg,image/png,image/webp,image/heic,image/heif"
+                    disabled={isLoading || isGigLoading || isQuickReceiptSaving}
+                    onChange={(event) => {
+                      const file = event.target.files?.[0]
+                      event.target.value = ''
+                      if (file) {
+                        handleQuickReceiptFile(file)
+                      }
+                    }}
+                  />
+                </label>
 
-                {isProfileMenuOpen && (
-                  <div className="profile-dropdown" role="menu" aria-label="Profile menu">
-                    <div className="profile-summary">
-                      <p className="section-label">Signed in</p>
-                      <strong>{profileDisplayName}</strong>
-                      <span>{authUser?.email}</span>
-                    </div>
-                    <div className="profile-meta">
-                      <span>{isAdmin ? 'Administrator' : 'Standard access'}</span>
-                    </div>
-                    <div className="profile-meta">
-                      <span>
-                        {sellerProfile.isInvoiceReady
-                          ? 'Seller profile ready'
-                          : sellerProfile.isConfigured
-                            ? 'Seller profile needs attention'
-                            : 'Seller profile not set up'}
-                      </span>
-                    </div>
-                    <label className="theme-field" htmlFor="theme-preference-select">
-                      <span>Theme</span>
-                      <select
-                        id="theme-preference-select"
-                        value={themePreference}
-                        onChange={(event) =>
-                          handleThemePreferenceChange(event.target.value as ThemePreference)
-                        }
+                <div className="profile-menu" ref={profileMenuRef}>
+                  <button
+                    aria-expanded={isProfileMenuOpen}
+                    aria-haspopup="menu"
+                    aria-label="Open profile menu"
+                    className={`profile-trigger ${isProfileMenuOpen ? 'open' : ''}`}
+                    onClick={() => setIsProfileMenuOpen((current) => !current)}
+                    type="button"
+                  >
+                    <span className="profile-avatar" aria-hidden="true">
+                      {profileImageUrl ? (
+                        <img
+                          className="profile-avatar-image"
+                          src={profileImageUrl}
+                          alt=""
+                          decoding="async"
+                          referrerPolicy="no-referrer"
+                        />
+                      ) : (
+                        profileInitials || 'U'
+                      )}
+                    </span>
+                  </button>
+
+                  {isProfileMenuOpen && (
+                    <div className="profile-dropdown" role="menu" aria-label="Profile menu">
+                      <div className="profile-summary">
+                        <p className="section-label">Signed in</p>
+                        <strong>{profileDisplayName}</strong>
+                        <span>{authUser?.email}</span>
+                      </div>
+                      <div className="profile-meta">
+                        <span>{isAdmin ? 'Administrator' : 'Standard access'}</span>
+                      </div>
+                      <div className="profile-meta">
+                        <span>
+                          {sellerProfile.isInvoiceReady
+                            ? 'Seller profile ready'
+                            : sellerProfile.isConfigured
+                              ? 'Seller profile needs attention'
+                              : 'Seller profile not set up'}
+                        </span>
+                      </div>
+                      <label className="theme-field" htmlFor="theme-preference-select">
+                        <span>Theme</span>
+                        <select
+                          id="theme-preference-select"
+                          value={themePreference}
+                          onChange={(event) =>
+                            handleThemePreferenceChange(event.target.value as ThemePreference)
+                          }
+                        >
+                          <option value="system">System</option>
+                          <option value="light">Light</option>
+                          <option value="dark">Dark</option>
+                        </select>
+                      </label>
+                      <button
+                        className="ghost-button profile-settings"
+                        onClick={openSellerProfile}
+                        role="menuitem"
+                        type="button"
+                        disabled={isLoading || isAdminLoading || isSellerProfileSaving}
                       >
-                        <option value="system">System</option>
-                        <option value="light">Light</option>
-                        <option value="dark">Dark</option>
-                      </select>
-                    </label>
-                    <button
-                      className="ghost-button profile-settings"
-                      onClick={openSellerProfile}
-                      role="menuitem"
-                      type="button"
-                      disabled={isLoading || isAdminLoading || isSellerProfileSaving}
-                    >
-                      Seller profile
-                    </button>
-                    <button
-                      className="ghost-button profile-settings"
-                      onClick={openUserSettings}
-                      role="menuitem"
-                      type="button"
-                      disabled={isLoading || isAdminLoading || isUserSettingsSaving}
-                    >
-                      Settings
-                    </button>
-                    <button
-                      className="ghost-button profile-signout"
-                      onClick={signOut}
-                      role="menuitem"
-                      type="button"
-                      disabled={isLoading || isAdminLoading}
-                    >
-                      Sign out
-                    </button>
-                  </div>
-                )}
+                        Seller profile
+                      </button>
+                      <button
+                        className="ghost-button profile-settings"
+                        onClick={openUserSettings}
+                        role="menuitem"
+                        type="button"
+                        disabled={isLoading || isAdminLoading || isUserSettingsSaving}
+                      >
+                        Settings
+                      </button>
+                      <button
+                        className="ghost-button profile-signout"
+                        onClick={signOut}
+                        role="menuitem"
+                        type="button"
+                        disabled={isLoading || isAdminLoading}
+                      >
+                        Sign out
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
 
@@ -2975,6 +3264,145 @@ function App({ appMetadata }: AppProps) {
         profile={sellerProfile}
         status={sellerProfileStatus}
       />
+
+      {(pendingReceiptFile || quickReceiptDraft) && (
+        <div className="settings-overlay" role="presentation">
+          <section
+            aria-labelledby="quick-receipt-title"
+            className="settings-modal quick-receipt-modal panel"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="panel-heading">
+              <div>
+                <p className="section-label">Receipt capture</p>
+                <h2 id="quick-receipt-title">
+                  {quickReceiptDraft ? 'Receipt saved' : 'Choose a gig'}
+                </h2>
+              </div>
+              <button
+                className="ghost-button"
+                onClick={closeQuickReceiptPrompt}
+                type="button"
+                disabled={isQuickReceiptSaving}
+              >
+                Close
+              </button>
+            </div>
+
+            <div className="quick-receipt-summary">
+              <strong>
+                {pendingReceiptFile?.name ||
+                  quickReceiptDraft?.gig.expenses
+                    .find((expense) => expense.id === quickReceiptDraft.expenseId)
+                    ?.attachments.find(
+                      (attachment) => attachment.id === quickReceiptDraft.attachmentId
+                    )?.fileName ||
+                  'Receipt upload'}
+              </strong>
+              <span>{quickReceiptStatus}</span>
+              {isQuickReceiptSaving && !quickReceiptDraft ? (
+                <div className="quick-receipt-progress" aria-label="Receipt upload in progress">
+                  <span />
+                </div>
+              ) : null}
+            </div>
+
+            {quickReceiptDraft?.hasNearbyCandidates ? (
+              <div className="quick-receipt-warning">
+                <strong>Check the gig before moving on.</strong>
+                <span>
+                  There are other gigs close to this date. The nearest one has been
+                  selected, but this receipt may belong somewhere else.
+                </span>
+              </div>
+            ) : null}
+
+            {quickReceiptCandidates.length > 0 ? (
+              <label className="quick-receipt-select">
+                <span>Gig</span>
+                <select
+                  value={quickReceiptSelectedGigId}
+                  onChange={(event) => setQuickReceiptSelectedGigId(event.target.value)}
+                  disabled={isQuickReceiptSaving}
+                >
+                  {quickReceiptCandidates.map((gig) => (
+                    <option key={gig.id} value={gig.id}>
+                      {gig.title} · {formatDate(gig.date)} · {gig.venue} ·{' '}
+                      {clientNamesById.get(gig.clientId) ?? 'Unknown client'} ·{' '}
+                      {gig.daysFromToday === 0
+                        ? 'today'
+                        : `${gig.daysFromToday} day${gig.daysFromToday === 1 ? '' : 's'} away`}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : isQuickReceiptSaving && !quickReceiptDraft ? null : (
+              <div className="empty-state">
+                <strong>No candidate gigs are available.</strong>
+                <p>Create or update a gig near this receipt date, then try again.</p>
+              </div>
+            )}
+
+            {quickReceiptDraft ? (
+              <div className="form-grid quick-receipt-details">
+                <label>
+                  <span>Amount</span>
+                  <input
+                    inputMode="decimal"
+                    value={quickReceiptAmount}
+                    onChange={(event) => setQuickReceiptAmount(event.target.value)}
+                    placeholder="0.00"
+                    disabled={isQuickReceiptSaving}
+                  />
+                </label>
+                <label>
+                  <span>Description</span>
+                  <input
+                    value={quickReceiptDescription}
+                    onChange={(event) => setQuickReceiptDescription(event.target.value)}
+                    placeholder="Taxi, parking, hotel..."
+                    disabled={isQuickReceiptSaving}
+                  />
+                </label>
+              </div>
+            ) : null}
+
+            <div className="form-actions">
+              {quickReceiptDraft ? (
+                <>
+                  <button
+                    className="primary-button"
+                    onClick={saveQuickReceiptDetails}
+                    type="button"
+                    disabled={isQuickReceiptSaving || !quickReceiptSelectedGigId}
+                  >
+                    {isQuickReceiptSaving ? 'Saving...' : 'Save details'}
+                  </button>
+                  <button
+                    className="ghost-button"
+                    onClick={goToQuickReceiptGig}
+                    type="button"
+                    disabled={isQuickReceiptSaving || !quickReceiptSelectedGigId}
+                  >
+                    Go to gig
+                  </button>
+                </>
+              ) : (
+                <button
+                  className="primary-button"
+                  onClick={savePendingReceiptToSelectedGig}
+                  type="button"
+                  disabled={isQuickReceiptSaving || !quickReceiptSelectedGigId}
+                >
+                  {isQuickReceiptSaving ? 'Saving...' : 'Save receipt draft'}
+                </button>
+              )}
+              <span className="status-pill">{quickReceiptStatus}</span>
+            </div>
+          </section>
+        </div>
+      )}
 
       <ClientSettingsModal
         authUser={authUser}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1876,8 +1876,17 @@ function App({ appMetadata }: AppProps) {
     }
   }
 
+  const shouldCloseAfterSave = (event: FormEvent<HTMLFormElement>) => {
+    const submitter = (event.nativeEvent as SubmitEvent).submitter as
+      | HTMLButtonElement
+      | null
+
+    return submitter?.dataset.closeAfterSave !== 'false'
+  }
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    const closeAfterSave = shouldCloseAfterSave(event)
 
     const payload: ClientForm = {
       name: form.name.trim(),
@@ -1968,7 +1977,7 @@ function App({ appMetadata }: AppProps) {
       setSelectedClientId(savedClient.id)
       setMode('edit')
       setStatus(isEdit ? 'Client updated.' : 'Client created.')
-      setIsClientEditorOpen(false)
+      setIsClientEditorOpen(!closeAfterSave)
     } catch {
       setStatus('Unable to save right now. Please try again.')
     } finally {
@@ -2103,6 +2112,7 @@ function App({ appMetadata }: AppProps) {
 
   const handleGigSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    const closeAfterSave = shouldCloseAfterSave(event)
 
     const payload = {
       clientId: gigForm.clientId,
@@ -2225,7 +2235,7 @@ function App({ appMetadata }: AppProps) {
       setGigExpenseAmount('')
       setGigExpenseDescription('')
       setGigStatus(isEdit ? 'Gig updated.' : 'Gig created.')
-      setIsGigEditorOpen(false)
+      setIsGigEditorOpen(!closeAfterSave)
     } catch (error) {
       setGigStatus(
         error instanceof Error ? error.message : 'Unable to save this gig right now.'

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -401,11 +401,24 @@ export function ClientsSection({
             </div>
 
             <div className="form-actions">
-              <button className="primary-button" type="submit" disabled={isLoading}>
-                {mode === 'create' ? 'Save client' : 'Update client'}
+              <button
+                className="primary-button"
+                data-close-after-save="true"
+                type="submit"
+                disabled={isLoading}
+              >
+                Save and close
+              </button>
+              <button
+                className="ghost-button"
+                data-close-after-save="false"
+                type="submit"
+                disabled={isLoading}
+              >
+                Save
               </button>
               <button className="ghost-button" onClick={onCloseEditor} type="button">
-                Done
+                Discard changes
               </button>
             </div>
           </form>
@@ -1212,13 +1225,22 @@ export function GigsSection({
             <div className="form-actions">
               <button
                 className="primary-button"
+                data-close-after-save="true"
                 type="submit"
                 disabled={isGigLoading || clients.length === 0}
               >
-                {gigMode === 'create' ? 'Save gig' : 'Update gig'}
+                Save and close
+              </button>
+              <button
+                className="ghost-button"
+                data-close-after-save="false"
+                type="submit"
+                disabled={isGigLoading || clients.length === 0}
+              >
+                Save
               </button>
               <button className="ghost-button" onClick={onCloseEditor} type="button">
-                Done
+                Discard changes
               </button>
             </div>
 

--- a/frontend/glovelly-web/src/appShared.ts
+++ b/frontend/glovelly-web/src/appShared.ts
@@ -159,6 +159,31 @@ export type Gig = {
   expenses: GigExpense[]
 }
 
+export type QuickReceiptCandidate = Pick<
+  Gig,
+  'id' | 'clientId' | 'title' | 'date' | 'venue' | 'status'
+> & {
+  daysFromToday: number
+  isSelected: boolean
+}
+
+export type QuickReceiptDraftResponse = {
+  gig: Gig
+  expenseId: string
+  attachmentId: string
+  inferredGig: boolean
+  candidates: QuickReceiptCandidate[]
+  autoAttachWindowDays: number
+  hasNearbyCandidates: boolean
+}
+
+export type QuickReceiptDraftUpdateResponse = {
+  gig: Gig
+  previousGig: Gig | null
+  expenseId: string
+  moved: boolean
+}
+
 export type InvoiceLine = {
   id: string
   createdByUserId: string | null


### PR DESCRIPTION
## Summary

- add a prominent `Scan receipt` action in the authenticated app header
- create a quick receipt draft flow that uploads/captures a file and saves it against an inferred or explicitly selected gig
- infer receipt gigs from the nearest configurable candidate set within the auto-attach window instead of same-day-only matching
- use a separate configurable ambiguity window so warnings appear only when another candidate is genuinely close
- show the receipt modal immediately while upload is in progress, then update it into the saved/editable state
- show a compact post-capture review modal with candidate-only gig dropdown, nearby-gig warning, amount, description, and a `Go to gig` action
- add `POST /gigs/receipt-drafts` to create a zero-amount `Receipt draft` expense with the receipt attachment
- add `PATCH /gigs/receipt-drafts/{expenseId}` so users can save amount/description or move the draft to another gig
- read `ExpenseAttachments__BucketName` from each GitHub Environment's `GCP_BUCKET_NAME` variable during Cloud Run deploys
- cover nearest-gig inference, out-of-window prompts, ambiguity-window warnings, explicit gig selection, and receipt draft updates in API tests

## Impact

Logged-in users can capture a receipt from the main UI without navigating into a gig first. The app now considers the nearest configured set of gigs within the configured auto-attach window and auto-attaches when a candidate exists, which covers late-night travel, weekend work, and nearby gig dates. If no gig is close enough, the user is told no candidate gig is available.

After a receipt is selected, users immediately see upload progress in the modal. Once saved, the same modal lets them verify the selected gig from a compact dropdown of candidates, notice genuinely close alternatives, add the amount and description, or jump straight to the gig.

The deployment workflow binds PR deployments to the `staging` environment and main-branch deployments to the `production` environment so the receipt attachment bucket follows the GitHub Environment configuration.

## Validation

- `dotnet test`
- `dotnet test --filter QuickReceiptDraft`
- `npm run build`
- `npm run lint`
- `git diff --check`