### PR TITLE
[codex] Improve expense statement previews and public URL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Glovelly is a personal business platform for managing my self-employed music work.
 
+## Public URLs
+
+- Production site: [https://glovelly.net](https://glovelly.net)
+- Staging site: [https://staging.glovelly.net](https://staging.glovelly.net)
+- Docs site: [https://docs.glovelly.net](https://docs.glovelly.net)
+
 ## Handbook
 
 The repo-owned Glovelly Handbook starts at [docs/index.md](docs/index.md). Use the [UAT and regression section](docs/uat/index.md) for manual pre-merge testing journeys.
@@ -15,7 +21,7 @@ dotnet tool restore
 dotnet tool run docfx docs/docfx.json --serve
 ```
 
-Changes pushed to `main` are published to GitHub Pages at `https://alexhowgego.github.io/glovelly/`.
+Changes pushed to `main` are published to GitHub Pages at `https://docs.glovelly.net`.
 
 ## Current Scope (v1)
 - Gig tracking

--- a/backend/Glovelly.Api.Tests/ClientEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/ClientEndpointsTests.cs
@@ -107,4 +107,41 @@ public sealed class ClientEndpointsTests : IClassFixture<GlovellyApiFactory>
             "Invoice email subject pattern cannot be empty or whitespace.",
             problem.GetProperty("errors").GetProperty("invoiceEmailSubjectPattern")[0].GetString());
     }
+
+    [Fact]
+    public async Task DeleteClient_WhenNoRelatedRecords_DeletesClient()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/clients", new
+        {
+            name = "Delete Ready Client",
+            email = "delete-ready@example.com",
+            billingAddress = new
+            {
+                line1 = "1 Clear Lane",
+                city = "Leeds",
+                country = "United Kingdom",
+            },
+        });
+        createResponse.EnsureSuccessStatusCode();
+        var client = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var clientId = client.GetProperty("id").GetGuid();
+
+        var deleteResponse = await _client.DeleteAsync($"/clients/{clientId}");
+
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, (await _client.GetAsync($"/clients/{clientId}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteClient_WhenInvoiceExists_ReturnsValidationProblem()
+    {
+        var response = await _client.DeleteAsync($"/clients/{TestData.FoxAndFinchId}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Delete the client's invoices before deleting the client.",
+            problem.GetProperty("errors").GetProperty("invoices")[0].GetString());
+    }
 }

--- a/backend/Glovelly.Api.Tests/ExpenseStatementEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/ExpenseStatementEndpointsTests.cs
@@ -125,6 +125,33 @@ public sealed class ExpenseStatementEndpointsTests : IClassFixture<GlovellyApiFa
     }
 
     [Fact]
+    public async Task Preview_AllowsInvoicedGigsForExpenseStatements()
+    {
+        var gig = await CreateGigAsync(
+            "Invoiced statement expenses",
+            "2026-07-08",
+            "Arts Centre",
+            [new("Parking", 9.50m)],
+            TestData.FoxInvoiceId);
+
+        var response = await _client.PostAsJsonAsync("/expense-statements/preview", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            gigIds = new[] { gig.GigId },
+            includeReceiptAttachments = true,
+            includeReceiptAppendix = false,
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var statement = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var statementGig = Assert.Single(statement.GetProperty("gigs").EnumerateArray());
+        Assert.Equal(gig.GigId, statementGig.GetProperty("gigId").GetGuid());
+        Assert.True(statementGig.GetProperty("isInvoiced").GetBoolean());
+        Assert.Equal(9.50m, statement.GetProperty("total").GetDecimal());
+    }
+
+    [Fact]
     public async Task GenerateInvoice_ExcludesReimbursedExpensesByDefault()
     {
         var gig = await CreateGigAsync(

--- a/backend/Glovelly.Api/Endpoints/ClientEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/ClientEndpoints.cs
@@ -97,6 +97,26 @@ public static class ClientEndpoints
                 return Results.NotFound();
             }
 
+            if (await db.Gigs.WhereVisibleTo(userId).AnyAsync(gig => gig.ClientId == id))
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["client"] = ["Delete the client's gigs before deleting the client."]
+                });
+            }
+
+            var hasInvoices = await db.Invoices
+                .WhereVisibleTo(userId)
+                .AnyAsync(invoice => invoice.ClientId == id);
+
+            if (hasInvoices)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["invoices"] = ["Delete the client's invoices before deleting the client."]
+                });
+            }
+
             db.Clients.Remove(client);
             await db.SaveChangesAsync();
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.glovelly.net

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -14,7 +14,8 @@
     "resource": [
       {
         "files": [
-          "assets/**"
+          "assets/**",
+          "CNAME"
         ]
       }
     ],
@@ -38,7 +39,7 @@
       }
     },
     "sitemap": {
-      "baseUrl": "https://alexhowgego.github.io/glovelly/"
+      "baseUrl": "https://docs.glovelly.net/"
     }
   }
 }

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -6,6 +6,10 @@
 - email
 - billingAddress
 
+Client deletion is intentionally narrow: the UI and API block deletion while the
+client has any gig or invoice records. When deletion is available, the user must
+confirm the action before the record is removed.
+
 ## Gig
 - id
 - clientId

--- a/docs/engineering/deployment-pipeline.md
+++ b/docs/engineering/deployment-pipeline.md
@@ -68,7 +68,9 @@ The deployment depends on:
 - Google service accounts for deployment and runtime
 - Google Secret Manager secrets for production runtime values
 - Google Cloud Storage bucket for blob-backed features where configured
-- custom domain mapping for `glovelly.net`, if still applicable
+- custom domain mapping for `glovelly.net`
+- custom domain mapping for `staging.glovelly.net`
+- GitHub Pages custom domain mapping for `docs.glovelly.net`
 
 ## Pull Requests
 
@@ -81,4 +83,4 @@ The Glovelly Handbook is built with DocFX from the Markdown files under `docs/`.
 - `.github/workflows/docs-pr.yml` validates the handbook build on pull requests that touch documentation.
 - `.github/workflows/docs.yml` builds the handbook from `main` and publishes `docs/_site` to GitHub Pages.
 
-The public handbook URL is `https://alexhowgego.github.io/glovelly/`.
+The public handbook URL is `https://docs.glovelly.net`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Glovelly is a personal business platform for self-employed music work. The produ
 
 - [UAT and regression testing](uat/index.md): manual tester journeys for checking the product before release.
 - [Domain notes](domain.md): durable business concepts and vocabulary.
+- [Privacy policy](privacy.md): public privacy notice for Glovelly.
 - [Engineering](engineering/index.md): architecture, authentication, deployment, data, email, and ADR notes.
 - [Testing notes](testing.md): automated and manual verification guidance for engineers.
 - [Codebase map](agent-map.md): compact technical orientation for future agent work.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Glovelly is a personal business platform for self-employed music work. The produ
 - [UAT and regression testing](uat/index.md): manual tester journeys for checking the product before release.
 - [Domain notes](domain.md): durable business concepts and vocabulary.
 - [Privacy policy](privacy.md): public privacy notice for Glovelly.
+- [Application terms](terms.md): public terms of service for Glovelly.
 - [Engineering](engineering/index.md): architecture, authentication, deployment, data, email, and ADR notes.
 - [Testing notes](testing.md): automated and manual verification guidance for engineers.
 - [Codebase map](agent-map.md): compact technical orientation for future agent work.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,228 @@
+# Privacy Policy
+
+Last updated: 19 May 2026
+
+This privacy policy explains how Glovelly handles personal information when you use:
+
+- the production service at `https://glovelly.net`
+- the documentation site at `https://docs.glovelly.net`
+
+Glovelly is a small business administration tool, currently focused on self-employed music work. It is used to manage clients, gigs, expenses, receipts, invoices, seller profile details, invoice delivery, Google Drive invoice publishing, access administration, and related operational records.
+
+Glovelly is intended for business administration. It is not intended for children or consumer social use.
+
+## Who Is Responsible For Your Information
+
+The data controller is:
+
+```text
+Glovelly
+c/o Glovelly Privacy Team
+privacy@glovelly.net
+```
+
+Please use the privacy contact email above for any questions about this policy or about how Glovelly handles personal information.
+
+## Information Glovelly Collects
+
+Glovelly may collect and store the following categories of information.
+
+### Account and Access Information
+
+- Name, email address, and Google account subject identifier used for sign-in.
+- User role, approval status, account status, and access administration records.
+- Access request details, including request timestamps and administrator handling notes where applicable.
+- Authentication session information needed to keep users signed in securely.
+
+### Business Records
+
+- Client names, contact details, billing details, notes, and related business metadata.
+- Gig details such as dates, venues, fees, mileage, passenger counts, and status.
+- Expense details such as descriptions, categories, amounts, tax treatment, reimbursement status, and receipt attachments.
+- Receipt files or images uploaded by users. These may contain personal information visible on the receipt, such as names, partial payment card details, locations, timestamps, or purchase details.
+- Invoice details such as invoice numbers, line items, payment status, issue/reissue history, delivery details, PDF files, and Google Drive publication references.
+- Seller profile details used to generate invoices, such as trading name, address, payment details, invoice defaults, and tax or business identifiers where provided.
+
+### Communications and Delivery Data
+
+- Email addresses used for access workflows and invoice delivery.
+- Email delivery metadata returned by the email provider, such as message identifiers and delivery status where available.
+- Records showing when invoices or access-related emails were generated, sent, retried, delivered, failed, or otherwise processed.
+
+### Google Drive Integration Data
+
+If you connect Google Drive, Glovelly requests permission to create and manage files that it creates in your Google Drive. Glovelly uses this permission to publish generated invoice files to Drive when you request it.
+
+When Google Drive integration is enabled, Glovelly may store:
+
+- Google OAuth connection information, including protected access and refresh tokens.
+- Token expiry and reconnection status.
+- Google Drive file identifiers and file links for uploaded invoice files.
+- Configured Google Drive folder identifiers or related publishing settings.
+- Metadata showing when an invoice was published to Drive and by which user.
+
+Google Drive access can be revoked through your Google Account permissions. If access is revoked, expires, or otherwise stops working, Google Drive publishing will stop until the connection is restored.
+
+### Technical and Security Data
+
+Glovelly and its service providers may process technical and diagnostic information needed to operate, secure, debug, and maintain the service. This may include:
+
+- browser, device, network, request, and diagnostic information
+- IP address or approximate network metadata
+- timestamps
+- authentication, authorisation, and audit-style events
+- application logs and error information
+
+Glovelly aims to avoid logging sensitive business content unnecessarily, but diagnostic records may sometimes contain limited personal information needed to investigate issues or maintain security.
+
+### Documentation Site Data
+
+The documentation site is a static site published through GitHub Pages. GitHub may process limited technical information, such as IP address and request metadata, when serving the site.
+
+Glovelly does not intentionally collect account-level personal information from visitors to the documentation site unless a visitor contacts the controller separately.
+
+## How Glovelly Uses Personal Information
+
+Glovelly uses personal information to:
+
+- provide authenticated access to the service
+- manage users, roles, permissions, and access requests
+- manage clients, gigs, expenses, receipts, invoices, and seller profile settings
+- generate, issue, reissue, publish, and deliver invoices
+- publish invoice files to Google Drive where that integration is configured
+- send transactional emails, such as access request and invoice delivery messages
+- maintain invoice, accounting, tax, and business administration records
+- secure the service and detect misuse
+- maintain, debug, test, and improve the service
+- comply with legal, accounting, tax, and record-keeping obligations
+- respond to requests, questions, and rights exercises
+
+Glovelly does not sell personal information.
+
+## Lawful Bases For Processing
+
+Depending on the context, Glovelly relies on the following lawful bases under UK GDPR.
+
+| Purpose | Likely lawful basis |
+| --- | --- |
+| Providing access to Glovelly and operating core account features | Contract or legitimate interests |
+| Managing clients, gigs, expenses, receipts, invoices, and business records | Contract, legitimate interests, or legal obligation |
+| Creating and retaining invoices and accounting records | Legal obligation and legitimate interests |
+| Sending transactional emails and invoice delivery messages | Contract or legitimate interests |
+| Publishing invoices to Google Drive at the user's request | Contract or legitimate interests |
+| Administering access requests and user permissions | Legitimate interests |
+| Security, abuse prevention, diagnostics, and service maintenance | Legitimate interests |
+| Responding to legal requests or regulatory obligations | Legal obligation |
+
+Where Glovelly relies on legitimate interests, those interests are the operation, administration, security, and improvement of a small business administration service, balanced against the rights and expectations of the people whose information is processed.
+
+Where a user connects an external service such as Google Drive, Glovelly processes the related connection information in order to provide the requested integration.
+
+## Special Category Data
+
+Glovelly is not designed to collect special category data, such as information about health, religion, ethnicity, political opinions, trade union membership, genetic or biometric data, or sexual orientation.
+
+Users should avoid entering special category data into free-text fields, notes, receipt attachments, invoice descriptions, or client records unless there is a clear business need and an appropriate lawful basis has been confirmed.
+
+## Who Personal Information Is Shared With
+
+Glovelly may share or make personal information available to service providers that help run the service, including:
+
+- hosting and infrastructure providers
+- database, storage, backup, logging, and monitoring providers
+- authentication providers, including Google sign-in
+- Google Drive, where Drive publishing is configured
+- email delivery providers
+- GitHub, for source control, GitHub Actions, and GitHub Pages documentation hosting
+- professional advisers, accountants, tax authorities, regulators, or legal bodies where required
+
+Service providers are expected to process personal information only as needed to provide their services, support Glovelly's operation, or meet their own legal obligations.
+
+Current expected subprocessors include:
+
+- Google Cloud Platform, for hosting, infrastructure, managed secrets, and related cloud services
+- Google, for sign-in and Google Drive integration
+- Neon, for database hosting
+- Resend or another configured email delivery provider, for transactional email
+- GitHub, for source control, GitHub Actions, and documentation hosting
+
+This list may change as Glovelly evolves.
+
+## International Transfers
+
+Some service providers may process personal information outside the United Kingdom.
+
+Where this happens, Glovelly relies on appropriate safeguards, which may include UK adequacy regulations, standard contractual clauses, the UK International Data Transfer Agreement or Addendum, or equivalent provider commitments.
+
+## How Long Information Is Kept
+
+Glovelly keeps personal information only for as long as needed for the purposes described in this policy.
+
+Typical retention expectations are:
+
+- account and access records: for the life of the account, then for a reasonable audit and security period after closure
+- Google Drive OAuth tokens and connection data: until the integration is disconnected, expires, is revoked, or the account is deleted, unless limited records are needed for audit or security purposes
+- client, gig, expense, receipt, and invoice records: for as long as needed for business, tax, accounting, and dispute purposes
+- invoice, expense, receipt, and accounting records: normally at least 6 years after the relevant tax year or accounting period, where required for UK tax or accounting records
+- access request records: normally up to 12 months after handling, unless needed for security, audit, or dispute purposes
+- email delivery records: for as long as needed to confirm delivery, investigate delivery issues, or maintain business records
+- logs and diagnostic records: normally for a limited operational period, such as up to 90 days, unless needed for security investigation, debugging, legal, accounting, or dispute purposes
+- documentation site technical records: according to the retention practices of GitHub or other hosting providers used to serve the site
+
+Some information may be retained for longer where required by law, tax rules, accounting obligations, security needs, dispute resolution, or backup retention.
+
+## Security
+
+Glovelly uses technical and organisational measures intended to protect personal information, including authenticated access, role-based controls, secure cookies, owner visibility checks for user-owned data, managed secrets, provider-backed storage, and encryption or token protection where configured.
+
+Google OAuth tokens used for Drive integration are protected before storage where token persistence is enabled.
+
+No online service can guarantee absolute security. Users should keep their Google account secure, use appropriate access controls, and only upload business records that are appropriate for Glovelly to process.
+
+## Your Rights
+
+Depending on the circumstances, individuals may have rights to:
+
+- be informed about how their personal information is used
+- access their personal information
+- correct inaccurate or incomplete information
+- request deletion of information
+- request restriction of processing
+- object to processing based on legitimate interests
+- receive certain information in a portable format
+- withdraw consent, where consent is the lawful basis
+
+Some rights may be limited where Glovelly needs to keep information for legal, accounting, tax, security, audit, or dispute-resolution reasons.
+
+To exercise rights, contact:
+
+```text
+privacy@glovelly.net
+```
+
+## Complaints
+
+Please contact the controller first if you have questions or concerns about how Glovelly handles personal information.
+
+You can also complain to the UK Information Commissioner's Office:
+
+```text
+Information Commissioner's Office
+https://ico.org.uk/make-a-complaint/
+```
+
+## Cookies And Local Storage
+
+Glovelly uses cookies or similar browser storage where needed for authentication, session management, security, and user preferences.
+
+Glovelly does not currently use advertising cookies.
+
+If analytics, embedded media, advertising cookies, or additional tracking tools are added later, this policy should be updated before those tools are enabled.
+
+The documentation site is static. Any cookies or similar technologies used by GitHub Pages or related hosting infrastructure are controlled by those providers.
+
+## Changes To This Policy
+
+This policy may be updated as Glovelly changes. The latest version will be published through Glovelly or its online documentation site.
+
+Material changes may be highlighted in the service or documentation where appropriate.

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,182 @@
+# Application Terms of Service
+
+Last updated: 19 May 2026
+
+These terms apply to use of the Glovelly application at `https://glovelly.net`.
+
+They also apply to related Glovelly documentation and support material at `https://docs.glovelly.net`, unless a page says otherwise.
+
+## Who Operates Glovelly
+
+Glovelly is operated by:
+
+```text
+Glovelly
+c/o Glovelly Support Team
+support@glovelly.net
+```
+
+In these terms, "Glovelly", "we", "us", and "our" refer to the operator. "You" means the person or organisation using Glovelly.
+
+Glovelly is intended for business use by authorised users.
+
+## What Glovelly Is
+
+Glovelly is a small business administration tool, currently focused on self-employed music work. It helps users manage clients, gigs, expenses, receipt attachments, invoice generation, invoice issue and reissue, invoice delivery, seller profile settings, Google Drive invoice publishing, user access, and related business records.
+
+Glovelly is not accounting, tax, financial, legal, or professional advice. You are responsible for checking that records, invoices, tax treatment, and business decisions are accurate and suitable for your circumstances.
+
+## Accounts and Access
+
+You must sign in using an approved Google account. Access may require approval by a Glovelly administrator.
+
+You are responsible for:
+
+- keeping your Google account secure
+- using accurate account information
+- only accessing information you are authorised to access
+- telling us promptly if you believe your account or access has been compromised
+
+We may suspend, restrict, or remove access where needed to protect Glovelly, comply with legal obligations, investigate misuse, or manage authorised users.
+
+## Acceptable Use
+
+You must not use Glovelly to:
+
+- break the law or infringe someone else's rights
+- upload malicious code or attempt to disrupt the service
+- attempt to bypass authentication, authorisation, or owner visibility controls
+- access, alter, or delete information you are not authorised to manage
+- upload content that is unlawful, abusive, misleading, or not reasonably connected to business administration
+- overload, probe, scrape, or reverse engineer the service except where permitted by law
+
+## Your Content and Records
+
+You remain responsible for the business records, files, text, receipt attachments, invoice details, client details, gig details, and other content you enter into Glovelly.
+
+You confirm that you have the rights and permissions needed to upload and process that content in Glovelly.
+
+You give us permission to host, process, copy, generate, transform, transmit, and display your content as needed to provide Glovelly. This includes generating invoice PDFs, storing receipt attachments, sending transactional emails, and publishing files to Google Drive where you configure that integration.
+
+## Accuracy of Business Records
+
+Glovelly can help generate invoices, expense statements, and related business records, but you are responsible for reviewing them before using or sending them.
+
+You are responsible for:
+
+- checking invoice numbers, dates, fees, expenses, tax treatment, payment details, and recipient details
+- deciding whether invoices or expense records should be issued, reissued, sent, deleted, or retained
+- meeting your own accounting, tax, record-keeping, and client obligations
+
+## Google Drive Integration
+
+If you connect Google Drive, you authorise Glovelly to publish generated invoice files to your Google Drive when you request it.
+
+You are responsible for ensuring that any selected Google Drive destination is appropriate and that you have permission to store the relevant invoice files there.
+
+Google Drive integration depends on Google's services, permissions, scopes, and availability. If Google Drive access expires, is revoked, or otherwise stops working, publishing to Google Drive may fail until the connection is restored.
+
+## Third-Party Services
+
+Glovelly may integrate with third-party services, including Google sign-in, Google Drive, email delivery providers, GitHub Pages, hosting, storage, logging, and other infrastructure services.
+
+Third-party services may have their own terms, privacy notices, availability, limits, and security practices. We are not responsible for third-party services outside our reasonable control.
+
+## Documentation
+
+The Glovelly documentation is provided to help users and maintainers understand the service. It may contain technical guidance, testing notes, operational notes, and policy material.
+
+Documentation may change over time. If documentation conflicts with these terms, these terms take priority unless the documentation expressly says otherwise.
+
+## Availability and Changes
+
+We aim to keep Glovelly available and useful, but we do not guarantee uninterrupted or error-free operation.
+
+We may change, suspend, replace, or remove features where reasonably needed for maintenance, security, reliability, legal compliance, or product development.
+
+Where a change materially affects normal use of Glovelly, we will try to give reasonable notice where practical.
+
+## Fees and Payment
+
+Glovelly is currently provided without subscription fees.
+
+If fees, subscriptions, or paid access are introduced later, separate payment terms will be provided before those charges apply.
+
+## Privacy
+
+Our handling of personal information is described in the [Privacy Policy](privacy.md).
+
+## Intellectual Property
+
+Glovelly, its source code, design, documentation, generated templates, and related materials are owned by the operator or licensed to the operator, except for content that belongs to users or third parties.
+
+You may use Glovelly only as permitted by these terms and any applicable licence that applies to the repository or documentation.
+
+You retain ownership of your own business records and uploaded content.
+
+## Confidentiality
+
+Glovelly may contain business information that is private or commercially sensitive, including client details, fees, invoices, receipts, and payment information.
+
+You must not disclose another user's confidential information unless authorised or legally required.
+
+## Ending Access
+
+You may stop using Glovelly at any time.
+
+We may remove or restrict access if:
+
+- you no longer need or are no longer authorised to use Glovelly
+- you breach these terms
+- continued access creates a security, legal, operational, or data protection risk
+- the service is discontinued
+
+Some records may need to be retained after access ends for legal, accounting, tax, audit, security, or dispute-resolution purposes.
+
+## Disclaimers
+
+Glovelly is provided on a reasonable care and skill basis, but it is not a substitute for professional judgement or advice.
+
+To the extent permitted by law, we do not promise that:
+
+- Glovelly will always be available
+- every feature will be error-free
+- generated invoices, statements, reports, or documents will be legally, financially, or tax compliant for your specific situation
+- integrations with third-party providers will always remain available
+
+Nothing in these terms excludes or limits liability where it would be unlawful to do so.
+
+## Liability
+
+We are responsible for losses that cannot legally be excluded or limited.
+
+Subject to that, and to the extent permitted by law, we are not responsible for:
+
+- indirect or consequential loss
+- loss of profit, revenue, goodwill, opportunity, or anticipated savings
+- loss caused by inaccurate user-entered data
+- loss caused by third-party services outside our reasonable control
+- loss caused by unauthorised access resulting from your failure to secure your Google account
+- loss caused by using Glovelly outside its intended business administration purpose
+
+Nothing in these terms limits or excludes liability for death or personal injury caused by negligence, fraud or fraudulent misrepresentation, or any other liability that cannot legally be limited or excluded.
+
+## Changes to These Terms
+
+We may update these terms from time to time. The latest version will be published through Glovelly or its online documentation site.
+
+If a change materially affects your rights or obligations, we will try to give reasonable notice where practical.
+
+## Governing Law
+
+These terms are governed by the laws of England and Wales.
+
+The courts of England and Wales will have jurisdiction, unless applicable law requires otherwise.
+
+## Contact
+
+Questions about these terms should be sent to:
+
+```text
+support@glovelly.net
+```

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -4,6 +4,8 @@
       href: index.md
     - name: Domain notes
       href: domain.md
+    - name: Privacy policy
+      href: privacy.md
     - name: Roadmap
       href: roadmap.md
 - name: Testing and release

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -6,6 +6,8 @@
       href: domain.md
     - name: Privacy policy
       href: privacy.md
+    - name: Application terms
+      href: terms.md
     - name: Roadmap
       href: roadmap.md
 - name: Testing and release

--- a/docs/uat/expenses.md
+++ b/docs/uat/expenses.md
@@ -75,6 +75,14 @@ Expected result: the expense becomes eligible for generated invoice lines again.
 
 The expense statement modal opens, expenses are grouped by gig, reimbursed or not-claimable expenses are visually distinct, and reimbursed expenses are excluded by default.
 
+### Invoiced Gig Selection
+
+1. Identify a gig that already has a linked invoice and at least one expense.
+2. Select it in the Gigs list with another gig for the same client.
+3. Open the expense statement workflow.
+
+Expected result: invoiced gigs remain selectable for expense statements, the statement opens for the same-client selection, and invoice links are not changed.
+
 ### Preview And Download
 
 1. Select the reimbursed expense in the modal.

--- a/docs/uat/expenses.md
+++ b/docs/uat/expenses.md
@@ -82,7 +82,7 @@ The expense statement modal opens, expenses are grouped by gig, reimbursed or no
 3. Preview the PDF.
 4. Download the PDF.
 
-Expected result: selected reimbursed expenses appear in the statement, receipt options affect the generated preview/download, the embedded PDF preview loads in the modal, and the downloaded PDF matches the preview.
+Expected result: selected reimbursed expenses appear in the statement, receipt options affect the generated preview/download, the embedded PDF preview loads in the modal without being pushed out of view by long expense lists, and the downloaded PDF matches the preview.
 
 ### Negative Checks
 

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -73,6 +73,16 @@ These checks guard against unsaved edits being discarded while moving between re
 
 Expected result: unsaved client edits are never discarded without confirmation. Accepted navigation switches the editor to the selected client or a blank new-client form.
 
+### Client Deletion
+
+1. Open Clients and select a client with gigs or invoice history.
+2. Confirm `Delete` is disabled and the helper text explains the blocking records.
+3. Select a client with no gigs and no invoices.
+4. Click `Delete`, decline the confirmation prompt, and confirm the client remains.
+5. Click `Delete` again, accept the confirmation prompt, and confirm the client is removed from the list.
+
+Expected result: clients cannot be deleted silently. Deletion is only available after explicit confirmation and only when the client has no gig or invoice records.
+
 ### Gigs
 
 1. Open Gigs, select a gig, and click `Edit gig`.

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -430,6 +430,10 @@
 .expense-statement-modal {
   display: grid;
   gap: 18px;
+  width: min(100%, 1120px);
+  height: min(100svh - 48px, 860px);
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  overflow: hidden;
 }
 
 .invoice-generation-preview-modal {
@@ -460,8 +464,8 @@
 .expense-statement-preview iframe {
   display: block;
   width: 100%;
-  height: min(62svh, 720px);
-  min-height: 420px;
+  height: 100%;
+  min-height: 0;
   border: 0;
   background: white;
 }
@@ -498,10 +502,31 @@
 }
 
 .expense-statement-options,
+.expense-statement-body,
 .expense-statement-gigs,
 .expense-statement-expenses {
   display: grid;
   gap: 10px;
+}
+
+.expense-statement-body {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.expense-statement-body.has-preview {
+  grid-template-columns: minmax(320px, 0.95fr) minmax(420px, 1.05fr);
+  align-items: stretch;
+}
+
+.expense-statement-body.without-preview {
+  grid-template-columns: 1fr;
+}
+
+.expense-statement-gigs {
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
 }
 
 .expense-statement-gig-header,
@@ -1570,5 +1595,26 @@ button:disabled {
 
   .settings-modal {
     max-height: min(100svh - 28px, 860px);
+  }
+
+  .expense-statement-modal {
+    height: min(100svh - 28px, 860px);
+    overflow: auto;
+  }
+
+  .expense-statement-body,
+  .expense-statement-body.has-preview,
+  .expense-statement-body.without-preview {
+    grid-template-columns: 1fr;
+    overflow: visible;
+  }
+
+  .expense-statement-gigs {
+    max-height: 38svh;
+  }
+
+  .expense-statement-preview iframe {
+    height: 55svh;
+    min-height: 320px;
   }
 }

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1164,6 +1164,12 @@
   color: var(--muted);
 }
 
+.delete-helper {
+  margin: -4px 0 14px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .link-button {
   border: 0;
   padding: 0;

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -581,6 +581,56 @@ function App({ appMetadata }: AppProps) {
     return `${monthlyInvoiceEligibleGigs.length} eligible gig(s) ready to invoice for ${selectedClient.name} in ${monthlyInvoiceMonth}.`
   })()
 
+  const clientDeleteEligibility = useMemo(() => {
+    if (!selectedClient) {
+      return {
+        canDelete: false,
+        helperText: 'Select a client before deleting.',
+      }
+    }
+
+    const relatedGigs = gigs.filter((gig) => gig.clientId === selectedClient.id)
+    if (relatedGigs.length > 0) {
+      return {
+        canDelete: false,
+        helperText: `Delete disabled: ${selectedClient.name} has ${relatedGigs.length} gig record(s).`,
+      }
+    }
+
+    const relatedInvoices = invoices.filter(
+      (invoice) => invoice.clientId === selectedClient.id
+    )
+
+    if (relatedInvoices.length > 0) {
+      return {
+        canDelete: false,
+        helperText: `Delete disabled: ${selectedClient.name} has ${relatedInvoices.length} invoice record(s).`,
+      }
+    }
+
+    return {
+      canDelete: true,
+      helperText: `Delete ${selectedClient.name} after confirmation.`,
+    }
+  }, [gigs, invoices, selectedClient])
+
+  const handleClientDelete = () => {
+    if (!selectedClient) {
+      return
+    }
+
+    if (!clientDeleteEligibility.canDelete) {
+      setStatus(clientDeleteEligibility.helperText)
+      return
+    }
+
+    if (!window.confirm(`Delete ${selectedClient.name}? This cannot be undone.`)) {
+      return
+    }
+
+    void handleDelete()
+  }
+
   const openSelectedGigInvoice = () => {
     if (!selectedGig?.invoiceId) {
       return
@@ -1260,6 +1310,8 @@ function App({ appMetadata }: AppProps) {
       <ClientsSection
         filteredClients={filteredClients}
         form={form}
+        canDeleteSelectedClient={clientDeleteEligibility.canDelete}
+        clientDeleteHelperText={clientDeleteEligibility.helperText}
         isApiConnected={isApiConnected}
         isEditorOpen={isClientEditorOpen}
         isMonthlyInvoiceReady={isMonthlyInvoiceReady}
@@ -1269,7 +1321,7 @@ function App({ appMetadata }: AppProps) {
         monthlyInvoiceMonth={monthlyInvoiceMonth}
         mode={mode}
         onCloseEditor={closeClientEditor}
-        onDelete={handleDelete}
+        onDelete={handleClientDelete}
         onGenerateMonthlyInvoice={handleGenerateMonthlyInvoice}
         onMonthlyInvoiceMonthChange={setMonthlyInvoiceMonth}
         onOpenClientSettings={openClientSettings}

--- a/frontend/glovelly-web/src/components/ClientsSection.tsx
+++ b/frontend/glovelly-web/src/components/ClientsSection.tsx
@@ -4,6 +4,8 @@ import type { Client, ClientForm } from '../types'
 type ClientsSectionProps = {
   filteredClients: Client[]
   form: ClientForm
+  canDeleteSelectedClient: boolean
+  clientDeleteHelperText: string
   isApiConnected: boolean
   isEditorOpen: boolean
   isMonthlyInvoiceReady: boolean
@@ -32,6 +34,8 @@ type ClientsSectionProps = {
 export function ClientsSection({
   filteredClients,
   form,
+  canDeleteSelectedClient,
+  clientDeleteHelperText,
   isApiConnected,
   isEditorOpen,
   isMonthlyInvoiceReady,
@@ -142,7 +146,8 @@ export function ClientsSection({
                 className="danger-button"
                 onClick={onDelete}
                 type="button"
-                disabled={!selectedClient || isLoading}
+                disabled={!canDeleteSelectedClient || isLoading}
+                title={clientDeleteHelperText}
               >
                 Delete
               </button>
@@ -151,6 +156,7 @@ export function ClientsSection({
 
           {selectedClient ? (
             <>
+              <p className="delete-helper">{clientDeleteHelperText}</p>
               <div className="gig-timeline-note">
                 <p className="detail-label">Monthly invoice run</p>
                 <div className="invoice-adjustment-form">

--- a/frontend/glovelly-web/src/components/ExpenseStatementModal.tsx
+++ b/frontend/glovelly-web/src/components/ExpenseStatementModal.tsx
@@ -104,45 +104,51 @@ export function ExpenseStatementModal({
           </label>
         </div>
 
-        <div className="expense-statement-gigs">
-          {gigs.map((gig) => (
-            <section className="expense-statement-gig" key={gig.id}>
-              <div className="expense-statement-gig-header">
-                <div>
-                  <strong>{gig.title}</strong>
-                  <span>
-                    {formatDate(gig.date)} · {gig.venue}
-                  </span>
+        <div
+          className={`expense-statement-body ${
+            previewPdfUrl ? 'has-preview' : 'without-preview'
+          }`}
+        >
+          <div className="expense-statement-gigs">
+            {gigs.map((gig) => (
+              <section className="expense-statement-gig" key={gig.id}>
+                <div className="expense-statement-gig-header">
+                  <div>
+                    <strong>{gig.title}</strong>
+                    <span>
+                      {formatDate(gig.date)} · {gig.venue}
+                    </span>
+                  </div>
+                  {gig.isInvoiced && <span className="expense-status-badge">Invoiced</span>}
                 </div>
-                {gig.isInvoiced && <span className="expense-status-badge">Invoiced</span>}
-              </div>
 
-              {gig.expenses.length > 0 ? (
-                <div className="expense-statement-expenses">
-                  {gig.expenses
-                    .slice()
-                    .sort((left, right) => left.sortOrder - right.sortOrder)
-                    .map((expense) => (
-                      <ExpenseStatementExpenseRow
-                        expense={expense}
-                        isSelected={selectedExpenseIdSet.has(expense.id)}
-                        key={expense.id}
-                        onToggleExpense={onToggleExpense}
-                      />
-                    ))}
-                </div>
-              ) : (
-                <p className="attachment-helper">No expenses recorded for this gig.</p>
-              )}
-            </section>
-          ))}
-        </div>
-
-        {previewPdfUrl && (
-          <div className="expense-statement-preview">
-            <iframe src={previewPdfUrl} title="Expense statement PDF preview" />
+                {gig.expenses.length > 0 ? (
+                  <div className="expense-statement-expenses">
+                    {gig.expenses
+                      .slice()
+                      .sort((left, right) => left.sortOrder - right.sortOrder)
+                      .map((expense) => (
+                        <ExpenseStatementExpenseRow
+                          expense={expense}
+                          isSelected={selectedExpenseIdSet.has(expense.id)}
+                          key={expense.id}
+                          onToggleExpense={onToggleExpense}
+                        />
+                      ))}
+                  </div>
+                ) : (
+                  <p className="attachment-helper">No expenses recorded for this gig.</p>
+                )}
+              </section>
+            ))}
           </div>
-        )}
+
+          {previewPdfUrl && (
+            <div className="expense-statement-preview">
+              <iframe src={previewPdfUrl} title="Expense statement PDF preview" />
+            </div>
+          )}
+        </div>
 
         <div className="expense-statement-footer">
           <span className="status-pill">

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -117,6 +117,7 @@ export function GigsSection({
     (selectedGig ? clientNamesById.get(selectedGig.clientId) : null) ?? 'Unknown client'
   const selectedClientId = selectedGigs[0]?.clientId ?? null
   const hasCrossClientSelection = new Set(selectedGigs.map((gig) => gig.clientId)).size > 1
+  const hasInvoicedSelection = selectedGigs.some((gig) => gig.isInvoiced)
 
   return (
     <section className="section-layout">
@@ -164,7 +165,7 @@ export function GigsSection({
                 Boolean(selectedClientId) &&
                 selectedClientId !== gig.clientId &&
                 !selectedGigIds.includes(gig.id)
-              const isSelectionDisabled = gig.isInvoiced || isDifferentSelectedClient
+              const isSelectionDisabled = isDifferentSelectedClient
 
               return (
                 <button
@@ -230,6 +231,7 @@ export function GigsSection({
                   (selectedGigIds.length === 0 &&
                     (!selectedGig || selectedGig.isInvoiced)) ||
                   hasCrossClientSelection
+                  || hasInvoicedSelection
                 }
               >
                 {selectedGigIds.length > 0
@@ -359,7 +361,9 @@ export function GigsSection({
                   <span>
                     {hasCrossClientSelection
                       ? ' Selected gigs need to belong to the same client before they can be invoiced together.'
-                      : ` ${selectedGigIds.length} gig(s) selected for a combined invoice.`}
+                      : hasInvoicedSelection
+                        ? ` ${selectedGigIds.length} gig(s) selected. Invoiced gigs can be used for expense statements, but not new invoices.`
+                        : ` ${selectedGigIds.length} gig(s) selected for a combined invoice or expense statement.`}
                   </span>
                 )}
                 <button

--- a/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
@@ -334,7 +334,12 @@ export function useClientsWorkspace({
       }
 
       if (!response.ok) {
-        throw new Error('Delete failed.')
+        const problem = await parseProblemDetails(response)
+        const validationMessages = problem?.errors
+          ? Object.values(problem.errors).flat().join(' ')
+          : problem?.detail ?? problem?.title
+
+        throw new Error(validationMessages || 'Delete failed.')
       }
 
       let nextSelectedClientId = ''
@@ -350,8 +355,10 @@ export function useClientsWorkspace({
       setForm(emptyForm())
       setStatus('Client deleted.')
       setIsClientEditorOpen(false)
-    } catch {
-      setStatus('Unable to delete right now.')
+    } catch (error) {
+      setStatus(
+        error instanceof Error ? error.message : 'Unable to delete right now.'
+      )
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
## Summary

- Adds a dedicated expense statement preview content region and related UI refinements.
- Allows already-invoiced gigs to be selected where needed and shores up client deletion behavior.
- Updates docs and UAT coverage for expense statements, client deletion, and public Glovelly URLs.
- Adds the persistent public URL set to the README and points DocFX/GitHub Pages output at `https://docs.glovelly.net` with a `CNAME` resource.

## Impact

The app gets more robust expense statement/client workflows, and the repository landing page now exposes the stable production, staging, and documentation URLs:

- Production: `https://glovelly.net`
- Staging: `https://staging.glovelly.net`
- Docs: `https://docs.glovelly.net`

## Validation

- `dotnet test glovelly.sln -m:1` - 139 passed
- `npm --prefix frontend/glovelly-web run lint`
- `dotnet tool run docfx docs/docfx.json` - 0 warnings, 0 errors