### PR TITLE
[codex] Add MCP read-only surface with OAuth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,10 @@ jobs:
             Email__AccessRequests__FromDisplayName=Glovelly
             Email__Invoices__FromDisplayName=Glovelly
             ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
+            Mcp__OAuth__Issuer=${{ vars.DEPLOYMENT_URL }}
+            Mcp__OAuth__Resource=${{ vars.DEPLOYMENT_URL }}/mcp
+            Mcp__OAuth__Clients__0__DisplayName=ChatGPT
+            Mcp__OAuth__Clients__0__Scopes__0=mcp:read
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest
@@ -139,6 +143,9 @@ jobs:
             Email__Resend__ApiKey=glovelly-resend-api-key:latest
             Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest
             Email__Invoices__FromAddress=glovelly-invoices-from-address:latest
+            Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest
+            Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest
+            Mcp__OAuth__Clients__0__RedirectUris__0=${{ vars.GCP_CHATGPT_REDIRECT_SECRET_ID }}:latest
           secrets_update_strategy: merge
           flags: >-
             --allow-unauthenticated

--- a/.glovelly.dev.local.example
+++ b/.glovelly.dev.local.example
@@ -7,5 +7,13 @@ export Email__AccessRequests__FromDisplayName="Glovelly Access"
 export Email__Invoices__FromAddress="invoices@example.com"
 export Email__Invoices__FromDisplayName="Glovelly Invoices"
 export Mcp__DevelopmentAuth__AllowAnonymous="false"
+# Optional: configure an OAuth client for staging/local MCP OAuth testing.
+# export Mcp__OAuth__Issuer="https://your-public-glovelly-host.example"
+# export Mcp__OAuth__Resource="https://your-public-glovelly-host.example/mcp"
+# export Mcp__OAuth__Clients__0__ClientId="chatgpt"
+# export Mcp__OAuth__Clients__0__ClientSecret="replace-with-a-secret"
+# export Mcp__OAuth__Clients__0__DisplayName="ChatGPT"
+# export Mcp__OAuth__Clients__0__RedirectUris__0="replace-with-chatgpt-provided-redirect-uri"
+# export Mcp__OAuth__Clients__0__Scopes__0="mcp:read"
 # Optional: comma-separated public dev hosts for Vite, such as a stable ngrok domain.
 # export VITE_ALLOWED_HOSTS="example.ngrok-free.dev"

--- a/.glovelly.dev.local.example
+++ b/.glovelly.dev.local.example
@@ -6,3 +6,6 @@ export Email__AccessRequests__FromAddress="access@example.com"
 export Email__AccessRequests__FromDisplayName="Glovelly Access"
 export Email__Invoices__FromAddress="invoices@example.com"
 export Email__Invoices__FromDisplayName="Glovelly Invoices"
+export Mcp__DevelopmentAuth__AllowAnonymous="false"
+# Optional: comma-separated public dev hosts for Vite, such as a stable ngrok domain.
+# export VITE_ALLOWED_HOSTS="example.ngrok-free.dev"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# Glovelly Agent Guide
+
+This file is the first stop for coding agents. Keep it compact and update it when repo shape or core workflows change.
+
+## Purpose
+
+Glovelly is a personal business platform for self-employed music work. The current product covers authenticated access, clients, gigs, gig expenses and receipt attachments, invoice generation, invoice issue/reissue/delivery, seller profile setup, Google Drive invoice publishing, email delivery, admin user management, and a small MCP read-only business data surface.
+
+## Stack
+
+- Backend: ASP.NET Core minimal API, .NET 10, Entity Framework Core, PostgreSQL in production, in-memory database for local development and tests when no connection string is configured.
+- Frontend: React 19, TypeScript, Vite.
+- Tests: xUnit integration-style API tests using `WebApplicationFactory` and EF in-memory.
+- Deployment: one Docker image containing the Vite build copied into ASP.NET Core `wwwroot`, deployed by GitHub Actions to Cloud Run.
+
+## Fast Commands
+
+Run from the repo root unless noted.
+
+```bash
+dotnet test glovelly.sln -m:1
+npm --prefix frontend/glovelly-web run lint
+npm --prefix frontend/glovelly-web run build
+./verify.sh
+./run-dev.sh
+```
+
+Use `./verify.sh` before handing over broad code changes. For backend-only changes, `dotnet test glovelly.sln -m:1` is usually the best first check.
+
+## Repo Map
+
+- `backend/Glovelly.Api/Program.cs`: service setup, HTTP pipeline, endpoint registration.
+- `backend/Glovelly.Api/Configuration/`: startup, auth, infrastructure, database initialization, Swagger/static file pipeline.
+- `backend/Glovelly.Api/Auth/`: current user access, app policies, Google OIDC claim handling, development MCP auth handler.
+- `backend/Glovelly.Api/Data/`: EF `AppDbContext` and development seeding.
+- `backend/Glovelly.Api/Models/`: EF/domain models used directly by minimal APIs.
+- `backend/Glovelly.Api/Endpoints/`: minimal API route groups and request validation helpers.
+- `backend/Glovelly.Api/Services/`: workflow services, delivery channels, email, Google Drive, storage, MCP query service.
+- `backend/Glovelly.Api.Tests/`: API tests. `Infrastructure/GlovellyApiFactory.cs` configures test auth, seeded data, fake email, and in-memory storage.
+- `frontend/glovelly-web/src/App.tsx`: top-level app orchestration, session state, data loading, cross-workspace coordination.
+- `frontend/glovelly-web/src/hooks/`: stateful workspace logic for clients, gigs, invoices, admin, user settings, seller profile, quick receipts.
+- `frontend/glovelly-web/src/components/`: presentational sections and modals.
+- `frontend/glovelly-web/src/api.ts`: fetch helpers, session expiry, problem details parsing.
+- `frontend/glovelly-web/src/types.ts`: frontend API/domain types.
+- `docs/`: domain, roadmap, and agent-oriented architecture/convention/testing notes.
+
+## Backend Conventions
+
+- Endpoints are grouped in extension methods. `Program.cs` maps auth/access/MCP/admin and CRUD groups.
+- CRUD groups are registered via `MapCrudEndpoints`, then delegated to files such as `GigEndpoints.cs` and `InvoiceEndpoints.cs`.
+- Use `EndpointSupport` for shared visibility filters, validation helpers, stamping helpers, invoice status transition rules, and gig expense normalization.
+- Most user-owned data must be filtered with `WhereVisibleTo(userId)` or equivalent owner checks.
+- Prefer workflow services for multi-step business behavior. Invoice creation, line generation, PDF generation, issue/reissue behavior, and delivery coordination live in `InvoiceWorkflowService` and related delivery services.
+- Keep request validation close to endpoint behavior unless a reusable validation helper already exists in `EndpointSupport`.
+- When adding endpoints, add focused tests in the matching `*EndpointsTests.cs` file or create a new test file for a new route group.
+
+## Frontend Conventions
+
+- Keep data/workflow state in hooks under `src/hooks`. Components should mostly render state and call hook-provided handlers.
+- Use `fetchWithSession`, `buildApiUrl`, `parseProblemDetails`, and session-expiry helpers from `src/api.ts` for API calls.
+- Update `src/types.ts` when backend response shapes change.
+- `App.tsx` coordinates workspaces and cross-cutting state. Avoid adding large new workflow bodies there when a hook can own the behavior.
+- Preserve the existing plain React/CSS style. There is no component library.
+
+## Testing Notes
+
+- Backend tests use fake authorization by default. `GlovellyApiFactory.WithConfiguration(...)` enables real auth/development-style configuration for auth-specific tests.
+- Seeded test IDs live in `backend/Glovelly.Api.Tests/Infrastructure/TestData.cs`; seeded auth context lives in `TestAuthContext.cs`.
+- Fake email assertions should use `GlovellyApiFactory.Emails`.
+- Frontend has lint/build scripts but no dedicated frontend test runner yet.
+
+## High-Token Files
+
+Read these selectively and search within them before opening large chunks:
+
+- `frontend/glovelly-web/src/App.tsx`
+- `backend/Glovelly.Api/Services/InvoiceWorkflowService.cs`
+- `backend/Glovelly.Api/Endpoints/GigEndpoints.cs`
+- `backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs`
+- `frontend/glovelly-web/src/hooks/useGigsWorkspace.ts`
+- `frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts`
+
+## Useful Search Patterns
+
+```bash
+rg "Map.*Endpoints" backend/Glovelly.Api/Endpoints
+rg "WhereVisibleTo|StampCreate|Validate" backend/Glovelly.Api/Endpoints
+rg "fetchWithSession|parseProblemDetails" frontend/glovelly-web/src
+rg "InvoiceWorkflowService|IInvoiceWorkflowService" backend/Glovelly.Api
+rg "TestData\\.|TestAuthContext" backend/Glovelly.Api.Tests
+```
+
+## Avoid
+
+- Do not commit secrets or edit `.glovelly.dev.local`.
+- Do not bypass owner visibility checks for user data.
+- Do not add frontend API calls using raw `fetch` unless there is a specific reason.
+- Do not run destructive git commands unless the user explicitly asks.
+- Do not refactor large files just to tidy them while solving a narrow task.

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Authorization.Policy;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Configuration;
 
 namespace Glovelly.Api.Tests.Infrastructure;
 
@@ -17,21 +17,48 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
     private readonly string _databaseName = $"glovelly-tests-{Guid.NewGuid()}";
     private readonly object _databaseResetLock = new();
     private readonly FakeEmailSender _fakeEmailSender = new();
+    private readonly Dictionary<string, string?> _configuration = new();
+    private bool _useRealAuthentication;
+    private string _environmentName = "Testing";
 
     internal FakeEmailSender Emails => _fakeEmailSender;
 
+    public GlovellyApiFactory WithConfiguration(Dictionary<string, string?> configuration)
+    {
+        var factory = new GlovellyApiFactory();
+        foreach (var pair in configuration)
+        {
+            factory._configuration[pair.Key] = pair.Value;
+        }
+        factory._useRealAuthentication = true;
+        factory._environmentName = "Development";
+
+        return factory;
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        builder.UseEnvironment("Testing");
+        builder.UseEnvironment(_environmentName);
+        builder.ConfigureAppConfiguration(configurationBuilder =>
+        {
+            if (_configuration.Count > 0)
+            {
+                configurationBuilder.AddInMemoryCollection(_configuration);
+            }
+        });
 
         builder.ConfigureTestServices(services =>
         {
             services.RemoveAll<DbContextOptions<AppDbContext>>();
-            services.RemoveAll<IPolicyEvaluator>();
             services.RemoveAll<IEmailSender>();
             services.RemoveAll<IExpenseAttachmentStore>();
 
-            services.AddSingleton<IPolicyEvaluator, TestPolicyEvaluator>();
+            if (!_useRealAuthentication)
+            {
+                services.RemoveAll<IPolicyEvaluator>();
+                services.AddSingleton<IPolicyEvaluator, TestPolicyEvaluator>();
+            }
+
             services.AddSingleton<IEmailSender>(_fakeEmailSender);
             services.AddSingleton<IExpenseAttachmentStore, InMemoryExpenseAttachmentStore>();
             services.PostConfigure<EmailSettings>(settings =>
@@ -79,6 +106,7 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
         dbContext.Users.Add(new User
         {
             Id = TestAuthContext.UserId,
+            GoogleSubject = TestAuthContext.DefaultSubject,
             Email = "test-admin@glovelly.local",
             DisplayName = "Test Admin",
             MileageRate = 0.45m,

--- a/backend/Glovelly.Api.Tests/McpEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/McpEndpointsTests.cs
@@ -1,0 +1,464 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Models;
+using Glovelly.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class McpEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _client;
+
+    public McpEndpointsTests(GlovellyApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task OptionsMcp_ReturnsChatGptCompatibleCorsHeaders()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Options, "/mcp");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Equal("*", response.Headers.GetValues("Access-Control-Allow-Origin").Single());
+        Assert.Contains("POST", response.Headers.GetValues("Access-Control-Allow-Methods").Single());
+        Assert.Contains("authorization", response.Headers.GetValues("Access-Control-Allow-Headers").Single());
+        Assert.Contains("mcp-session-id", response.Headers.GetValues("Access-Control-Allow-Headers").Single());
+        Assert.Contains("Mcp-Session-Id", response.Headers.GetValues("Access-Control-Expose-Headers").Single());
+    }
+
+    [Fact]
+    public async Task GetMcp_WhenServerDoesNotOfferSseStream_ReturnsMethodNotAllowed()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Contains("Mcp-Session-Id", response.Headers.GetValues("Access-Control-Expose-Headers").Single());
+    }
+
+    [Fact]
+    public async Task InitializedNotification_ReturnsAcceptedWithoutBody()
+    {
+        var response = await PostMcpAsync(new
+        {
+            jsonrpc = "2.0",
+            method = "notifications/initialized",
+        });
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(0, response.Content.Headers.ContentLength ?? 0);
+    }
+
+    [Fact]
+    public async Task Initialize_NegotiatesCurrentProtocolVersion()
+    {
+        var response = await PostMcpAsync(new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion = "2025-06-18",
+                capabilities = new { },
+                clientInfo = new
+                {
+                    name = "test-client",
+                    version = "1.0.0",
+                },
+            },
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("2025-06-18", response.Headers.GetValues("MCP-Protocol-Version").Single());
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("2025-06-18", payload.GetProperty("result").GetProperty("protocolVersion").GetString());
+        Assert.Equal("glovelly", payload.GetProperty("result").GetProperty("serverInfo").GetProperty("name").GetString());
+        Assert.True(payload.GetProperty("result").GetProperty("capabilities").TryGetProperty("tools", out _));
+    }
+
+    [Fact]
+    public async Task PostMcp_WithAnonymousDevelopmentAuthDisabled_ReturnsUnauthorized()
+    {
+        using var factory = CreateMcpDevelopmentFactory();
+        using var client = factory.CreateClient();
+        using var request = CreateMcpRequest(ListInvoicesPayload());
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostMcp_WithAnonymousDevelopmentAuth_AuthenticatesConfiguredUser()
+    {
+        using var factory = CreateMcpDevelopmentFactory(allowAnonymous: true);
+        using var client = factory.CreateClient();
+        using var request = CreateMcpRequest(ListInvoicesPayload());
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var result = payload
+            .GetProperty("result")
+            .GetProperty("structuredContent");
+
+        Assert.NotEmpty(result.GetProperty("invoices").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task PostMcp_WithAnonymousDevelopmentAuthMissingUserId_ReturnsUnauthorized()
+    {
+        using var factory = new GlovellyApiFactory().WithConfiguration(new Dictionary<string, string?>
+        {
+            ["Mcp:DevelopmentAuth:AllowAnonymous"] = "true",
+        });
+        using var client = factory.CreateClient();
+        using var request = CreateMcpRequest(ListInvoicesPayload());
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostMcp_WithUnsupportedProtocolHeader_ReturnsBadRequest()
+    {
+        using var request = CreateMcpRequest(new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "ping",
+        });
+        request.Headers.Remove("MCP-Protocol-Version");
+        request.Headers.Add("MCP-Protocol-Version", "1900-01-01");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ToolsList_ReturnsExperimentalGlovellyTools()
+    {
+        var response = await PostMcpAsync(new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "tools/list",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var toolNames = payload
+            .GetProperty("result")
+            .GetProperty("tools")
+            .EnumerateArray()
+            .Select(tool => tool.GetProperty("name").GetString())
+            .ToArray();
+
+        Assert.Contains("glovelly_search_contacts", toolNames);
+        Assert.Contains("glovelly_list_invoices", toolNames);
+        Assert.Contains("glovelly_get_invoice", toolNames);
+        Assert.Contains("glovelly_list_receipts", toolNames);
+        Assert.Contains("glovelly_get_business_summary", toolNames);
+    }
+
+    [Fact]
+    public async Task ListInvoices_CanReturnOutstandingInvoicesForDateRange()
+    {
+        await CreateInvoiceLineAsync(TestData.FoxInvoiceId, 450m);
+
+        var result = await CallToolAsync("glovelly_list_invoices", new
+        {
+            status = "outstanding",
+            fromDate = "2026-04-01",
+            toDate = "2026-04-30",
+            dateBasis = "issueDate",
+        });
+
+        Assert.False(result.GetProperty("ambiguous").GetBoolean());
+        Assert.Equal(450m, result.GetProperty("totalOutstanding").GetDecimal());
+
+        var invoice = Assert.Single(result.GetProperty("invoices").EnumerateArray());
+        Assert.Equal(TestData.FoxInvoiceId, invoice.GetProperty("invoiceId").GetGuid());
+        Assert.Equal("Fox & Finch Events", invoice.GetProperty("contactName").GetString());
+        Assert.Equal("issued", invoice.GetProperty("status").GetString());
+        Assert.Equal(450m, invoice.GetProperty("outstandingAmount").GetDecimal());
+    }
+
+    [Fact]
+    public async Task ListInvoices_CanFilterByResolvedContactQuery()
+    {
+        await CreateInvoiceLineAsync(TestData.FoxInvoiceId, 200m);
+        await CreateInvoiceLineAsync(TestData.RiversideInvoiceId, 300m);
+
+        var issueResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/status", new
+        {
+            status = "Issued",
+        });
+        issueResponse.EnsureSuccessStatusCode();
+
+        var result = await CallToolAsync("glovelly_list_invoices", new
+        {
+            contactQuery = "Riverside",
+            status = "outstanding",
+        });
+
+        var invoice = Assert.Single(result.GetProperty("invoices").EnumerateArray());
+        Assert.Equal(TestData.RiversideInvoiceId, invoice.GetProperty("invoiceId").GetGuid());
+        Assert.Equal("Riverside Arts Centre", invoice.GetProperty("contactName").GetString());
+    }
+
+    [Fact]
+    public async Task ListInvoices_WhenContactQueryIsAmbiguous_ReturnsMatchesWithoutGuessing()
+    {
+        var createClientResponse = await _client.PostAsJsonAsync("/clients", new
+        {
+            name = "Fox Theatre",
+            email = "accounts@foxtheatre.test",
+            billingAddress = new { },
+        });
+        createClientResponse.EnsureSuccessStatusCode();
+
+        var result = await CallToolAsync("glovelly_list_invoices", new
+        {
+            contactQuery = "Fox",
+            status = "outstanding",
+        });
+
+        Assert.True(result.GetProperty("ambiguous").GetBoolean());
+        Assert.Empty(result.GetProperty("invoices").EnumerateArray());
+        Assert.True(result.GetProperty("matches").GetArrayLength() >= 2);
+    }
+
+    [Fact]
+    public async Task ListInvoices_WhenContactQueryHasNoMatches_ReturnsEmptyList()
+    {
+        var result = await CallToolAsync("glovelly_list_invoices", new
+        {
+            contactQuery = "No such contact",
+            status = "outstanding",
+        });
+
+        Assert.False(result.GetProperty("ambiguous").GetBoolean());
+        Assert.Empty(result.GetProperty("invoices").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task GetInvoice_WhenInvoiceExists_ReturnsInvoiceDetail()
+    {
+        await CreateInvoiceLineAsync(TestData.FoxInvoiceId, 125m);
+
+        var result = await CallToolAsync("glovelly_get_invoice", new
+        {
+            invoiceId = TestData.FoxInvoiceId,
+        });
+
+        Assert.True(result.GetProperty("found").GetBoolean());
+
+        var invoice = result.GetProperty("invoice");
+        Assert.Equal(TestData.FoxInvoiceId, invoice.GetProperty("invoiceId").GetGuid());
+        Assert.Equal(125m, invoice.GetProperty("total").GetDecimal());
+        Assert.Single(invoice.GetProperty("lines").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task ListInvoices_WhenAuthenticatedAsAnotherUser_DoesNotExposeOtherUserInvoices()
+    {
+        await CreateInvoiceLineAsync(TestData.FoxInvoiceId, 125m);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+        {
+            Content = JsonContent.Create(new
+            {
+                jsonrpc = "2.0",
+                id = 1,
+                method = "tools/call",
+                @params = new
+                {
+                    name = "glovelly_list_invoices",
+                    arguments = new
+                    {
+                        status = "outstanding",
+                    },
+                },
+            }),
+        };
+        request.Headers.Add("X-Test-UserId", TestAuthContext.AlternateUserId.ToString());
+
+        var response = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var result = payload
+            .GetProperty("result")
+            .GetProperty("structuredContent");
+
+        Assert.Empty(result.GetProperty("invoices").EnumerateArray());
+        Assert.Equal(0m, result.GetProperty("totalOutstanding").GetDecimal());
+    }
+
+    [Fact]
+    public async Task ListReceipts_ReturnsReadOnlyReceiptExpenses()
+    {
+        await CreateGigAsync("Receipt gig", new[]
+        {
+            new { sortOrder = 1, description = "Receipt draft", amount = 0m },
+            new { sortOrder = 2, description = "Parking", amount = 12m },
+        });
+
+        var result = await CallToolAsync("glovelly_list_receipts", new
+        {
+            fromDate = "2026-04-01",
+            toDate = "2026-04-30",
+            status = "unmatched",
+        });
+
+        Assert.Equal(1, result.GetProperty("receiptCount").GetInt32());
+        Assert.Equal(1, result.GetProperty("unmatchedReceiptCount").GetInt32());
+
+        var receipt = Assert.Single(result.GetProperty("receipts").EnumerateArray());
+        Assert.Equal("Receipt draft", receipt.GetProperty("description").GetString());
+        Assert.Equal("unmatched", receipt.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task BusinessSummary_ReturnsPeriodTotals()
+    {
+        await CreateInvoiceLineAsync(TestData.FoxInvoiceId, 150m);
+        await CreateGigAsync("Summary gig", new[]
+        {
+            new { sortOrder = 1, description = "Train", amount = 24m },
+        });
+
+        var result = await CallToolAsync("glovelly_get_business_summary", new
+        {
+            fromDate = "2026-04-01",
+            toDate = "2026-04-30",
+        });
+
+        Assert.Equal(150m, result.GetProperty("invoiceTotal").GetDecimal());
+        Assert.Equal(150m, result.GetProperty("outstandingTotal").GetDecimal());
+        Assert.Equal(24m, result.GetProperty("expenseTotal").GetDecimal());
+        Assert.Equal(1, result.GetProperty("receiptCount").GetInt32());
+    }
+
+    private async Task<JsonElement> CallToolAsync(string name, object arguments)
+    {
+        var response = await PostMcpAsync(new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "tools/call",
+            @params = new
+            {
+                name,
+                arguments,
+            },
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        if (payload.TryGetProperty("error", out var error) && error.ValueKind != JsonValueKind.Null)
+        {
+            throw new InvalidOperationException(error.GetRawText());
+        }
+
+        return payload
+            .GetProperty("result")
+            .GetProperty("structuredContent");
+    }
+
+    private Task<HttpResponseMessage> PostMcpAsync(object payload)
+    {
+        return _client.SendAsync(CreateMcpRequest(payload));
+    }
+
+    private static HttpRequestMessage CreateMcpRequest(object payload)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        request.Headers.Add("MCP-Protocol-Version", "2025-06-18");
+
+        return request;
+    }
+
+    private static object ListInvoicesPayload()
+    {
+        return new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "tools/call",
+            @params = new
+            {
+                name = "glovelly_list_invoices",
+                arguments = new
+                {
+                    status = "outstanding",
+                },
+            },
+        };
+    }
+
+    private static GlovellyApiFactory CreateMcpDevelopmentFactory(bool allowAnonymous = false)
+    {
+        return new GlovellyApiFactory().WithConfiguration(new Dictionary<string, string?>
+        {
+            ["DevelopmentSeeding:AdminGoogleSubject"] = TestAuthContext.DefaultSubject,
+            ["Mcp:DevelopmentAuth:AllowAnonymous"] = allowAnonymous.ToString(),
+        });
+    }
+
+    private async Task CreateInvoiceLineAsync(Guid invoiceId, decimal amount)
+    {
+        var response = await _client.PostAsJsonAsync("/invoice-lines", new
+        {
+            invoiceId,
+            sortOrder = 1,
+            type = InvoiceLineType.PerformanceFee,
+            description = "Performance",
+            quantity = 1m,
+            unitPrice = amount,
+        });
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task CreateGigAsync(string title, object[] expenses)
+    {
+        var response = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title,
+            date = "2026-04-12",
+            venue = "Test venue",
+            fee = 100m,
+            travelMiles = 0m,
+            wasDriving = false,
+            status = GigStatus.Confirmed,
+            expenses,
+        });
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/backend/Glovelly.Api.Tests/McpEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/McpEndpointsTests.cs
@@ -1,9 +1,14 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
+using Glovelly.Api.Services;
 using Glovelly.Api.Models;
 using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -97,6 +102,101 @@ public sealed class McpEndpointsTests : IClassFixture<GlovellyApiFactory>
         var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains("resource_metadata=", response.Headers.WwwAuthenticate.ToString());
+    }
+
+    [Fact]
+    public async Task OAuthProtectedResourceMetadata_AdvertisesAuthorizationServer()
+    {
+        using var factory = CreateMcpOAuthFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/.well-known/oauth-protected-resource");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("https://glovelly.test/mcp", payload.GetProperty("resource").GetString());
+        Assert.Equal(
+            "https://glovelly.test",
+            payload.GetProperty("authorization_servers").EnumerateArray().Single().GetString());
+        Assert.Equal("mcp:read", payload.GetProperty("scopes_supported").EnumerateArray().Single().GetString());
+    }
+
+    [Fact]
+    public async Task OAuthAuthorizationServerMetadata_AdvertisesCodeFlowWithPkce()
+    {
+        using var factory = CreateMcpOAuthFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/.well-known/oauth-authorization-server");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("https://glovelly.test", payload.GetProperty("issuer").GetString());
+        Assert.Equal("https://glovelly.test/oauth/authorize", payload.GetProperty("authorization_endpoint").GetString());
+        Assert.Equal("https://glovelly.test/oauth/token", payload.GetProperty("token_endpoint").GetString());
+        Assert.Contains(
+            payload.GetProperty("code_challenge_methods_supported").EnumerateArray(),
+            value => value.GetString() == "S256");
+    }
+
+    [Fact]
+    public async Task PostMcp_WithOAuthBearerToken_AuthenticatesTokenUser()
+    {
+        using var factory = CreateMcpOAuthFactory();
+        using var client = factory.CreateClient();
+        var codeVerifier = "test-code-verifier-with-enough-entropy";
+        var codeChallenge = WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier)));
+        string authorizationCode;
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var oauthService = scope.ServiceProvider.GetRequiredService<IMcpOAuthService>();
+            var issuedCode = await oauthService.CreateAuthorizationCodeAsync(
+                "chatgpt-test",
+                TestAuthContext.UserId,
+                "https://chatgpt.test/callback",
+                "mcp:read",
+                "https://glovelly.test/mcp",
+                codeChallenge,
+                "S256",
+                CancellationToken.None);
+            authorizationCode = issuedCode.Code;
+        }
+
+        var tokenResponse = await client.PostAsync(
+            "/oauth/token",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "authorization_code",
+                ["client_id"] = "chatgpt-test",
+                ["client_secret"] = "secret-test",
+                ["code"] = authorizationCode,
+                ["redirect_uri"] = "https://chatgpt.test/callback",
+                ["code_verifier"] = codeVerifier,
+                ["resource"] = "https://glovelly.test/mcp",
+            }));
+
+        Assert.Equal(HttpStatusCode.OK, tokenResponse.StatusCode);
+        var tokenPayload = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var accessToken = tokenPayload.GetProperty("access_token").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(accessToken));
+
+        using var request = CreateMcpRequest(ListInvoicesPayload());
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.NotEmpty(payload
+            .GetProperty("result")
+            .GetProperty("structuredContent")
+            .GetProperty("invoices")
+            .EnumerateArray());
     }
 
     [Fact]
@@ -426,6 +526,20 @@ public sealed class McpEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             ["DevelopmentSeeding:AdminGoogleSubject"] = TestAuthContext.DefaultSubject,
             ["Mcp:DevelopmentAuth:AllowAnonymous"] = allowAnonymous.ToString(),
+        });
+    }
+
+    private static GlovellyApiFactory CreateMcpOAuthFactory()
+    {
+        return new GlovellyApiFactory().WithConfiguration(new Dictionary<string, string?>
+        {
+            ["Mcp:OAuth:Issuer"] = "https://glovelly.test",
+            ["Mcp:OAuth:Resource"] = "https://glovelly.test/mcp",
+            ["Mcp:OAuth:Clients:0:ClientId"] = "chatgpt-test",
+            ["Mcp:OAuth:Clients:0:ClientSecret"] = "secret-test",
+            ["Mcp:OAuth:Clients:0:DisplayName"] = "ChatGPT Test",
+            ["Mcp:OAuth:Clients:0:RedirectUris:0"] = "https://chatgpt.test/callback",
+            ["Mcp:OAuth:Clients:0:Scopes:0"] = "mcp:read",
         });
     }
 

--- a/backend/Glovelly.Api/Auth/GlovellyPolicies.cs
+++ b/backend/Glovelly.Api/Auth/GlovellyPolicies.cs
@@ -3,5 +3,6 @@ namespace Glovelly.Api.Auth;
 public static class GlovellyPolicies
 {
     public const string GlovellyUser = "GlovellyUser";
+    public const string McpUser = "McpUser";
     public const string AdminUser = "AdminUser";
 }

--- a/backend/Glovelly.Api/Auth/McpDevelopmentAuthenticationHandler.cs
+++ b/backend/Glovelly.Api/Auth/McpDevelopmentAuthenticationHandler.cs
@@ -1,0 +1,71 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Glovelly.Api.Auth;
+
+public sealed class McpDevelopmentAuthenticationHandler(
+    IOptionsMonitor<McpDevelopmentAuthenticationOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    IHostEnvironment environment,
+    IConfiguration configuration,
+    AppDbContext db) : AuthenticationHandler<McpDevelopmentAuthenticationOptions>(options, logger, encoder)
+{
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!environment.IsDevelopment())
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        if (!Request.Path.StartsWithSegments("/mcp"))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        if (!Options.AllowAnonymous)
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var googleSubject = configuration["DevelopmentSeeding:AdminGoogleSubject"]?.Trim();
+        if (string.IsNullOrWhiteSpace(googleSubject))
+        {
+            Logger.LogWarning("MCP development anonymous auth is disabled because no seeded admin Google subject is configured.");
+            return AuthenticateResult.NoResult();
+        }
+
+        var user = await db.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(value =>
+                value.GoogleSubject == googleSubject &&
+                value.IsActive &&
+                value.Role == UserRole.Admin);
+
+        if (user is null)
+        {
+            return AuthenticateResult.Fail("Seeded MCP development admin user does not exist or is inactive.");
+        }
+
+        var claims = new[]
+        {
+            new Claim(GlovellyClaimTypes.UserId, user.Id.ToString()),
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new Claim(ClaimTypes.Email, user.Email),
+            new Claim("email", user.Email),
+            new Claim(ClaimTypes.Role, user.Role.ToString()),
+            new Claim("role", user.Role.ToString()),
+            new Claim(ClaimTypes.Name, user.DisplayName ?? user.Email),
+        };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return AuthenticateResult.Success(ticket);
+    }
+}

--- a/backend/Glovelly.Api/Auth/McpDevelopmentAuthenticationOptions.cs
+++ b/backend/Glovelly.Api/Auth/McpDevelopmentAuthenticationOptions.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Glovelly.Api.Auth;
+
+public sealed class McpDevelopmentAuthenticationOptions : AuthenticationSchemeOptions
+{
+    public const string SectionName = "Mcp:DevelopmentAuth";
+    public const string SchemeName = "McpDevelopment";
+
+    public bool AllowAnonymous { get; set; }
+}

--- a/backend/Glovelly.Api/Auth/McpOAuthAuthenticationHandler.cs
+++ b/backend/Glovelly.Api/Auth/McpOAuthAuthenticationHandler.cs
@@ -1,0 +1,75 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Glovelly.Api.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Glovelly.Api.Auth;
+
+public sealed class McpOAuthAuthenticationHandler(
+    IOptionsMonitor<McpOAuthAuthenticationOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    IMcpOAuthService oauthService) : AuthenticationHandler<McpOAuthAuthenticationOptions>(options, logger, encoder)
+{
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Path.StartsWithSegments("/mcp"))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var authorization = Request.Headers.Authorization.ToString();
+        const string bearerPrefix = "Bearer ";
+        if (string.IsNullOrWhiteSpace(authorization) ||
+            !authorization.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var token = authorization[bearerPrefix.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return AuthenticateResult.Fail("Bearer token is empty.");
+        }
+
+        var validation = await oauthService.ValidateAccessTokenAsync(
+            token,
+            oauthService.GetResource(Request),
+            Context.RequestAborted);
+        if (validation is null)
+        {
+            return AuthenticateResult.Fail("Bearer token is invalid or expired.");
+        }
+
+        var user = validation.User;
+        var claims = new[]
+        {
+            new Claim(GlovellyClaimTypes.UserId, user.Id.ToString()),
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new Claim(ClaimTypes.Email, user.Email),
+            new Claim("email", user.Email),
+            new Claim(ClaimTypes.Role, user.Role.ToString()),
+            new Claim("role", user.Role.ToString()),
+            new Claim(ClaimTypes.Name, user.DisplayName ?? user.Email),
+            new Claim("scope", validation.Scope),
+            new Claim("client_id", validation.ClientId),
+        };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return AuthenticateResult.Success(ticket);
+    }
+
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = StatusCodes.Status401Unauthorized;
+        Response.Headers.AccessControlAllowOrigin = "*";
+        Response.Headers.AccessControlExposeHeaders = "Mcp-Session-Id, MCP-Protocol-Version, WWW-Authenticate";
+        Response.Headers["MCP-Protocol-Version"] = "2025-06-18";
+        Response.Headers.WWWAuthenticate =
+            $"Bearer realm=\"glovelly-mcp\", resource_metadata=\"{oauthService.GetProtectedResourceMetadataUrl(Request)}\"";
+        return Task.CompletedTask;
+    }
+}

--- a/backend/Glovelly.Api/Auth/McpOAuthAuthenticationOptions.cs
+++ b/backend/Glovelly.Api/Auth/McpOAuthAuthenticationOptions.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Glovelly.Api.Auth;
+
+public sealed class McpOAuthAuthenticationOptions : AuthenticationSchemeOptions
+{
+    public const string SchemeName = "McpOAuthBearer";
+}

--- a/backend/Glovelly.Api/Configuration/AuthenticationServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/AuthenticationServiceCollectionExtensions.cs
@@ -55,7 +55,10 @@ internal static class AuthenticationServiceCollectionExtensions
                     OnRedirectToLogin = context => RedirectApiRequestsOrContinue(context, StatusCodes.Status401Unauthorized),
                     OnRedirectToAccessDenied = context => RedirectApiRequestsOrContinue(context, StatusCodes.Status403Forbidden),
                 };
-            });
+            })
+            .AddScheme<McpDevelopmentAuthenticationOptions, McpDevelopmentAuthenticationHandler>(
+                McpDevelopmentAuthenticationOptions.SchemeName,
+                _ => { });
 
         if (!string.IsNullOrWhiteSpace(settings.GoogleClientId) &&
             !string.IsNullOrWhiteSpace(settings.GoogleClientSecret))

--- a/backend/Glovelly.Api/Configuration/AuthenticationServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/AuthenticationServiceCollectionExtensions.cs
@@ -58,6 +58,9 @@ internal static class AuthenticationServiceCollectionExtensions
             })
             .AddScheme<McpDevelopmentAuthenticationOptions, McpDevelopmentAuthenticationHandler>(
                 McpDevelopmentAuthenticationOptions.SchemeName,
+                _ => { })
+            .AddScheme<McpOAuthAuthenticationOptions, McpOAuthAuthenticationHandler>(
+                McpOAuthAuthenticationOptions.SchemeName,
                 _ => { });
 
         if (!string.IsNullOrWhiteSpace(settings.GoogleClientId) &&

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ internal static class InfrastructureServiceCollectionExtensions
             .Bind(configuration.GetSection("Email"));
         services.AddOptions<AccessRequestProtectionSettings>()
             .Bind(configuration.GetSection(AccessRequestProtectionSettings.SectionName));
+        services.AddOptions<McpDevelopmentAuthenticationOptions>(McpDevelopmentAuthenticationOptions.SchemeName)
+            .Bind(configuration.GetSection(McpDevelopmentAuthenticationOptions.SectionName));
         services.AddGlovellyApplicationServices();
         services.AddScoped<IGoogleDriveTokenProtector, GoogleDriveTokenProtector>();
         services.AddHttpClient<IGoogleDriveOAuthTokenExchanger, GoogleDriveOAuthTokenExchanger>();
@@ -42,6 +44,7 @@ internal static class InfrastructureServiceCollectionExtensions
             options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
         });
         services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
+        services.AddScoped<IGlovellyMcpQueryService, GlovellyMcpQueryService>();
         services.AddScoped<IClaimsTransformation, GoogleOidcClaimsTransformation>();
         services.AddDbContext<AppDbContext>(options =>
         {
@@ -70,11 +73,14 @@ internal static class InfrastructureServiceCollectionExtensions
         {
             options.AddPolicy(GlovellyPolicies.GlovellyUser, policy =>
             {
+                policy.AuthenticationSchemes.Add(Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme);
+                policy.AuthenticationSchemes.Add(McpDevelopmentAuthenticationOptions.SchemeName);
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(GlovellyClaimTypes.UserId);
             });
             options.AddPolicy(GlovellyPolicies.AdminUser, policy =>
             {
+                policy.AuthenticationSchemes.Add(Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme);
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(GlovellyClaimTypes.UserId);
                 policy.RequireRole(UserRole.Admin.ToString());

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -30,6 +30,8 @@ internal static class InfrastructureServiceCollectionExtensions
             .Bind(configuration.GetSection(AccessRequestProtectionSettings.SectionName));
         services.AddOptions<McpDevelopmentAuthenticationOptions>(McpDevelopmentAuthenticationOptions.SchemeName)
             .Bind(configuration.GetSection(McpDevelopmentAuthenticationOptions.SectionName));
+        services.AddOptions<McpOAuthOptions>()
+            .Bind(configuration.GetSection(McpOAuthOptions.SectionName));
         services.AddGlovellyApplicationServices();
         services.AddScoped<IGoogleDriveTokenProtector, GoogleDriveTokenProtector>();
         services.AddHttpClient<IGoogleDriveOAuthTokenExchanger, GoogleDriveOAuthTokenExchanger>();
@@ -45,6 +47,7 @@ internal static class InfrastructureServiceCollectionExtensions
         });
         services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
         services.AddScoped<IGlovellyMcpQueryService, GlovellyMcpQueryService>();
+        services.AddScoped<IMcpOAuthService, McpOAuthService>();
         services.AddScoped<IClaimsTransformation, GoogleOidcClaimsTransformation>();
         services.AddDbContext<AppDbContext>(options =>
         {
@@ -74,7 +77,14 @@ internal static class InfrastructureServiceCollectionExtensions
             options.AddPolicy(GlovellyPolicies.GlovellyUser, policy =>
             {
                 policy.AuthenticationSchemes.Add(Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme);
+                policy.RequireAuthenticatedUser();
+                policy.RequireClaim(GlovellyClaimTypes.UserId);
+            });
+            options.AddPolicy(GlovellyPolicies.McpUser, policy =>
+            {
+                policy.AuthenticationSchemes.Add(Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme);
                 policy.AuthenticationSchemes.Add(McpDevelopmentAuthenticationOptions.SchemeName);
+                policy.AuthenticationSchemes.Add(McpOAuthAuthenticationOptions.SchemeName);
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(GlovellyClaimTypes.UserId);
             });

--- a/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
@@ -29,7 +29,9 @@ internal static class WebApplicationExtensions
             app.UseSwagger();
             app.UseSwaggerUI();
 
-            app.UseHttpsRedirection();
+            app.UseWhen(
+                context => !context.Request.Path.StartsWithSegments("/mcp"),
+                branch => branch.UseHttpsRedirection());
             app.UseCors(settings.DevCorsPolicy);
         }
 

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -17,6 +17,9 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<InvoiceLine> InvoiceLines => Set<InvoiceLine>();
     public DbSet<SellerProfile> SellerProfiles => Set<SellerProfile>();
     public DbSet<GoogleDriveConnection> GoogleDriveConnections => Set<GoogleDriveConnection>();
+    public DbSet<McpOAuthAuthorizationCode> McpOAuthAuthorizationCodes => Set<McpOAuthAuthorizationCode>();
+    public DbSet<McpOAuthAccessToken> McpOAuthAccessTokens => Set<McpOAuthAccessToken>();
+    public DbSet<McpOAuthRefreshToken> McpOAuthRefreshTokens => Set<McpOAuthRefreshToken>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -98,6 +101,87 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
             entity.HasOne(connection => connection.User)
                 .WithOne(user => user.GoogleDriveConnection)
                 .HasForeignKey<GoogleDriveConnection>(connection => connection.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<McpOAuthAuthorizationCode>(entity =>
+        {
+            entity.HasKey(code => code.Id);
+            entity.Property(code => code.CodeHash)
+                .IsRequired()
+                .HasMaxLength(128);
+            entity.Property(code => code.ClientId)
+                .IsRequired()
+                .HasMaxLength(200);
+            entity.Property(code => code.RedirectUri)
+                .IsRequired()
+                .HasMaxLength(1000);
+            entity.Property(code => code.Scope)
+                .IsRequired()
+                .HasMaxLength(500);
+            entity.Property(code => code.Resource)
+                .IsRequired()
+                .HasMaxLength(1000);
+            entity.Property(code => code.CodeChallenge)
+                .IsRequired()
+                .HasMaxLength(200);
+            entity.Property(code => code.CodeChallengeMethod)
+                .IsRequired()
+                .HasMaxLength(20);
+            entity.HasIndex(code => code.CodeHash)
+                .IsUnique();
+            entity.HasIndex(code => code.ExpiresUtc);
+            entity.HasOne(code => code.User)
+                .WithMany()
+                .HasForeignKey(code => code.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<McpOAuthAccessToken>(entity =>
+        {
+            entity.HasKey(token => token.Id);
+            entity.Property(token => token.TokenHash)
+                .IsRequired()
+                .HasMaxLength(128);
+            entity.Property(token => token.ClientId)
+                .IsRequired()
+                .HasMaxLength(200);
+            entity.Property(token => token.Scope)
+                .IsRequired()
+                .HasMaxLength(500);
+            entity.Property(token => token.Resource)
+                .IsRequired()
+                .HasMaxLength(1000);
+            entity.HasIndex(token => token.TokenHash)
+                .IsUnique();
+            entity.HasIndex(token => token.ExpiresUtc);
+            entity.HasOne(token => token.User)
+                .WithMany()
+                .HasForeignKey(token => token.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<McpOAuthRefreshToken>(entity =>
+        {
+            entity.HasKey(token => token.Id);
+            entity.Property(token => token.TokenHash)
+                .IsRequired()
+                .HasMaxLength(128);
+            entity.Property(token => token.ClientId)
+                .IsRequired()
+                .HasMaxLength(200);
+            entity.Property(token => token.Scope)
+                .IsRequired()
+                .HasMaxLength(500);
+            entity.Property(token => token.Resource)
+                .IsRequired()
+                .HasMaxLength(1000);
+            entity.HasIndex(token => token.TokenHash)
+                .IsUnique();
+            entity.HasIndex(token => token.ExpiresUtc);
+            entity.HasOne(token => token.User)
+                .WithMany()
+                .HasForeignKey(token => token.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 

--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -54,6 +54,7 @@ internal static class AuthFlowSupport
                path.StartsWithSegments("/integrations") ||
                path.StartsWithSegments("/invoices") ||
                path.StartsWithSegments("/invoice-lines") ||
+               path.StartsWithSegments("/mcp") ||
                path.StartsWithSegments("/seller-profile");
     }
 

--- a/backend/Glovelly.Api/Endpoints/McpEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/McpEndpoints.cs
@@ -44,7 +44,7 @@ public static class McpEndpoints
             .WithTags("MCP");
 
         app.MapPost("/mcp", HandleRpcAsync)
-            .RequireAuthorization(GlovellyPolicies.GlovellyUser)
+            .RequireAuthorization(GlovellyPolicies.McpUser)
             .WithTags("MCP");
 
         return app;

--- a/backend/Glovelly.Api/Endpoints/McpEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/McpEndpoints.cs
@@ -1,0 +1,377 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Glovelly.Api.Auth;
+using Glovelly.Api.Services;
+
+namespace Glovelly.Api.Endpoints;
+
+public static class McpEndpoints
+{
+    private const string ProtocolVersion = "2025-06-18";
+    private const string LegacyProtocolVersion = "2024-11-05";
+    private const string McpProtocolVersionHeader = "MCP-Protocol-Version";
+    private const string McpSessionIdHeader = "Mcp-Session-Id";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    public static IEndpointRouteBuilder MapMcpEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapMethods("/mcp", ["OPTIONS"], HandlePreflight)
+            .AllowAnonymous()
+            .WithTags("MCP");
+
+        app.MapGet("/mcp", (HttpContext httpContext) =>
+            {
+                SetMcpCorsHeaders(httpContext.Response);
+                httpContext.Response.Headers["Allow"] = "POST, OPTIONS";
+                httpContext.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+                return Task.CompletedTask;
+            })
+            .AllowAnonymous()
+            .WithTags("MCP");
+
+        app.MapDelete("/mcp", (HttpContext httpContext) =>
+            {
+                SetMcpCorsHeaders(httpContext.Response);
+                httpContext.Response.Headers["Allow"] = "POST, OPTIONS";
+                httpContext.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+                return Task.CompletedTask;
+            })
+            .AllowAnonymous()
+            .WithTags("MCP");
+
+        app.MapPost("/mcp", HandleRpcAsync)
+            .RequireAuthorization(GlovellyPolicies.GlovellyUser)
+            .WithTags("MCP");
+
+        return app;
+    }
+
+    private static IResult HandlePreflight(HttpContext httpContext)
+    {
+        SetMcpCorsHeaders(httpContext.Response);
+        httpContext.Response.Headers.AccessControlAllowMethods = "POST, GET, DELETE, OPTIONS";
+        httpContext.Response.Headers.AccessControlAllowHeaders =
+            "accept, authorization, content-type, last-event-id, mcp-session-id, mcp-protocol-version";
+        httpContext.Response.Headers.AccessControlMaxAge = "86400";
+
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleRpcAsync(
+        JsonElement request,
+        HttpContext httpContext,
+        ICurrentUserAccessor currentUserAccessor,
+        IGlovellyMcpQueryService queryService,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken)
+    {
+        SetMcpCorsHeaders(httpContext.Response);
+
+        var versionValidation = ValidateProtocolVersion(httpContext.Request);
+        if (versionValidation is not null)
+        {
+            return versionValidation;
+        }
+
+        if (!request.TryGetProperty("id", out var id))
+        {
+            return Results.Accepted();
+        }
+
+        var logger = loggerFactory.CreateLogger("Glovelly.Mcp");
+        var userId = currentUserAccessor.TryGetUserId(httpContext.User);
+        if (!userId.HasValue)
+        {
+            return Results.Unauthorized();
+        }
+
+        var method = request.TryGetProperty("method", out var methodElement)
+            ? methodElement.GetString()
+            : null;
+
+        logger.LogInformation("Glovelly MCP method {Method} called by user {UserId}.", method, userId);
+
+        try
+        {
+            return method switch
+            {
+                "initialize" => Rpc(id, result: InitializeResult(request)),
+                "ping" => Rpc(id, result: new { }),
+                "tools/list" => Rpc(id, result: new { tools = Tools }),
+                "tools/call" => await CallToolAsync(id, request, userId.Value, queryService, logger, cancellationToken),
+                _ => Rpc(id, error: new McpRpcError(-32601, $"Unsupported MCP method '{method}'.")),
+            };
+        }
+        catch (JsonException exception)
+        {
+            logger.LogWarning(exception, "Invalid Glovelly MCP request payload.");
+            return Rpc(id, error: new McpRpcError(-32602, "Invalid tool arguments."));
+        }
+    }
+
+    private static IResult? ValidateProtocolVersion(HttpRequest request)
+    {
+        if (!request.Headers.TryGetValue(McpProtocolVersionHeader, out var values))
+        {
+            return null;
+        }
+
+        var version = values.FirstOrDefault();
+        return version is ProtocolVersion or LegacyProtocolVersion
+            ? null
+            : Results.BadRequest(new
+            {
+                error = $"Unsupported MCP protocol version '{version}'.",
+                supported = new[] { ProtocolVersion, LegacyProtocolVersion },
+            });
+    }
+
+    private static void SetMcpCorsHeaders(HttpResponse response)
+    {
+        response.Headers.AccessControlAllowOrigin = "*";
+        response.Headers.AccessControlExposeHeaders = $"{McpSessionIdHeader}, {McpProtocolVersionHeader}, WWW-Authenticate";
+        response.Headers[McpProtocolVersionHeader] = ProtocolVersion;
+    }
+
+    private static async Task<IResult> CallToolAsync(
+        JsonElement id,
+        JsonElement request,
+        Guid userId,
+        IGlovellyMcpQueryService queryService,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (!request.TryGetProperty("params", out var parameters) ||
+            !parameters.TryGetProperty("name", out var nameElement))
+        {
+            return Rpc(id, error: new McpRpcError(-32602, "Tool name is required."));
+        }
+
+        var toolName = nameElement.GetString();
+        var arguments = parameters.TryGetProperty("arguments", out var argumentsElement)
+            ? argumentsElement
+            : default;
+
+        logger.LogInformation("Glovelly MCP tool {ToolName} called by user {UserId}.", toolName, userId);
+
+        object? result = toolName switch
+        {
+            "glovelly_search_contacts" => await queryService.SearchContactsAsync(
+                userId,
+                ReadArgument<string?>(arguments, "query"),
+                cancellationToken),
+            "glovelly_list_invoices" => await queryService.ListInvoicesAsync(
+                userId,
+                ReadArguments<InvoiceListRequest>(arguments),
+                cancellationToken),
+            "glovelly_get_invoice" => await GetInvoiceAsync(userId, arguments, queryService, cancellationToken),
+            "glovelly_list_receipts" => await queryService.ListReceiptsAsync(
+                userId,
+                ReadArguments<ReceiptListRequest>(arguments),
+                cancellationToken),
+            "glovelly_get_business_summary" => await queryService.GetBusinessSummaryAsync(
+                userId,
+                ReadArguments<BusinessSummaryRequest>(arguments),
+                cancellationToken),
+            _ => null,
+        };
+
+        if (result is null)
+        {
+            return Rpc(id, error: new McpRpcError(-32602, $"Unknown or unavailable tool '{toolName}'."));
+        }
+
+        return Rpc(id, result: ToolResult(result));
+    }
+
+    private static async Task<object?> GetInvoiceAsync(
+        Guid userId,
+        JsonElement arguments,
+        IGlovellyMcpQueryService queryService,
+        CancellationToken cancellationToken)
+    {
+        var invoiceId = ReadArgument<Guid?>(arguments, "invoiceId");
+        if (!invoiceId.HasValue || invoiceId == Guid.Empty)
+        {
+            return null;
+        }
+
+        var invoice = await queryService.GetInvoiceAsync(userId, invoiceId.Value, cancellationToken);
+        return new
+        {
+            found = invoice is not null,
+            invoice,
+        };
+    }
+
+    private static T ReadArguments<T>(JsonElement arguments)
+    {
+        if (arguments.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+        {
+            return JsonSerializer.Deserialize<T>("{}", JsonOptions)!;
+        }
+
+        return arguments.Deserialize<T>(JsonOptions)!;
+    }
+
+    private static T ReadArgument<T>(JsonElement arguments, string name)
+    {
+        if (arguments.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null ||
+            !arguments.TryGetProperty(name, out var value))
+        {
+            return default!;
+        }
+
+        return value.Deserialize<T>(JsonOptions)!;
+    }
+
+    private static IResult Rpc(JsonElement id, object? result = null, McpRpcError? error = null)
+    {
+        var response = error is null
+            ? new McpRpcResponse("2.0", id, result, null)
+            : new McpRpcResponse("2.0", id, null, error);
+
+        return Results.Json(response, JsonOptions);
+    }
+
+    private static object InitializeResult(JsonElement request)
+    {
+        var requestedVersion = request.TryGetProperty("params", out var parameters) &&
+            parameters.TryGetProperty("protocolVersion", out var versionElement)
+                ? versionElement.GetString()
+                : null;
+        var protocolVersion = requestedVersion is LegacyProtocolVersion
+            ? LegacyProtocolVersion
+            : ProtocolVersion;
+
+        return new
+        {
+            protocolVersion,
+            serverInfo = new
+            {
+                name = "glovelly",
+                title = "Glovelly",
+                version = "0.1.0-experimental",
+            },
+            capabilities = new
+            {
+                tools = new
+                {
+                    listChanged = false,
+                },
+            },
+        };
+    }
+
+    private static object ToolResult(object structuredContent)
+    {
+        return new
+        {
+            content = new[]
+            {
+                new
+                {
+                    type = "text",
+                    text = JsonSerializer.Serialize(structuredContent, JsonOptions),
+                },
+            },
+            structuredContent,
+            isError = false,
+        };
+    }
+
+    private static readonly object[] Tools =
+    [
+        new
+        {
+            name = "glovelly_search_contacts",
+            title = "Search Contacts",
+            description = "Search Glovelly contacts by name or email. Returns possible matches without guessing.",
+            inputSchema = new
+            {
+                type = "object",
+                properties = new
+                {
+                    query = new { type = "string" },
+                },
+            },
+        },
+        new
+        {
+            name = "glovelly_list_invoices",
+            title = "List Invoices",
+            description = "List invoices by optional contact, status, date range, and date basis.",
+            inputSchema = new
+            {
+                type = "object",
+                properties = new
+                {
+                    contactId = new { type = "string", format = "uuid" },
+                    contactQuery = new { type = "string" },
+                    status = new { type = "string", description = "all, outstanding, issued, paid, draft, overdue, or cancelled" },
+                    fromDate = new { type = "string", format = "date" },
+                    toDate = new { type = "string", format = "date" },
+                    dateBasis = new { type = "string", @enum = new[] { "issueDate", "dueDate" } },
+                },
+            },
+        },
+        new
+        {
+            name = "glovelly_get_invoice",
+            title = "Get Invoice",
+            description = "Fetch read-only invoice details for a single invoice.",
+            inputSchema = new
+            {
+                type = "object",
+                required = new[] { "invoiceId" },
+                properties = new
+                {
+                    invoiceId = new { type = "string", format = "uuid" },
+                },
+            },
+        },
+        new
+        {
+            name = "glovelly_list_receipts",
+            title = "List Receipts",
+            description = "List read-only receipt and expense records by date range and optional status.",
+            inputSchema = new
+            {
+                type = "object",
+                properties = new
+                {
+                    fromDate = new { type = "string", format = "date" },
+                    toDate = new { type = "string", format = "date" },
+                    status = new { type = "string", description = "all, matched, or unmatched" },
+                },
+            },
+        },
+        new
+        {
+            name = "glovelly_get_business_summary",
+            title = "Get Business Summary",
+            description = "Summarise invoice totals, paid totals, outstanding totals, expenses, and receipt counts for a period.",
+            inputSchema = new
+            {
+                type = "object",
+                properties = new
+                {
+                    fromDate = new { type = "string", format = "date" },
+                    toDate = new { type = "string", format = "date" },
+                },
+            },
+        },
+    ];
+
+    private sealed record McpRpcResponse(
+        [property: JsonPropertyName("jsonrpc")] string JsonRpc,
+        JsonElement Id,
+        object? Result,
+        McpRpcError? Error);
+
+    private sealed record McpRpcError(int Code, string Message);
+}

--- a/backend/Glovelly.Api/Endpoints/McpOAuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/McpOAuthEndpoints.cs
@@ -1,0 +1,326 @@
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json.Serialization;
+using Glovelly.Api.Auth;
+using Glovelly.Api.Data;
+using Glovelly.Api.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.EntityFrameworkCore;
+
+namespace Glovelly.Api.Endpoints;
+
+public static class McpOAuthEndpoints
+{
+    public static IEndpointRouteBuilder MapMcpOAuthEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/.well-known/oauth-protected-resource", (
+                HttpRequest request,
+                IMcpOAuthService oauthService) =>
+            {
+                var resource = oauthService.GetResource(request);
+                return Results.Ok(new
+                {
+                    resource,
+                    authorization_servers = new[] { oauthService.GetIssuer(request) },
+                    scopes_supported = new[] { "mcp:read" },
+                    bearer_methods_supported = new[] { "header" },
+                });
+            })
+            .AllowAnonymous()
+            .WithTags("MCP OAuth");
+
+        app.MapGet("/.well-known/oauth-authorization-server", (
+                HttpRequest request,
+                IMcpOAuthService oauthService) =>
+            {
+                var issuer = oauthService.GetIssuer(request);
+                return Results.Ok(new
+                {
+                    issuer,
+                    authorization_endpoint = $"{issuer}/oauth/authorize",
+                    token_endpoint = $"{issuer}/oauth/token",
+                    response_types_supported = new[] { "code" },
+                    grant_types_supported = new[] { "authorization_code", "refresh_token" },
+                    token_endpoint_auth_methods_supported = new[] { "client_secret_basic", "client_secret_post", "none" },
+                    code_challenge_methods_supported = new[] { "S256" },
+                    scopes_supported = new[] { "mcp:read" },
+                    resource_parameter_supported = true,
+                });
+            })
+            .AllowAnonymous()
+            .WithTags("MCP OAuth");
+
+        var oauth = app.MapGroup("/oauth").AllowAnonymous().WithTags("MCP OAuth");
+
+        oauth.MapGet("/authorize", AuthorizeAsync);
+        oauth.MapPost("/token", TokenAsync);
+
+        return app;
+    }
+
+    private static async Task<IResult> AuthorizeAsync(
+        HttpContext httpContext,
+        IMcpOAuthService oauthService,
+        AppDbContext db,
+        string? response_type,
+        string? client_id,
+        string? redirect_uri,
+        string? scope,
+        string? state,
+        string? code_challenge,
+        string? code_challenge_method,
+        string? resource,
+        CancellationToken cancellationToken)
+    {
+        var validationError = ValidateAuthorizationRequest(
+            httpContext.Request,
+            oauthService,
+            response_type,
+            client_id,
+            redirect_uri,
+            scope,
+            code_challenge,
+            code_challenge_method,
+            resource,
+            out var client,
+            out var validatedScope,
+            out var validatedResource);
+        if (validationError is not null)
+        {
+            return validationError;
+        }
+
+        var cookieAuth = await httpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        if (!cookieAuth.Succeeded || cookieAuth.Principal?.Identity?.IsAuthenticated != true)
+        {
+            var returnUrl = $"{httpContext.Request.PathBase}{httpContext.Request.Path}{httpContext.Request.QueryString}";
+            return Results.Redirect($"/auth/login?returnUrl={Uri.EscapeDataString(returnUrl)}");
+        }
+
+        var userIdClaim = cookieAuth.Principal.FindFirstValue(GlovellyClaimTypes.UserId);
+        if (!Guid.TryParse(userIdClaim, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        var userExists = await db.Users
+            .AsNoTracking()
+            .AnyAsync(user => user.Id == userId && user.IsActive, cancellationToken);
+        if (!userExists)
+        {
+            return Results.Unauthorized();
+        }
+
+        var issuedCode = await oauthService.CreateAuthorizationCodeAsync(
+            client!.ClientId,
+            userId,
+            redirect_uri!,
+            validatedScope,
+            validatedResource,
+            code_challenge!,
+            code_challenge_method!,
+            cancellationToken);
+
+        var redirect = AddQuery(redirect_uri!, "code", issuedCode.Code);
+        if (!string.IsNullOrWhiteSpace(state))
+        {
+            redirect = AddQuery(redirect, "state", state);
+        }
+
+        return Results.Redirect(redirect);
+    }
+
+    private static async Task<IResult> TokenAsync(
+        HttpContext httpContext,
+        IMcpOAuthService oauthService,
+        CancellationToken cancellationToken)
+    {
+        IFormCollection form;
+        try
+        {
+            form = await httpContext.Request.ReadFormAsync(cancellationToken);
+        }
+        catch (InvalidOperationException)
+        {
+            return OAuthError("invalid_request", "Token requests must use application/x-www-form-urlencoded.");
+        }
+        var grantType = form["grant_type"].FirstOrDefault();
+        var clientId = form["client_id"].FirstOrDefault();
+        var clientSecret = form["client_secret"].FirstOrDefault();
+
+        TryReadBasicClientCredentials(httpContext.Request, out var basicClientId, out var basicClientSecret);
+        clientId = basicClientId ?? clientId;
+        clientSecret = basicClientSecret ?? clientSecret;
+
+        if (string.IsNullOrWhiteSpace(clientId))
+        {
+            return OAuthError("invalid_client", "Client id is required.", StatusCodes.Status401Unauthorized);
+        }
+
+        var client = oauthService.FindClient(clientId);
+        if (client is null || !ValidateClientSecret(client, clientSecret))
+        {
+            return OAuthError("invalid_client", "Client authentication failed.", StatusCodes.Status401Unauthorized);
+        }
+
+        var resource = form["resource"].FirstOrDefault() ?? oauthService.GetResource(httpContext.Request);
+        if (!string.Equals(resource, oauthService.GetResource(httpContext.Request), StringComparison.Ordinal))
+        {
+            return OAuthError("invalid_target", "Requested resource is not supported.");
+        }
+
+        McpOAuthTokenIssueResult? tokens = grantType switch
+        {
+            "authorization_code" => await oauthService.RedeemAuthorizationCodeAsync(
+                form["code"].FirstOrDefault() ?? string.Empty,
+                client.ClientId,
+                form["redirect_uri"].FirstOrDefault() ?? string.Empty,
+                form["code_verifier"].FirstOrDefault() ?? string.Empty,
+                resource,
+                cancellationToken),
+            "refresh_token" => await oauthService.RefreshAccessTokenAsync(
+                form["refresh_token"].FirstOrDefault() ?? string.Empty,
+                client.ClientId,
+                resource,
+                cancellationToken),
+            _ => null,
+        };
+
+        if (tokens is null)
+        {
+            return OAuthError("invalid_grant", "Grant is invalid, expired, or already used.");
+        }
+
+        return Results.Ok(new TokenResponse(
+            tokens.AccessToken,
+            tokens.TokenType,
+            tokens.ExpiresIn,
+            tokens.RefreshToken,
+            tokens.Scope));
+    }
+
+    private static IResult? ValidateAuthorizationRequest(
+        HttpRequest request,
+        IMcpOAuthService oauthService,
+        string? responseType,
+        string? clientId,
+        string? redirectUri,
+        string? scope,
+        string? codeChallenge,
+        string? codeChallengeMethod,
+        string? resource,
+        out McpOAuthClientOptions? client,
+        out string validatedScope,
+        out string validatedResource)
+    {
+        client = null;
+        validatedScope = McpOAuthService.NormalizeScope(scope);
+        validatedResource = resource ?? oauthService.GetResource(request);
+
+        if (!string.Equals(responseType, "code", StringComparison.Ordinal))
+        {
+            return OAuthError("unsupported_response_type", "Only the authorization code response type is supported.");
+        }
+
+        if (string.IsNullOrWhiteSpace(clientId))
+        {
+            return OAuthError("invalid_request", "Client id is required.");
+        }
+
+        client = oauthService.FindClient(clientId);
+        if (client is null)
+        {
+            return OAuthError("unauthorized_client", "OAuth client is not registered.");
+        }
+
+        if (string.IsNullOrWhiteSpace(redirectUri) ||
+            !client.RedirectUris.Contains(redirectUri, StringComparer.Ordinal))
+        {
+            return OAuthError("invalid_request", "Redirect URI is not registered for this client.");
+        }
+
+        var registeredClient = client;
+        if (!McpOAuthService.HasScope(validatedScope, "mcp:read") ||
+            !validatedScope.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .All(requestedScope => registeredClient.Scopes.Contains(requestedScope, StringComparer.Ordinal)))
+        {
+            return OAuthError("invalid_scope", "Requested scope is not supported.");
+        }
+
+        if (!string.Equals(validatedResource, oauthService.GetResource(request), StringComparison.Ordinal))
+        {
+            return OAuthError("invalid_target", "Requested resource is not supported.");
+        }
+
+        if (string.IsNullOrWhiteSpace(codeChallenge) ||
+            !string.Equals(codeChallengeMethod, "S256", StringComparison.Ordinal))
+        {
+            return OAuthError("invalid_request", "PKCE with code_challenge_method S256 is required.");
+        }
+
+        return null;
+    }
+
+    private static bool ValidateClientSecret(McpOAuthClientOptions client, string? clientSecret)
+    {
+        return string.IsNullOrWhiteSpace(client.ClientSecret) ||
+            string.Equals(client.ClientSecret, clientSecret, StringComparison.Ordinal);
+    }
+
+    private static bool TryReadBasicClientCredentials(HttpRequest request, out string? clientId, out string? clientSecret)
+    {
+        clientId = null;
+        clientSecret = null;
+
+        var authorization = request.Headers.Authorization.ToString();
+        const string basicPrefix = "Basic ";
+        if (string.IsNullOrWhiteSpace(authorization) ||
+            !authorization.StartsWith(basicPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        try
+        {
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(authorization[basicPrefix.Length..].Trim()));
+            var separator = decoded.IndexOf(':', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                return false;
+            }
+
+            clientId = Uri.UnescapeDataString(decoded[..separator]);
+            clientSecret = Uri.UnescapeDataString(decoded[(separator + 1)..]);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static IResult OAuthError(string error, string description, int statusCode = StatusCodes.Status400BadRequest)
+    {
+        return Results.Json(
+            new
+            {
+                error,
+                error_description = description,
+            },
+            statusCode: statusCode);
+    }
+
+    private static string AddQuery(string uri, string name, string value)
+    {
+        var separator = uri.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+        return $"{uri}{separator}{Uri.EscapeDataString(name)}={Uri.EscapeDataString(value)}";
+    }
+
+    private sealed record TokenResponse(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("token_type")] string TokenType,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("refresh_token")] string RefreshToken,
+        [property: JsonPropertyName("scope")] string Scope);
+}

--- a/backend/Glovelly.Api/Models/McpOAuthAccessToken.cs
+++ b/backend/Glovelly.Api/Models/McpOAuthAccessToken.cs
@@ -1,0 +1,15 @@
+namespace Glovelly.Api.Models;
+
+public sealed class McpOAuthAccessToken
+{
+    public Guid Id { get; set; }
+    public string TokenHash { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public string Scope { get; set; } = string.Empty;
+    public string Resource { get; set; } = string.Empty;
+    public DateTimeOffset CreatedUtc { get; set; }
+    public DateTimeOffset ExpiresUtc { get; set; }
+    public DateTimeOffset? RevokedUtc { get; set; }
+    public User? User { get; set; }
+}

--- a/backend/Glovelly.Api/Models/McpOAuthAuthorizationCode.cs
+++ b/backend/Glovelly.Api/Models/McpOAuthAuthorizationCode.cs
@@ -1,0 +1,18 @@
+namespace Glovelly.Api.Models;
+
+public sealed class McpOAuthAuthorizationCode
+{
+    public Guid Id { get; set; }
+    public string CodeHash { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public string RedirectUri { get; set; } = string.Empty;
+    public string Scope { get; set; } = string.Empty;
+    public string Resource { get; set; } = string.Empty;
+    public string CodeChallenge { get; set; } = string.Empty;
+    public string CodeChallengeMethod { get; set; } = string.Empty;
+    public DateTimeOffset CreatedUtc { get; set; }
+    public DateTimeOffset ExpiresUtc { get; set; }
+    public DateTimeOffset? ConsumedUtc { get; set; }
+    public User? User { get; set; }
+}

--- a/backend/Glovelly.Api/Models/McpOAuthRefreshToken.cs
+++ b/backend/Glovelly.Api/Models/McpOAuthRefreshToken.cs
@@ -1,0 +1,15 @@
+namespace Glovelly.Api.Models;
+
+public sealed class McpOAuthRefreshToken
+{
+    public Guid Id { get; set; }
+    public string TokenHash { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public string Scope { get; set; } = string.Empty;
+    public string Resource { get; set; } = string.Empty;
+    public DateTimeOffset CreatedUtc { get; set; }
+    public DateTimeOffset ExpiresUtc { get; set; }
+    public DateTimeOffset? RevokedUtc { get; set; }
+    public User? User { get; set; }
+}

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -16,6 +16,7 @@ app.MapAppMetadataEndpoints(startupSettings);
 app.MapAuthEndpoints(startupSettings);
 app.MapAccessEndpoints(startupSettings);
 app.MapGoogleDriveIntegrationEndpoints(startupSettings);
+app.MapMcpEndpoints();
 app.MapCrudEndpoints();
 app.MapAdminEndpoints();
 app.MapFallbackToFile("index.html");

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -16,6 +16,7 @@ app.MapAppMetadataEndpoints(startupSettings);
 app.MapAuthEndpoints(startupSettings);
 app.MapAccessEndpoints(startupSettings);
 app.MapGoogleDriveIntegrationEndpoints(startupSettings);
+app.MapMcpOAuthEndpoints();
 app.MapMcpEndpoints();
 app.MapCrudEndpoints();
 app.MapAdminEndpoints();

--- a/backend/Glovelly.Api/Services/GlovellyMcpQueryService.cs
+++ b/backend/Glovelly.Api/Services/GlovellyMcpQueryService.cs
@@ -1,0 +1,353 @@
+using Glovelly.Api.Data;
+using Glovelly.Api.Endpoints;
+using Glovelly.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Glovelly.Api.Services;
+
+public interface IGlovellyMcpQueryService
+{
+    Task<ContactSearchResult> SearchContactsAsync(Guid userId, string? query, CancellationToken cancellationToken);
+    Task<InvoiceListResult> ListInvoicesAsync(Guid userId, InvoiceListRequest request, CancellationToken cancellationToken);
+    Task<InvoiceDetail?> GetInvoiceAsync(Guid userId, Guid invoiceId, CancellationToken cancellationToken);
+    Task<ReceiptListResult> ListReceiptsAsync(Guid userId, ReceiptListRequest request, CancellationToken cancellationToken);
+    Task<BusinessSummaryResult> GetBusinessSummaryAsync(Guid userId, BusinessSummaryRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class GlovellyMcpQueryService(AppDbContext db) : IGlovellyMcpQueryService
+{
+    private const string DefaultCurrency = "GBP";
+
+    public async Task<ContactSearchResult> SearchContactsAsync(Guid userId, string? query, CancellationToken cancellationToken)
+    {
+        var normalizedQuery = query?.Trim();
+        var contactsQuery = db.Clients
+            .WhereVisibleTo(userId)
+            .AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(normalizedQuery))
+        {
+            var lowered = normalizedQuery.ToLowerInvariant();
+            contactsQuery = contactsQuery.Where(contact =>
+                contact.Name.ToLower().Contains(lowered) ||
+                contact.Email.ToLower().Contains(lowered));
+        }
+
+        var matches = await contactsQuery
+            .OrderBy(contact => contact.Name)
+            .ThenBy(contact => contact.Email)
+            .Take(10)
+            .Select(contact => new ContactMatch(contact.Id, contact.Name, contact.Email))
+            .ToListAsync(cancellationToken);
+
+        return new ContactSearchResult(normalizedQuery ?? string.Empty, matches);
+    }
+
+    public async Task<InvoiceListResult> ListInvoicesAsync(Guid userId, InvoiceListRequest request, CancellationToken cancellationToken)
+    {
+        var contactId = request.ContactId;
+        if (!contactId.HasValue && !string.IsNullOrWhiteSpace(request.ContactQuery))
+        {
+            var contactMatches = await SearchContactsAsync(userId, request.ContactQuery, cancellationToken);
+            if (contactMatches.Matches.Count == 0)
+            {
+                return InvoiceListResult.Success([], 0m, DefaultCurrency);
+            }
+
+            if (contactMatches.Matches.Count > 1)
+            {
+                return InvoiceListResult.WithAmbiguity(
+                    $"Contact query matched {contactMatches.Matches.Count} contacts.",
+                    contactMatches.Matches);
+            }
+
+            contactId = contactMatches.Matches[0].ContactId;
+        }
+
+        var query = db.Invoices
+            .WhereVisibleTo(userId)
+            .AsNoTracking()
+            .Include(invoice => invoice.Client)
+            .Include(invoice => invoice.Lines)
+            .AsQueryable();
+
+        if (contactId.HasValue)
+        {
+            query = query.Where(invoice => invoice.ClientId == contactId.Value);
+        }
+
+        query = ApplyInvoiceStatusFilter(query, request.Status);
+        query = ApplyInvoiceDateFilter(query, request);
+
+        var invoices = await query
+            .OrderByDescending(invoice => invoice.InvoiceDate)
+            .ThenBy(invoice => invoice.InvoiceNumber)
+            .Select(invoice => ToInvoiceSummary(invoice))
+            .ToListAsync(cancellationToken);
+
+        return InvoiceListResult.Success(invoices, invoices.Sum(invoice => invoice.OutstandingAmount), DefaultCurrency);
+    }
+
+    public async Task<InvoiceDetail?> GetInvoiceAsync(Guid userId, Guid invoiceId, CancellationToken cancellationToken)
+    {
+        var invoice = await db.Invoices
+            .WhereVisibleTo(userId)
+            .AsNoTracking()
+            .Include(value => value.Client)
+            .Include(value => value.Lines)
+            .FirstOrDefaultAsync(value => value.Id == invoiceId, cancellationToken);
+
+        return invoice is null ? null : ToInvoiceDetail(invoice);
+    }
+
+    public async Task<ReceiptListResult> ListReceiptsAsync(Guid userId, ReceiptListRequest request, CancellationToken cancellationToken)
+    {
+        var query = db.GigExpenses
+            .AsNoTracking()
+            .Include(expense => expense.Attachments)
+            .Include(expense => expense.Gig)
+                .ThenInclude(gig => gig!.Client)
+            .Where(expense => expense.Gig != null)
+            .Where(expense => expense.Gig!.CreatedByUserId == null || expense.Gig.CreatedByUserId == userId);
+
+        if (request.FromDate.HasValue)
+        {
+            query = query.Where(expense => expense.Gig!.Date >= request.FromDate.Value);
+        }
+
+        if (request.ToDate.HasValue)
+        {
+            query = query.Where(expense => expense.Gig!.Date <= request.ToDate.Value);
+        }
+
+        query = ApplyReceiptStatusFilter(query, request.Status);
+
+        var receipts = await query
+            .OrderByDescending(expense => expense.Gig!.Date)
+            .ThenBy(expense => expense.Description)
+            .Select(expense => ToReceiptSummary(expense))
+            .ToListAsync(cancellationToken);
+
+        return new ReceiptListResult(
+            receipts,
+            receipts.Count,
+            receipts.Count(receipt => receipt.Status == ReceiptStatusValues.Unmatched),
+            receipts.Sum(receipt => receipt.Amount),
+            DefaultCurrency);
+    }
+
+    public async Task<BusinessSummaryResult> GetBusinessSummaryAsync(Guid userId, BusinessSummaryRequest request, CancellationToken cancellationToken)
+    {
+        var invoiceQuery = ApplyInvoiceDateFilter(
+            db.Invoices
+                .WhereVisibleTo(userId)
+                .AsNoTracking()
+                .Include(invoice => invoice.Lines)
+                .AsQueryable(),
+            new InvoiceListRequest(null, null, null, request.FromDate, request.ToDate, InvoiceDateBasis.IssueDate));
+
+        var invoices = await invoiceQuery.ToListAsync(cancellationToken);
+        var receipts = await ListReceiptsAsync(userId, new ReceiptListRequest(request.FromDate, request.ToDate, null), cancellationToken);
+
+        return new BusinessSummaryResult(
+            request.FromDate,
+            request.ToDate,
+            invoices.Sum(invoice => invoice.Total),
+            invoices.Where(invoice => invoice.Status == InvoiceStatus.Paid).Sum(invoice => invoice.Total),
+            invoices.Sum(CalculateOutstandingAmount),
+            receipts.TotalAmount,
+            receipts.ReceiptCount,
+            receipts.UnmatchedReceiptCount,
+            DefaultCurrency);
+    }
+
+    private static IQueryable<Invoice> ApplyInvoiceStatusFilter(IQueryable<Invoice> query, string? status)
+    {
+        return Normalize(status) switch
+        {
+            null or "" or "all" => query,
+            "outstanding" => query.Where(invoice => invoice.Status == InvoiceStatus.Issued || invoice.Status == InvoiceStatus.Overdue),
+            "sent" or "issued" => query.Where(invoice => invoice.Status == InvoiceStatus.Issued),
+            "draft" => query.Where(invoice => invoice.Status == InvoiceStatus.Draft),
+            "paid" => query.Where(invoice => invoice.Status == InvoiceStatus.Paid),
+            "overdue" => query.Where(invoice => invoice.Status == InvoiceStatus.Overdue),
+            "cancelled" or "canceled" => query.Where(invoice => invoice.Status == InvoiceStatus.Cancelled),
+            _ => query.Where(invoice => invoice.Status.ToString().ToLower() == Normalize(status)),
+        };
+    }
+
+    private static IQueryable<Invoice> ApplyInvoiceDateFilter(IQueryable<Invoice> query, InvoiceListRequest request)
+    {
+        var dateBasis = request.DateBasis ?? InvoiceDateBasis.IssueDate;
+        return dateBasis switch
+        {
+            InvoiceDateBasis.DueDate => ApplyDateFilter(query, request.FromDate, request.ToDate, invoice => invoice.DueDate),
+            _ => ApplyDateFilter(query, request.FromDate, request.ToDate, invoice => invoice.InvoiceDate),
+        };
+    }
+
+    private static IQueryable<Invoice> ApplyDateFilter(
+        IQueryable<Invoice> query,
+        DateOnly? fromDate,
+        DateOnly? toDate,
+        System.Linq.Expressions.Expression<Func<Invoice, DateOnly>> dateSelector)
+    {
+        if (fromDate.HasValue)
+        {
+            var from = fromDate.Value;
+            query = query.Where(ReplaceComparison(dateSelector, from, greaterThanOrEqual: true));
+        }
+
+        if (toDate.HasValue)
+        {
+            var to = toDate.Value;
+            query = query.Where(ReplaceComparison(dateSelector, to, greaterThanOrEqual: false));
+        }
+
+        return query;
+    }
+
+    private static System.Linq.Expressions.Expression<Func<Invoice, bool>> ReplaceComparison(
+        System.Linq.Expressions.Expression<Func<Invoice, DateOnly>> selector,
+        DateOnly value,
+        bool greaterThanOrEqual)
+    {
+        var comparison = greaterThanOrEqual
+            ? System.Linq.Expressions.Expression.GreaterThanOrEqual(selector.Body, System.Linq.Expressions.Expression.Constant(value))
+            : System.Linq.Expressions.Expression.LessThanOrEqual(selector.Body, System.Linq.Expressions.Expression.Constant(value));
+
+        return System.Linq.Expressions.Expression.Lambda<Func<Invoice, bool>>(comparison, selector.Parameters);
+    }
+
+    private static IQueryable<GigExpense> ApplyReceiptStatusFilter(IQueryable<GigExpense> query, string? status)
+    {
+        return Normalize(status) switch
+        {
+            null or "" or "all" => query,
+            ReceiptStatusValues.Unmatched => query.Where(expense =>
+                expense.Amount == 0m ||
+                expense.Description.ToLower().Contains("receipt draft")),
+            ReceiptStatusValues.Matched => query.Where(expense =>
+                expense.Amount > 0m &&
+                !expense.Description.ToLower().Contains("receipt draft")),
+            _ => query,
+        };
+    }
+
+    private static InvoiceSummary ToInvoiceSummary(Invoice invoice)
+    {
+        return new InvoiceSummary(
+            invoice.Id,
+            invoice.InvoiceNumber,
+            invoice.ClientId,
+            invoice.Client?.Name ?? string.Empty,
+            invoice.InvoiceDate,
+            invoice.DueDate,
+            invoice.Status.ToString().ToLowerInvariant(),
+            invoice.Total,
+            CalculateOutstandingAmount(invoice),
+            DefaultCurrency);
+    }
+
+    private static InvoiceDetail ToInvoiceDetail(Invoice invoice)
+    {
+        var lines = invoice.Lines
+            .OrderBy(line => line.SortOrder)
+            .ThenBy(line => line.Description)
+            .Select(line => new InvoiceLineDetail(
+                line.Id,
+                line.Description,
+                line.Quantity,
+                line.UnitPrice,
+                line.LineTotal,
+                line.Type.ToString().ToLowerInvariant(),
+                line.GigId))
+            .ToList();
+
+        return new InvoiceDetail(
+            invoice.Id,
+            invoice.InvoiceNumber,
+            invoice.ClientId,
+            invoice.Client?.Name ?? string.Empty,
+            invoice.InvoiceDate,
+            invoice.DueDate,
+            invoice.Status.ToString().ToLowerInvariant(),
+            invoice.Description,
+            invoice.Total,
+            CalculateOutstandingAmount(invoice),
+            DefaultCurrency,
+            lines);
+    }
+
+    private static ReceiptSummary ToReceiptSummary(GigExpense expense)
+    {
+        return new ReceiptSummary(
+            expense.Id,
+            expense.GigId,
+            expense.Gig?.Title ?? string.Empty,
+            expense.Gig?.Date ?? default,
+            expense.Gig?.ClientId,
+            expense.Gig?.Client?.Name,
+            expense.Description,
+            expense.Amount,
+            IsUnmatchedReceipt(expense) ? ReceiptStatusValues.Unmatched : ReceiptStatusValues.Matched,
+            expense.Attachments.Count,
+            expense.Attachments.Select(attachment => attachment.FileName).Order().ToList(),
+            DefaultCurrency);
+    }
+
+    private static bool IsUnmatchedReceipt(GigExpense expense)
+    {
+        return expense.Amount == 0m ||
+            expense.Description.Contains("receipt draft", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static decimal CalculateOutstandingAmount(Invoice invoice)
+    {
+        return invoice.Status is InvoiceStatus.Paid or InvoiceStatus.Cancelled ? 0m : invoice.Total;
+    }
+
+    private static string? Normalize(string? value)
+    {
+        return value?.Trim().ToLowerInvariant();
+    }
+}
+
+public sealed record ContactSearchResult(string Query, IReadOnlyList<ContactMatch> Matches);
+public sealed record ContactMatch(Guid ContactId, string Name, string Email);
+public sealed record InvoiceListRequest(Guid? ContactId, string? ContactQuery, string? Status, DateOnly? FromDate, DateOnly? ToDate, InvoiceDateBasis? DateBasis);
+
+public enum InvoiceDateBasis
+{
+    IssueDate,
+    DueDate,
+}
+
+public sealed record InvoiceListResult(bool Ambiguous, string? Message, IReadOnlyList<ContactMatch> Matches, IReadOnlyList<InvoiceSummary> Invoices, decimal TotalOutstanding, string Currency)
+{
+    public static InvoiceListResult Success(IReadOnlyList<InvoiceSummary> invoices, decimal totalOutstanding, string currency)
+    {
+        return new InvoiceListResult(false, null, [], invoices, totalOutstanding, currency);
+    }
+
+    public static InvoiceListResult WithAmbiguity(string message, IReadOnlyList<ContactMatch> matches)
+    {
+        return new InvoiceListResult(true, message, matches, [], 0m, "GBP");
+    }
+}
+
+public sealed record InvoiceSummary(Guid InvoiceId, string InvoiceNumber, Guid ContactId, string ContactName, DateOnly IssueDate, DateOnly DueDate, string Status, decimal Total, decimal OutstandingAmount, string Currency);
+public sealed record InvoiceDetail(Guid InvoiceId, string InvoiceNumber, Guid ContactId, string ContactName, DateOnly IssueDate, DateOnly DueDate, string Status, string? Description, decimal Total, decimal OutstandingAmount, string Currency, IReadOnlyList<InvoiceLineDetail> Lines);
+public sealed record InvoiceLineDetail(Guid InvoiceLineId, string Description, decimal Quantity, decimal UnitPrice, decimal LineTotal, string Type, Guid? GigId);
+public sealed record ReceiptListRequest(DateOnly? FromDate, DateOnly? ToDate, string? Status);
+public sealed record ReceiptListResult(IReadOnlyList<ReceiptSummary> Receipts, int ReceiptCount, int UnmatchedReceiptCount, decimal TotalAmount, string Currency);
+public sealed record ReceiptSummary(Guid ReceiptId, Guid GigId, string GigTitle, DateOnly ReceiptDate, Guid? ContactId, string? ContactName, string Description, decimal Amount, string Status, int AttachmentCount, IReadOnlyList<string> AttachmentFileNames, string Currency);
+
+public static class ReceiptStatusValues
+{
+    public const string Matched = "matched";
+    public const string Unmatched = "unmatched";
+}
+
+public sealed record BusinessSummaryRequest(DateOnly? FromDate, DateOnly? ToDate);
+public sealed record BusinessSummaryResult(DateOnly? FromDate, DateOnly? ToDate, decimal InvoiceTotal, decimal PaidTotal, decimal OutstandingTotal, decimal ExpenseTotal, int ReceiptCount, int UnmatchedReceiptCount, string Currency);

--- a/backend/Glovelly.Api/Services/McpOAuthOptions.cs
+++ b/backend/Glovelly.Api/Services/McpOAuthOptions.cs
@@ -1,0 +1,22 @@
+namespace Glovelly.Api.Services;
+
+public sealed class McpOAuthOptions
+{
+    public const string SectionName = "Mcp:OAuth";
+
+    public string? Issuer { get; set; }
+    public string? Resource { get; set; }
+    public int AuthorizationCodeLifetimeMinutes { get; set; } = 5;
+    public int AccessTokenLifetimeMinutes { get; set; } = 60;
+    public int RefreshTokenLifetimeDays { get; set; } = 30;
+    public List<McpOAuthClientOptions> Clients { get; set; } = [];
+}
+
+public sealed class McpOAuthClientOptions
+{
+    public string ClientId { get; set; } = string.Empty;
+    public string? ClientSecret { get; set; }
+    public string DisplayName { get; set; } = "MCP client";
+    public List<string> RedirectUris { get; set; } = [];
+    public List<string> Scopes { get; set; } = ["mcp:read"];
+}

--- a/backend/Glovelly.Api/Services/McpOAuthService.cs
+++ b/backend/Glovelly.Api/Services/McpOAuthService.cs
@@ -1,0 +1,326 @@
+using System.Security.Cryptography;
+using System.Text;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Glovelly.Api.Services;
+
+public interface IMcpOAuthService
+{
+    McpOAuthClientOptions? FindClient(string clientId);
+    string GetIssuer(HttpRequest request);
+    string GetResource(HttpRequest request);
+    string GetProtectedResourceMetadataUrl(HttpRequest request);
+    string GetAuthorizationServerMetadataUrl(HttpRequest request);
+    Task<McpOAuthAuthorizationCodeResult> CreateAuthorizationCodeAsync(
+        string clientId,
+        Guid userId,
+        string redirectUri,
+        string scope,
+        string resource,
+        string codeChallenge,
+        string codeChallengeMethod,
+        CancellationToken cancellationToken);
+    Task<McpOAuthTokenIssueResult?> RedeemAuthorizationCodeAsync(
+        string code,
+        string clientId,
+        string redirectUri,
+        string codeVerifier,
+        string resource,
+        CancellationToken cancellationToken);
+    Task<McpOAuthTokenIssueResult?> RefreshAccessTokenAsync(
+        string refreshToken,
+        string clientId,
+        string resource,
+        CancellationToken cancellationToken);
+    Task<McpOAuthTokenValidationResult?> ValidateAccessTokenAsync(
+        string accessToken,
+        string resource,
+        CancellationToken cancellationToken);
+}
+
+public sealed class McpOAuthService(
+    AppDbContext db,
+    IOptions<McpOAuthOptions> optionsAccessor) : IMcpOAuthService
+{
+    private const string DefaultScope = "mcp:read";
+
+    private readonly McpOAuthOptions _options = optionsAccessor.Value;
+
+    public McpOAuthClientOptions? FindClient(string clientId)
+    {
+        return _options.Clients.FirstOrDefault(client =>
+            string.Equals(client.ClientId, clientId, StringComparison.Ordinal));
+    }
+
+    public string GetIssuer(HttpRequest request)
+    {
+        return NormalizeBaseUri(_options.Issuer) ?? BuildRequestBaseUri(request);
+    }
+
+    public string GetResource(HttpRequest request)
+    {
+        return NormalizeResourceUri(_options.Resource) ?? $"{BuildRequestBaseUri(request)}/mcp";
+    }
+
+    public string GetProtectedResourceMetadataUrl(HttpRequest request)
+    {
+        return $"{GetResourceOrigin(request)}/.well-known/oauth-protected-resource";
+    }
+
+    public string GetAuthorizationServerMetadataUrl(HttpRequest request)
+    {
+        return $"{GetIssuer(request)}/.well-known/oauth-authorization-server";
+    }
+
+    public async Task<McpOAuthAuthorizationCodeResult> CreateAuthorizationCodeAsync(
+        string clientId,
+        Guid userId,
+        string redirectUri,
+        string scope,
+        string resource,
+        string codeChallenge,
+        string codeChallengeMethod,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var code = GenerateToken();
+        var authorizationCode = new McpOAuthAuthorizationCode
+        {
+            Id = Guid.NewGuid(),
+            CodeHash = HashToken(code),
+            ClientId = clientId,
+            UserId = userId,
+            RedirectUri = redirectUri,
+            Scope = NormalizeScope(scope),
+            Resource = resource,
+            CodeChallenge = codeChallenge,
+            CodeChallengeMethod = codeChallengeMethod,
+            CreatedUtc = now,
+            ExpiresUtc = now.AddMinutes(Math.Max(1, _options.AuthorizationCodeLifetimeMinutes)),
+        };
+
+        db.McpOAuthAuthorizationCodes.Add(authorizationCode);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new McpOAuthAuthorizationCodeResult(code, authorizationCode.ExpiresUtc);
+    }
+
+    public async Task<McpOAuthTokenIssueResult?> RedeemAuthorizationCodeAsync(
+        string code,
+        string clientId,
+        string redirectUri,
+        string codeVerifier,
+        string resource,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var codeHash = HashToken(code);
+        var authorizationCode = await db.McpOAuthAuthorizationCodes
+            .FirstOrDefaultAsync(value => value.CodeHash == codeHash, cancellationToken);
+
+        if (authorizationCode is null ||
+            authorizationCode.ConsumedUtc is not null ||
+            authorizationCode.ExpiresUtc <= now ||
+            !string.Equals(authorizationCode.ClientId, clientId, StringComparison.Ordinal) ||
+            !string.Equals(authorizationCode.RedirectUri, redirectUri, StringComparison.Ordinal) ||
+            !string.Equals(authorizationCode.Resource, resource, StringComparison.Ordinal) ||
+            !ValidatePkce(authorizationCode.CodeChallenge, authorizationCode.CodeChallengeMethod, codeVerifier))
+        {
+            return null;
+        }
+
+        authorizationCode.ConsumedUtc = now;
+        return await IssueTokensAsync(
+            authorizationCode.ClientId,
+            authorizationCode.UserId,
+            authorizationCode.Scope,
+            authorizationCode.Resource,
+            now,
+            cancellationToken);
+    }
+
+    public async Task<McpOAuthTokenIssueResult?> RefreshAccessTokenAsync(
+        string refreshToken,
+        string clientId,
+        string resource,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var tokenHash = HashToken(refreshToken);
+        var storedToken = await db.McpOAuthRefreshTokens
+            .FirstOrDefaultAsync(value => value.TokenHash == tokenHash, cancellationToken);
+
+        if (storedToken is null ||
+            storedToken.RevokedUtc is not null ||
+            storedToken.ExpiresUtc <= now ||
+            !string.Equals(storedToken.ClientId, clientId, StringComparison.Ordinal) ||
+            !string.Equals(storedToken.Resource, resource, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        storedToken.RevokedUtc = now;
+        return await IssueTokensAsync(
+            storedToken.ClientId,
+            storedToken.UserId,
+            storedToken.Scope,
+            storedToken.Resource,
+            now,
+            cancellationToken);
+    }
+
+    public async Task<McpOAuthTokenValidationResult?> ValidateAccessTokenAsync(
+        string accessToken,
+        string resource,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var tokenHash = HashToken(accessToken);
+        var token = await db.McpOAuthAccessTokens
+            .Include(value => value.User)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(value => value.TokenHash == tokenHash, cancellationToken);
+
+        if (token?.User is null ||
+            token.RevokedUtc is not null ||
+            token.ExpiresUtc <= now ||
+            !token.User.IsActive ||
+            !string.Equals(token.Resource, resource, StringComparison.Ordinal) ||
+            !HasScope(token.Scope, DefaultScope))
+        {
+            return null;
+        }
+
+        return new McpOAuthTokenValidationResult(token.User, token.ClientId, token.Scope, token.Resource);
+    }
+
+    private async Task<McpOAuthTokenIssueResult> IssueTokensAsync(
+        string clientId,
+        Guid userId,
+        string scope,
+        string resource,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var accessToken = GenerateToken();
+        var refreshToken = GenerateToken();
+        var accessTokenLifetime = TimeSpan.FromMinutes(Math.Max(1, _options.AccessTokenLifetimeMinutes));
+        var refreshTokenLifetime = TimeSpan.FromDays(Math.Max(1, _options.RefreshTokenLifetimeDays));
+
+        db.McpOAuthAccessTokens.Add(new McpOAuthAccessToken
+        {
+            Id = Guid.NewGuid(),
+            TokenHash = HashToken(accessToken),
+            ClientId = clientId,
+            UserId = userId,
+            Scope = NormalizeScope(scope),
+            Resource = resource,
+            CreatedUtc = now,
+            ExpiresUtc = now.Add(accessTokenLifetime),
+        });
+        db.McpOAuthRefreshTokens.Add(new McpOAuthRefreshToken
+        {
+            Id = Guid.NewGuid(),
+            TokenHash = HashToken(refreshToken),
+            ClientId = clientId,
+            UserId = userId,
+            Scope = NormalizeScope(scope),
+            Resource = resource,
+            CreatedUtc = now,
+            ExpiresUtc = now.Add(refreshTokenLifetime),
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new McpOAuthTokenIssueResult(
+            accessToken,
+            refreshToken,
+            "Bearer",
+            (int)accessTokenLifetime.TotalSeconds,
+            NormalizeScope(scope));
+    }
+
+    public static bool HasScope(string grantedScopes, string requiredScope)
+    {
+        return grantedScopes.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Contains(requiredScope, StringComparer.Ordinal);
+    }
+
+    public static string NormalizeScope(string? scope)
+    {
+        var scopes = (scope ?? DefaultScope)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .ToArray();
+
+        return scopes.Length == 0 ? DefaultScope : string.Join(' ', scopes);
+    }
+
+    public static bool ValidatePkce(string codeChallenge, string codeChallengeMethod, string codeVerifier)
+    {
+        if (!string.Equals(codeChallengeMethod, "S256", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var verifierBytes = Encoding.ASCII.GetBytes(codeVerifier);
+        var challenge = WebEncoders.Base64UrlEncode(SHA256.HashData(verifierBytes));
+        return string.Equals(challenge, codeChallenge, StringComparison.Ordinal);
+    }
+
+    private static string GenerateToken()
+    {
+        return WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+    }
+
+    private static string HashToken(string token)
+    {
+        // MCP OAuth secrets are only compared when presented back to Glovelly, so store one-way hashes.
+        // Google Drive tokens use IDataProtection because Glovelly must recover them to call Google APIs.
+        return WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
+    }
+
+    private static string? NormalizeBaseUri(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim().TrimEnd('/');
+    }
+
+    private static string? NormalizeResourceUri(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim().TrimEnd('/');
+    }
+
+    private static string BuildRequestBaseUri(HttpRequest request)
+    {
+        var scheme = request.Headers["X-Forwarded-Proto"].FirstOrDefault() ?? request.Scheme;
+        var host = request.Headers["X-Forwarded-Host"].FirstOrDefault() ?? request.Host.Value;
+        return $"{scheme}://{host}".TrimEnd('/');
+    }
+
+    private string GetResourceOrigin(HttpRequest request)
+    {
+        var resource = GetResource(request);
+        if (Uri.TryCreate(resource, UriKind.Absolute, out var uri))
+        {
+            return uri.GetLeftPart(UriPartial.Authority).TrimEnd('/');
+        }
+
+        return BuildRequestBaseUri(request);
+    }
+}
+
+public sealed record McpOAuthAuthorizationCodeResult(string Code, DateTimeOffset ExpiresUtc);
+
+public sealed record McpOAuthTokenIssueResult(
+    string AccessToken,
+    string RefreshToken,
+    string TokenType,
+    int ExpiresIn,
+    string Scope);
+
+public sealed record McpOAuthTokenValidationResult(User User, string ClientId, string Scope, string Resource);

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -29,6 +29,16 @@
   "Cors": {
     "AllowedOrigins": []
   },
+  "Mcp": {
+    "OAuth": {
+      "Issuer": "",
+      "Resource": "",
+      "AuthorizationCodeLifetimeMinutes": 5,
+      "AccessTokenLifetimeMinutes": 60,
+      "RefreshTokenLifetimeDays": 30,
+      "Clients": []
+    }
+  },
   "AccessRequests": {
     "PerIpShortWindowPermitLimit": 5,
     "PerIpShortWindow": "00:10:00",

--- a/docs/agent-map.md
+++ b/docs/agent-map.md
@@ -1,0 +1,98 @@
+# Agent Map
+
+This document is a compact orientation map for future agent work. It intentionally summarizes the codebase instead of replacing source-level inspection.
+
+## Runtime Shape
+
+Glovelly runs as one ASP.NET Core process in deployed form. The Vite frontend is built first, copied into the backend `wwwroot`, and served by the API application. In local development, `./run-dev.sh` starts the backend on `http://localhost:5153` and Vite on `http://localhost:5173`.
+
+`Program.cs` is the backend entry point:
+
+1. Build `StartupSettings`.
+2. Register infrastructure and authentication.
+3. Initialize the database.
+4. Configure the HTTP pipeline.
+5. Map metadata, auth, access, Google Drive, MCP, CRUD, and admin endpoints.
+6. Fall back to `index.html` for the SPA.
+
+## Backend Areas
+
+- Configuration: startup settings, auth registration, database provider selection, CORS/Swagger/static file pipeline, and dev seeding.
+- Auth: Google OIDC, local/development helpers, current user extraction, policy names, and MCP development auth.
+- Data: `AppDbContext` owns EF mappings, indexes, precision, delete behavior, data protection keys, and model relationships.
+- Models: mutable EF/domain entities are serialized directly by many endpoints, with navigation properties mostly hidden by `JsonIgnore`.
+- Endpoints: minimal API route groups. Each file maps routes for one area and typically handles validation, authorization context, database calls, and simple response shaping.
+- Services: cross-cutting or multi-step behavior. Use these for workflows that touch email, Google Drive, invoice PDFs, delivery, token protection, storage, or MCP query projection.
+
+## Main Backend Route Groups
+
+- `/auth`: login/logout/session/debug auth flows.
+- `/access`: access request workflow and retention.
+- `/admin`: admin user management.
+- `/clients`: client CRUD plus client-level defaults/settings.
+- `/gigs`: gig CRUD, expense handling, receipt attachment upload/download, invoice draft generation from gigs.
+- `/invoices`: invoice CRUD, status transitions, PDF download, issue/reissue, email delivery, Google Drive delivery, adjustments.
+- `/invoice-lines`: invoice line CRUD.
+- `/seller-profile`: seller profile used for invoice readiness and PDF details.
+- `/google-drive`: Google Drive OAuth/connect/disconnect/configuration flow.
+- `/mcp`: JSON-RPC style MCP endpoint exposing read-only business tools.
+- `/app/metadata`: app/deployment metadata consumed by the frontend.
+
+## Frontend Areas
+
+- `main.tsx`: app bootstrapping and metadata loading.
+- `App.tsx`: session state, active section, top-level data loading, modal wiring, and cross-workspace coordination.
+- `AppSections.tsx`: barrel-style re-export layer for section/modal components and shared app section types.
+- `api.ts`: API URL construction, authenticated fetch helper, session expiration helper, and problem details parsing.
+- `types.ts`: frontend types mirroring backend responses.
+- `forms.ts`: shared form conversion/empty-value helpers.
+- `invoicePreview.ts`: invoice filename/email subject preview helpers and available tokens.
+- `theme.ts`, `useThemePreference.ts`: theme preference state.
+
+Workspace hooks:
+
+- `useClientsWorkspace`: clients list, client CRUD, search, client invoice/mileage settings.
+- `useGigsWorkspace`: gigs list, gig CRUD, expense editing, receipt attachments, multi-select, invoice draft preparation.
+- `useInvoicesWorkspace`: invoices list, invoice status, adjustments, PDF download, email delivery, Google Drive publish.
+- `useQuickReceipt`: quick receipt upload and candidate matching.
+- `useSellerProfile`: seller profile loading/editing.
+- `useUserSettings`: authenticated user defaults and invoice settings.
+- `useAdminWorkspace`: admin user list/create/edit behavior.
+- `useProfileMenu`: profile menu open/close state.
+
+## Data Ownership
+
+User-owned entities generally carry `CreatedByUserId` and `UpdatedByUserId`. Queries for client, gig, invoice, invoice line, and seller profile data should apply existing visibility helpers or equivalent user filtering. Some seed data can have null ownership for development/shared scenarios, so existing `WhereVisibleTo` helpers allow records with null creator IDs.
+
+## Invoice Flow
+
+The central invoice behavior lives in `InvoiceWorkflowService` and `InvoiceEndpoints`.
+
+Common flow:
+
+1. User creates or selects gigs.
+2. Backend generates an invoice draft and system-generated invoice lines from gig fees, mileage, passenger mileage, and expenses.
+3. Invoice can be edited with adjustment lines.
+4. Invoice can be issued or reissued, which updates issue metadata and PDF content.
+5. Invoice can be downloaded, emailed, or uploaded to Google Drive.
+6. Gig records are linked back to the invoice and carry derived `isInvoiced` behavior via `InvoiceId`.
+
+## Receipt Flow
+
+Receipt attachments are modeled under gig expenses. Storage is abstracted through `IExpenseAttachmentStore`; tests use `InMemoryExpenseAttachmentStore`, and production can use Google Cloud Storage. Quick receipt behavior can infer nearby gig candidates, create a draft expense, and later move/update that draft.
+
+## MCP Surface
+
+The MCP endpoint is read-only and user-scoped. It exposes:
+
+- contact search
+- invoice listing
+- invoice details
+- receipt/expense listing
+- business summary totals
+
+Implementation is split between `McpEndpoints.cs` for protocol/tool handling and `GlovellyMcpQueryService.cs` for EF query projection.
+
+## CI and Deploy
+
+GitHub Actions restores .NET dependencies, runs backend tests, builds the Docker image, and deploys internal builds to Cloud Run. Pull requests from the same repository can deploy to the shared staging service and receive a preview URL comment.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,57 @@
+# Conventions
+
+These are the working conventions that save future agents from rediscovering local patterns.
+
+## Backend
+
+- Use minimal API route-group extension methods for new endpoint areas.
+- Put new CRUD routes beside the relevant existing endpoint file.
+- Put multi-step domain workflows in services rather than in `Program.cs` or `AppDbContext`.
+- Keep EF relationship, index, precision, and delete behavior configuration in `AppDbContext`.
+- Use `DateOnly` for business dates such as gig, invoice, and due dates; use `DateTimeOffset` for audit/issue/delivery timestamps.
+- Keep money as `decimal`.
+- Serialize enums as strings where existing code does this; frontend types usually expect string unions.
+- Use `EndpointSupport.WhereVisibleTo(...)` or equivalent owner checks for user-scoped data.
+- Use `EndpointSupport.StampCreate(...)` and `StampUpdate(...)` helpers where they exist.
+- Use `EndpointSupport.ValidateGigRequest(...)`, invoice status transition helpers, filename/subject pattern validation, and gig expense normalization rather than duplicating behavior.
+- Return validation errors through `Results.ValidationProblem(...)` with field names matching frontend form fields.
+- Keep service interfaces small and place them near their implementations when that matches the existing pattern.
+
+## Backend Testing
+
+- Add or update xUnit tests in `backend/Glovelly.Api.Tests`.
+- Prefer integration-style endpoint tests through `GlovellyApiFactory`.
+- Use `TestData` constants for seeded IDs.
+- Use `TestAuthContext` for seeded/authenticated user details.
+- Use `factory.Emails` for email assertions.
+- Add direct service tests when behavior is mostly pure or when endpoint setup would obscure the scenario.
+- Run `dotnet test glovelly.sln -m:1` after backend changes.
+
+## Frontend
+
+- Keep workflow and data state in `src/hooks`.
+- Keep section/modal rendering in `src/components`.
+- Use `App.tsx` for top-level orchestration only: session, active section, app-wide loading/status, and cross-workspace coordination.
+- Use `fetchWithSession` for authenticated API calls.
+- Use `buildApiUrl` for endpoint URLs.
+- Use `parseProblemDetails` for backend validation/problem responses.
+- Treat `SessionExpiredError` and 401 handling consistently with existing hooks.
+- Update `src/types.ts` whenever backend JSON shapes change.
+- Keep form state string-based for numeric inputs where existing forms do so, then parse at submit boundaries.
+- Reuse existing formatter helpers from `formatters.ts`.
+- Preserve the current no-component-library setup unless the user explicitly asks for a UI framework.
+- Run `npm --prefix frontend/glovelly-web run lint` and `npm --prefix frontend/glovelly-web run build` after frontend changes.
+
+## Docs
+
+- Keep `README.md` focused on setup, run, deploy, and broad project context.
+- Keep `docs/domain.md` focused on durable domain concepts.
+- Keep `docs/roadmap.md` current enough that it does not contradict implemented features.
+- Keep agent docs concise. Their job is to point agents at the right source files, not to duplicate implementation details.
+
+## Git and Local Files
+
+- `.glovelly.dev.local` is local and git-ignored; do not edit it unless explicitly asked.
+- Do not commit secrets, user-specific claims, API keys, or connection strings.
+- Do not revert unrelated user changes.
+- Avoid broad refactors when making a targeted fix.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,78 @@
+# MCP
+
+Glovelly exposes a small authenticated MCP-compatible JSON-RPC endpoint at `/mcp`. The surface is read-only and scoped to the signed-in Glovelly user.
+
+## Implementation
+
+- Protocol and tool dispatch: `backend/Glovelly.Api/Endpoints/McpEndpoints.cs`
+- Query/projection logic: `backend/Glovelly.Api/Services/GlovellyMcpQueryService.cs`
+- Tool service registration: `backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs`
+
+The endpoint supports `initialize`, `ping`, `tools/list`, and `tools/call`. It accepts current and legacy MCP protocol version headers and exposes permissive MCP CORS headers.
+
+## Tools
+
+### `glovelly_search_contacts`
+
+Search contacts by name or email.
+
+Arguments:
+
+- `query`: optional string
+
+Returns possible contact matches without guessing.
+
+### `glovelly_list_invoices`
+
+List invoices by optional contact, status, date range, and date basis.
+
+Arguments:
+
+- `contactId`: optional UUID
+- `contactQuery`: optional string. If it matches multiple contacts, the result is marked ambiguous.
+- `status`: optional `all`, `outstanding`, `issued`, `paid`, `draft`, `overdue`, or `cancelled`
+- `fromDate`: optional date
+- `toDate`: optional date
+- `dateBasis`: optional `issueDate` or `dueDate`
+
+Returns invoice summaries plus total outstanding amount.
+
+### `glovelly_get_invoice`
+
+Fetch details for one invoice.
+
+Arguments:
+
+- `invoiceId`: required UUID
+
+Returns invoice details and ordered lines when found.
+
+### `glovelly_list_receipts`
+
+List receipt and expense records.
+
+Arguments:
+
+- `fromDate`: optional date
+- `toDate`: optional date
+- `status`: optional `all`, `matched`, or `unmatched`
+
+Unmatched receipts are expenses with zero amount or descriptions containing `receipt draft`.
+
+### `glovelly_get_business_summary`
+
+Summarise invoice and receipt totals for a date range.
+
+Arguments:
+
+- `fromDate`: optional date
+- `toDate`: optional date
+
+Returns invoice total, paid total, outstanding total, expense total, receipt count, and unmatched receipt count.
+
+## Notes for Agents
+
+- Prefer MCP tools for user business-data questions when they are available in the host environment.
+- Do not use MCP tools for codebase inspection; use the repository files.
+- Add tests in `McpEndpointsTests.cs` when changing protocol/tool dispatch.
+- Add query behavior tests when changing `GlovellyMcpQueryService`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,17 +1,31 @@
 # Roadmap
 
-## In Scope (Now)
+## Implemented
 - Clients
 - Gigs
-- Invoices
-- Generate invoice from gig
+- Gig expenses and receipt attachments
+- Invoices and invoice lines
+- Generate invoice draft from gigs
+- Issue and reissue invoices
+- Download invoice PDFs
+- Send invoices by email
+- Publish invoices to Google Drive
+- Seller profile and invoice readiness
+- Google sign-in and admin user management
+- Access request workflow
+- Read-only MCP tools for contacts, invoices, receipts, and business summaries
+
+## In Scope (Now)
+- Polish invoice workflows and delivery ergonomics
+- Improve receipt capture and expense matching
+- Strengthen frontend test coverage
+- Continue tightening agent-facing docs and conventions
 
 ## Later
-- Email sending
-- Google Drive integration
-- Expenses & mileage
 - Calendar integration
 - Set lists
+- Richer financial reporting
+- More automation around tax prep
 
 ## Not Yet
 - AI chat agent

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,65 @@
+# Testing
+
+This repo currently has backend integration tests and frontend lint/build checks.
+
+## One-Command Verification
+
+From the repo root:
+
+```bash
+./verify.sh
+```
+
+That script runs:
+
+```bash
+dotnet test glovelly.sln -m:1
+npm --prefix frontend/glovelly-web run lint
+npm --prefix frontend/glovelly-web run build
+```
+
+## Backend Tests
+
+Backend tests live in `backend/Glovelly.Api.Tests`.
+
+Important support files:
+
+- `Infrastructure/GlovellyApiFactory.cs`: creates the test host, replaces auth, uses EF in-memory, injects fake email/storage, and resets seeded data for each client.
+- `Infrastructure/TestAuthContext.cs`: default authenticated user identity and claim constants.
+- `Infrastructure/TestData.cs`: seeded client, gig, invoice, and related IDs.
+- `Infrastructure/FakeEmailSender.cs`: fake email sink for assertions.
+- `Infrastructure/TestPolicyEvaluator.cs`: default test authorization bypass.
+
+Run backend tests:
+
+```bash
+dotnet test glovelly.sln -m:1
+```
+
+Use `-m:1` because the test setup uses shared web application factory patterns and in-memory state; serial execution avoids noisy cross-test behavior.
+
+## Frontend Checks
+
+Frontend code lives in `frontend/glovelly-web`.
+
+Run lint:
+
+```bash
+npm --prefix frontend/glovelly-web run lint
+```
+
+Run production build:
+
+```bash
+npm --prefix frontend/glovelly-web run build
+```
+
+There is no dedicated frontend unit/e2e test runner configured yet. For frontend changes, lint and build are the available automated checks.
+
+## What to Add When Changing Behavior
+
+- New backend route: add endpoint tests for success, validation failure, authorization/session behavior when relevant, and user visibility boundaries.
+- New invoice behavior: add tests around generated lines, status transitions, issue/reissue metadata, delivery side effects, and gig linkage.
+- New email behavior: assert fake email count, recipient, subject, and meaningful body/attachment details.
+- New Google Drive behavior: prefer interface-backed tests or endpoint tests with test doubles; avoid real network calls.
+- New frontend API shape: update `src/types.ts`, affected hooks, and run lint/build.

--- a/frontend/glovelly-web/public/sw.js
+++ b/frontend/glovelly-web/public/sw.js
@@ -35,6 +35,7 @@ self.addEventListener('fetch', (event) => {
     requestUrl.pathname.startsWith('/invoices') ||
     requestUrl.pathname.startsWith('/invoice-lines') ||
     requestUrl.pathname.startsWith('/seller-profile') ||
+    requestUrl.pathname.startsWith('/mcp') ||
     requestUrl.pathname === '/app/metadata'
   ) {
     return

--- a/frontend/glovelly-web/vite.config.ts
+++ b/frontend/glovelly-web/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const extraAllowedHosts = (process.env.VITE_ALLOWED_HOSTS ?? '')
+  .split(',')
+  .map((host) => host.trim())
+  .filter(Boolean)
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
+    allowedHosts: ['localhost', ...extraAllowedHosts],
     proxy: {
       '/auth': {
         target: 'http://localhost:5153',
@@ -27,6 +33,10 @@ export default defineConfig({
         changeOrigin: true,
       },
       '/integrations': {
+        target: 'http://localhost:5153',
+        changeOrigin: true,
+      },
+      '/mcp': {
         target: 'http://localhost:5153',
         changeOrigin: true,
       },

--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Running backend tests..."
+dotnet test "$ROOT_DIR/glovelly.sln" -m:1
+
+echo
+echo "Running frontend lint..."
+npm --prefix "$ROOT_DIR/frontend/glovelly-web" run lint
+
+echo
+echo "Running frontend build..."
+npm --prefix "$ROOT_DIR/frontend/glovelly-web" run build
+
+echo
+echo "Verification complete."


### PR DESCRIPTION
## Summary

Adds an experimental read-only MCP endpoint for Glovelly business queries, then layers in a minimal OAuth authorization-code flow so ChatGPT can connect to staging without local no-auth shortcuts.

## What changed

- Added `/mcp` Streamable HTTP-style MCP handling for read-only Glovelly tools.
- Added MCP-compatible CORS, protocol headers, JSON-RPC handling, and development no-auth support for local ChatGPT testing.
- Added MCP OAuth discovery endpoints, authorization-code + PKCE token exchange, refresh tokens, and bearer-token validation scoped to MCP only.
- Added config-driven OAuth clients under `Mcp:OAuth`.
- Persisted MCP authorization codes/access tokens/refresh tokens as one-way hashes.
- Added focused backend coverage for MCP auth, discovery, tool calls, and OAuth bearer access.

## Notes

Google remains the human sign-in provider; Glovelly acts as the OAuth authorization server for MCP clients and issues Glovelly-scoped MCP bearer tokens.

For an existing staging PostgreSQL database, the new MCP OAuth tables will need a schema update path because the app currently uses `EnsureCreated` rather than EF migrations.

## Validation

- `dotnet test glovelly.sln -m:1 --verbosity minimal`
- `dotnet test backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj --verbosity minimal`
- `npm run build` in `frontend/glovelly-web`