### PR TITLE
[codex] Add Google Routes mileage estimation and docs links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,7 @@ jobs:
             Email__Resend__ApiKey=glovelly-resend-api-key:latest
             Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest
             Email__Invoices__FromAddress=glovelly-invoices-from-address:latest
+            Mileage__GoogleRoutes__ApiKey=glovelly-routes-api-key:latest
             Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest
             Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest
             Mcp__OAuth__Clients__0__RedirectUris__0=${{ vars.GCP_CHATGPT_REDIRECT_SECRET_ID }}:latest

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ export Email__Invoices__FromDisplayName="Glovelly Invoices"
 
 `run-dev.sh` sources this file automatically before starting the backend. The admin user is only seeded when no `ConnectionStrings:Glovelly` value is configured and Glovelly is using the in-memory development database.
 
-Keep secrets such as `Email__Resend__ApiKey` out of `.glovelly.dev.local`. Store those with `dotnet user-secrets` instead.
+Keep secrets such as `Email__Resend__ApiKey` and `Mileage__GoogleRoutes__ApiKey` out of `.glovelly.dev.local`. Store those with `dotnet user-secrets` instead.
 
 #### Finding your Google subject claim locally
 
@@ -101,6 +101,7 @@ dotnet user-secrets set "Authentication:Google:ClientId" "your-client-id"
 dotnet user-secrets set "Authentication:Google:ClientSecret" "your-client-secret"
 dotnet user-secrets set "ConnectionStrings:Glovelly" "your-postgresql-connection-string"
 dotnet user-secrets set "Email:Resend:ApiKey" "your-resend-api-key"
+dotnet user-secrets set "Mileage:GoogleRoutes:ApiKey" "your-google-routes-api-key"
 ```
 
 4. To make outbound email work locally with Resend, also add these non-secret values to `.glovelly.dev.local`:
@@ -118,6 +119,7 @@ export Email__Invoices__FromDisplayName="Glovelly Invoices"
    - `Authentication__Google__ClientSecret`
    - `ConnectionStrings__Glovelly`
    - `Email__Resend__ApiKey`
+   - `Mileage__GoogleRoutes__ApiKey`
    - `Email__Mode`
    - `Email__AccessRequests__FromAddress`
    - `Email__AccessRequests__FromDisplayName`
@@ -125,6 +127,17 @@ export Email__Invoices__FromDisplayName="Glovelly Invoices"
    - `Email__Invoices__FromDisplayName`
 
 The frontend signs users in through `/auth/login`, the backend completes the Google OpenID Connect flow, and the app stores the session in a secure cookie before allowing access to `/clients`, `/gigs`, `/invoices`, and `/invoice-lines`.
+
+### Google Routes mileage estimates
+
+Glovelly can estimate gig mileage from the seller profile postcode to the gig location using Google Routes API. The API key is a secret and should be stored with `dotnet user-secrets` locally:
+
+```bash
+cd backend/Glovelly.Api
+dotnet user-secrets set "Mileage:GoogleRoutes:ApiKey" "your-google-routes-api-key"
+```
+
+Non-secret local defaults are shown in `appsettings.Development.json`. In deployed environments, provide the key through Secret Manager or an equivalent secret-backed environment variable named `Mileage__GoogleRoutes__ApiKey`.
 
 Press `Ctrl+C` to stop both services.
 

--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -40,6 +40,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
+            travelOriginPostcode = "BS1 1AA",
             defaultPaymentWindowDays = 30,
             invoiceFilenamePattern = "{MonthName} {Year} {InvoiceNumber}",
             invoiceEmailSubjectPattern = "{ClientName} invoice {InvoiceNumber}",
@@ -61,6 +62,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(
             "billing@example.com",
             payload.GetProperty("invoiceReplyToEmail").GetString());
+        Assert.Equal("BS1 1AA", payload.GetProperty("travelOriginPostcode").GetString());
         Assert.Equal(30, payload.GetProperty("defaultPaymentWindowDays").GetInt32());
         Assert.False(payload.GetProperty("isGoogleDriveConnected").GetBoolean());
     }
@@ -165,6 +167,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
+            travelOriginPostcode = "  BS2 2BB  ",
             defaultPaymentWindowDays = 21,
             invoiceFilenamePattern = "  {ClientName} {InvoiceNumber}  ",
             invoiceEmailSubjectPattern = "  Invoice {InvoiceNumber} for {ClientName}  ",
@@ -183,6 +186,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(
             "accounts@example.com",
             payload.GetProperty("invoiceReplyToEmail").GetString());
+        Assert.Equal("BS2 2BB", payload.GetProperty("travelOriginPostcode").GetString());
         Assert.Equal(21, payload.GetProperty("defaultPaymentWindowDays").GetInt32());
 
         using var scope = _factory.Services.CreateScope();
@@ -193,7 +197,28 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal("{ClientName} {InvoiceNumber}", savedUser.InvoiceFilenamePattern);
         Assert.Equal("Invoice {InvoiceNumber} for {ClientName}", savedUser.InvoiceEmailSubjectPattern);
         Assert.Equal("accounts@example.com", savedUser.InvoiceReplyToEmail);
+        Assert.Equal("BS2 2BB", savedUser.TravelOriginPostcode);
         Assert.Equal(21, savedUser.DefaultPaymentWindowDays);
+    }
+
+    [Fact]
+    public async Task UpdateSettings_WithTooLongTravelOriginPostcode_ReturnsValidationProblem()
+    {
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            travelOriginPostcode = "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            invoiceFilenamePattern = "{InvoiceNumber}",
+            invoiceReplyToEmail = (string?)null,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(
+            "Travel origin postcode must be 20 characters or fewer.",
+            problem.GetProperty("errors").GetProperty("travelOriginPostcode")[0].GetString());
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -212,6 +212,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
                 originPostcode = "M1 1AA",
                 originCountry = "GB",
                 destination = "Arena",
+                destinationPlaceId = "ChIJN1t_tDeuEmsRUsoyG83frY4",
                 roundTrip = false,
             });
 
@@ -219,6 +220,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.NotNull(_factory.MileageEstimation.LastRequest);
         Assert.Equal("M1 1AA, GB", _factory.MileageEstimation.LastRequest!.Origin);
         Assert.Equal("Arena", _factory.MileageEstimation.LastRequest.Destination);
+        Assert.Equal("ChIJN1t_tDeuEmsRUsoyG83frY4", _factory.MileageEstimation.LastRequest.DestinationPlaceId);
         Assert.False(_factory.MileageEstimation.LastRequest.RoundTrip);
     }
 

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -179,6 +179,58 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task EstimateMileage_UsesUserTravelOriginBeforeSellerProfilePostcode()
+    {
+        await SaveSellerProfileAsync();
+
+        var settingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            mileageRate = 0.45m,
+            passengerMileageRate = 0.10m,
+            travelOriginPostcode = "  BS9 9ZZ  ",
+            defaultPaymentWindowDays = 14,
+            invoiceFilenamePattern = "{InvoiceNumber}",
+            invoiceReplyToEmail = (string?)null,
+        });
+        settingsResponse.EnsureSuccessStatusCode();
+
+        _factory.MileageEstimation.Result = Glovelly.Api.Services.MileageEstimateResult.Success(
+            distanceMeters: 16093.44m,
+            durationSeconds: 1200,
+            originLabel: "BS9 9ZZ, United Kingdom",
+            destinationLabel: "Town Hall",
+            provider: "test-routes",
+            calculatedAtUtc: new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero));
+
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "User origin estimate gig",
+            date = "2026-06-05",
+            venue = "Town Hall",
+            fee = 200.00m,
+            travelMiles = 0m,
+            notes = "Use user origin",
+            wasDriving = true,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        createResponse.EnsureSuccessStatusCode();
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/gigs/{createdGig.GetProperty("id").GetGuid()}/mileage-estimate",
+            new
+            {
+                roundTrip = true,
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(_factory.MileageEstimation.LastRequest);
+        Assert.Equal("BS9 9ZZ, United Kingdom", _factory.MileageEstimation.LastRequest!.Origin);
+    }
+
+    [Fact]
     public async Task EstimateMileage_WithRequestOriginAndDestination_OverridesDefaults()
     {
         _factory.MileageEstimation.Result = Glovelly.Api.Services.MileageEstimateResult.Success(

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -10,10 +10,12 @@ namespace Glovelly.Api.Tests;
 public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly GlovellyApiFactory _factory;
     private readonly HttpClient _client;
 
     public GigEndpointsTests(GlovellyApiFactory factory)
     {
+        _factory = factory;
         _client = factory.CreateClient();
     }
 
@@ -122,6 +124,163 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
 
         Assert.Equal(JsonValueKind.Object, problem.ValueKind);
         Assert.Equal("Invoice client must match the gig client.", problem.GetProperty("errors").GetProperty("invoiceId")[0].GetString());
+    }
+
+    [Fact]
+    public async Task EstimateMileage_UsesSellerProfileOriginAndGigVenue()
+    {
+        await SaveSellerProfileAsync();
+
+        _factory.MileageEstimation.Result = Glovelly.Api.Services.MileageEstimateResult.Success(
+            distanceMeters: 19955.8656m,
+            durationSeconds: 1840,
+            originLabel: "BS1 1AA, United Kingdom",
+            destinationLabel: "Town Hall",
+            provider: "test-routes",
+            calculatedAtUtc: new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero));
+
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Mileage estimate gig",
+            date = "2026-06-05",
+            venue = "Town Hall",
+            fee = 200.00m,
+            travelMiles = 0m,
+            notes = "Use venue fallback",
+            wasDriving = true,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        createResponse.EnsureSuccessStatusCode();
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/gigs/{createdGig.GetProperty("id").GetGuid()}/mileage-estimate",
+            new
+            {
+                roundTrip = true,
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var estimate = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        Assert.Equal(12.4m, estimate.GetProperty("distanceMiles").GetDecimal());
+        Assert.Equal(19955.8656m, estimate.GetProperty("distanceMeters").GetDecimal());
+        Assert.Equal(1840, estimate.GetProperty("durationSeconds").GetInt32());
+        Assert.True(estimate.GetProperty("roundTrip").GetBoolean());
+        Assert.Equal("test-routes", estimate.GetProperty("provider").GetString());
+
+        Assert.NotNull(_factory.MileageEstimation.LastRequest);
+        Assert.Equal("BS1 1AA, United Kingdom", _factory.MileageEstimation.LastRequest!.Origin);
+        Assert.Equal("Town Hall", _factory.MileageEstimation.LastRequest.Destination);
+        Assert.True(_factory.MileageEstimation.LastRequest.RoundTrip);
+    }
+
+    [Fact]
+    public async Task EstimateMileage_WithRequestOriginAndDestination_OverridesDefaults()
+    {
+        _factory.MileageEstimation.Result = Glovelly.Api.Services.MileageEstimateResult.Success(
+            distanceMeters: 32186.88m,
+            durationSeconds: null,
+            originLabel: "M1 1AA, GB",
+            destinationLabel: "Arena",
+            provider: "test-routes",
+            calculatedAtUtc: new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero));
+
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Manual destination estimate",
+            date = "2026-06-06",
+            venue = "Town Hall",
+            fee = 200.00m,
+            travelMiles = 0m,
+            notes = "Override destination",
+            wasDriving = true,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        createResponse.EnsureSuccessStatusCode();
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/gigs/{createdGig.GetProperty("id").GetGuid()}/mileage-estimate",
+            new
+            {
+                originPostcode = "M1 1AA",
+                originCountry = "GB",
+                destination = "Arena",
+                roundTrip = false,
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(_factory.MileageEstimation.LastRequest);
+        Assert.Equal("M1 1AA, GB", _factory.MileageEstimation.LastRequest!.Origin);
+        Assert.Equal("Arena", _factory.MileageEstimation.LastRequest.Destination);
+        Assert.False(_factory.MileageEstimation.LastRequest.RoundTrip);
+    }
+
+    [Fact]
+    public async Task EstimateMileage_WhenProviderFails_ReturnsServiceUnavailable()
+    {
+        _factory.MileageEstimation.Result = Glovelly.Api.Services.MileageEstimateResult.Failure(
+            "quota_exceeded",
+            "Mileage provider quota was exceeded.",
+            "test-routes");
+
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Provider failure estimate",
+            date = "2026-06-07",
+            venue = "Town Hall",
+            fee = 200.00m,
+            travelMiles = 0m,
+            notes = "Provider failure",
+            wasDriving = true,
+            status = 1,
+            invoicedAt = (string?)null,
+        });
+        createResponse.EnsureSuccessStatusCode();
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/gigs/{createdGig.GetProperty("id").GetGuid()}/mileage-estimate",
+            new
+            {
+                originPostcode = "BS1 1AA",
+                originCountry = "GB",
+            });
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal("Mileage provider quota was exceeded.", problem.GetProperty("detail").GetString());
+        Assert.Equal("quota_exceeded", problem.GetProperty("code").GetString());
+    }
+
+    private async Task SaveSellerProfileAsync()
+    {
+        var response = await _client.PutAsJsonAsync("/seller-profile", new
+        {
+            sellerName = "Test Seller",
+            addressLine1 = "1 Test Street",
+            addressLine2 = (string?)null,
+            city = "Bristol",
+            region = (string?)null,
+            postcode = "BS1 1AA",
+            country = "United Kingdom",
+            email = "seller@glovelly.test",
+            phone = (string?)null,
+            accountName = (string?)null,
+            sortCode = (string?)null,
+            accountNumber = (string?)null,
+            paymentReferenceNote = (string?)null,
+        });
+
+        response.EnsureSuccessStatusCode();
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/GoogleRoutesMileageEstimationServiceTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleRoutesMileageEstimationServiceTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Glovelly.Api.Services;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class GoogleRoutesMileageEstimationServiceTests
+{
+    [Fact]
+    public async Task EstimateAsync_SendsRouteMatrixRequestAndReturnsRoundTripEstimate()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
+        var service = CreateService(async (request, cancellationToken) =>
+        {
+            capturedRequest = request;
+            capturedBody = await request.Content!.ReadAsStringAsync(cancellationToken);
+
+            return JsonResponse("""
+                [
+                  {
+                    "originIndex": 0,
+                    "destinationIndex": 0,
+                    "condition": "ROUTE_EXISTS",
+                    "distanceMeters": 10000,
+                    "duration": "123s"
+                  }
+                ]
+                """);
+        });
+
+        var result = await service.EstimateAsync(new MileageEstimateRequest(
+            "BS1 1AA, GB",
+            "Town Hall, Bristol",
+            RoundTrip: true));
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(20000m, result.DistanceMeters);
+        Assert.Equal(246, result.DurationSeconds);
+        Assert.Equal("BS1 1AA, GB", result.OriginLabel);
+        Assert.Equal("Town Hall, Bristol", result.DestinationLabel);
+        Assert.Equal("google-routes", result.Provider);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(HttpMethod.Post, capturedRequest!.Method);
+        Assert.Equal("https://routes.test/computeRouteMatrix", capturedRequest.RequestUri!.ToString());
+        Assert.True(capturedRequest.Headers.TryGetValues("X-Goog-Api-Key", out var apiKeyValues));
+        Assert.Equal("test-api-key", Assert.Single(apiKeyValues));
+        Assert.True(capturedRequest.Headers.TryGetValues("X-Goog-FieldMask", out var fieldMaskValues));
+        Assert.Equal(
+            "originIndex,destinationIndex,duration,distanceMeters,status,condition",
+            Assert.Single(fieldMaskValues));
+
+        using var document = JsonDocument.Parse(capturedBody!);
+        var root = document.RootElement;
+        Assert.Equal("DRIVE", root.GetProperty("travelMode").GetString());
+        Assert.Equal("TRAFFIC_UNAWARE", root.GetProperty("routingPreference").GetString());
+        Assert.Equal(
+            "BS1 1AA, GB",
+            root.GetProperty("origins")[0].GetProperty("waypoint").GetProperty("address").GetString());
+        Assert.Equal(
+            "Town Hall, Bristol",
+            root.GetProperty("destinations")[0].GetProperty("waypoint").GetProperty("address").GetString());
+    }
+
+    [Fact]
+    public async Task EstimateAsync_WhenApiKeyMissing_DoesNotCallGoogle()
+    {
+        var wasCalled = false;
+        var service = CreateService(
+            (_, _) =>
+            {
+                wasCalled = true;
+                return Task.FromResult(JsonResponse("[]"));
+            },
+            apiKey: null);
+
+        var result = await service.EstimateAsync(new MileageEstimateRequest(
+            "BS1 1AA",
+            "Town Hall",
+            RoundTrip: false));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("google_routes_not_configured", result.FailureCode);
+        Assert.False(wasCalled);
+    }
+
+    [Fact]
+    public async Task EstimateAsync_WithDestinationPlaceId_SendsPlaceIdWaypoint()
+    {
+        string? capturedBody = null;
+        var service = CreateService(async (request, cancellationToken) =>
+        {
+            capturedBody = await request.Content!.ReadAsStringAsync(cancellationToken);
+            return JsonResponse("""
+                [
+                  {
+                    "originIndex": 0,
+                    "destinationIndex": 0,
+                    "condition": "ROUTE_EXISTS",
+                    "distanceMeters": 10000,
+                    "duration": "123s"
+                  }
+                ]
+                """);
+        });
+
+        var result = await service.EstimateAsync(new MileageEstimateRequest(
+            "BS1 1AA, GB",
+            "Town Hall, Bristol",
+            RoundTrip: false,
+            DestinationPlaceId: "ChIJN1t_tDeuEmsRUsoyG83frY4"));
+
+        Assert.True(result.IsSuccess);
+
+        using var document = JsonDocument.Parse(capturedBody!);
+        var destinationWaypoint = document.RootElement
+            .GetProperty("destinations")[0]
+            .GetProperty("waypoint");
+        Assert.Equal("ChIJN1t_tDeuEmsRUsoyG83frY4", destinationWaypoint.GetProperty("placeId").GetString());
+        Assert.False(destinationWaypoint.TryGetProperty("address", out _));
+    }
+
+    [Fact]
+    public async Task EstimateAsync_WhenRouteNotFound_ReturnsProviderFailure()
+    {
+        var service = CreateService((_, _) => Task.FromResult(JsonResponse("""
+            [
+              {
+                "originIndex": 0,
+                "destinationIndex": 0,
+                "condition": "ROUTE_NOT_FOUND",
+                "status": {
+                  "code": 5,
+                  "message": "No route found."
+                }
+              }
+            ]
+            """)));
+
+        var result = await service.EstimateAsync(new MileageEstimateRequest(
+            "BS1 1AA",
+            "Somewhere",
+            RoundTrip: false));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("google_routes_route_not_found", result.FailureCode);
+        Assert.Equal("No route found.", result.FailureMessage);
+    }
+
+    [Fact]
+    public async Task EstimateAsync_WhenGoogleReturnsHttpError_ReturnsProviderFailure()
+    {
+        var service = CreateService((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("forbidden", Encoding.UTF8, "text/plain"),
+        }));
+
+        var result = await service.EstimateAsync(new MileageEstimateRequest(
+            "BS1 1AA",
+            "Town Hall",
+            RoundTrip: false));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("google_routes_http_403", result.FailureCode);
+    }
+
+    private static GoogleRoutesMileageEstimationService CreateService(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler,
+        string? apiKey = "test-api-key")
+    {
+        var httpClient = new HttpClient(new StubHttpMessageHandler(handler));
+        var settings = Options.Create(new GoogleRoutesMileageSettings
+        {
+            ApiKey = apiKey,
+            Endpoint = "https://routes.test/computeRouteMatrix",
+        });
+
+        return new GoogleRoutesMileageEstimationService(httpClient, settings);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            handler(request, cancellationToken);
+    }
+}

--- a/backend/Glovelly.Api.Tests/Infrastructure/FakeMileageEstimationService.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/FakeMileageEstimationService.cs
@@ -1,0 +1,30 @@
+using Glovelly.Api.Services;
+
+namespace Glovelly.Api.Tests.Infrastructure;
+
+internal sealed class FakeMileageEstimationService : IMileageEstimationService
+{
+    public MileageEstimateResult Result { get; set; } = MileageEstimateResult.Failure(
+        "test_mileage_estimation_unavailable",
+        "Test mileage estimation result was not configured.",
+        "test");
+
+    public MileageEstimateRequest? LastRequest { get; private set; }
+
+    public Task<MileageEstimateResult> EstimateAsync(
+        MileageEstimateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        LastRequest = request;
+        return Task.FromResult(Result);
+    }
+
+    public void Reset()
+    {
+        Result = MileageEstimateResult.Failure(
+            "test_mileage_estimation_unavailable",
+            "Test mileage estimation result was not configured.",
+            "test");
+        LastRequest = null;
+    }
+}

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -17,11 +17,13 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
     private readonly string _databaseName = $"glovelly-tests-{Guid.NewGuid()}";
     private readonly object _databaseResetLock = new();
     private readonly FakeEmailSender _fakeEmailSender = new();
+    private readonly FakeMileageEstimationService _fakeMileageEstimationService = new();
     private readonly Dictionary<string, string?> _configuration = new();
     private bool _useRealAuthentication;
     private string _environmentName = "Testing";
 
     internal FakeEmailSender Emails => _fakeEmailSender;
+    internal FakeMileageEstimationService MileageEstimation => _fakeMileageEstimationService;
 
     public GlovellyApiFactory WithConfiguration(Dictionary<string, string?> configuration)
     {
@@ -51,6 +53,7 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
         {
             services.RemoveAll<DbContextOptions<AppDbContext>>();
             services.RemoveAll<IEmailSender>();
+            services.RemoveAll<IMileageEstimationService>();
             services.RemoveAll<IBlobStore>();
             services.RemoveAll<IExpenseAttachmentStore>();
 
@@ -61,6 +64,7 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
             }
 
             services.AddSingleton<IEmailSender>(_fakeEmailSender);
+            services.AddSingleton<IMileageEstimationService>(_fakeMileageEstimationService);
             services.AddSingleton<IBlobStore, InMemoryBlobStore>();
             services.AddSingleton<IExpenseAttachmentStore, ExpenseAttachmentStore>();
             services.PostConfigure<EmailSettings>(settings =>
@@ -91,6 +95,7 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
             ResetDatabase(scope.ServiceProvider.GetRequiredService<AppDbContext>());
             _fakeEmailSender.SentEmails.Clear();
             _fakeEmailSender.ExceptionToThrow = null;
+            _fakeMileageEstimationService.Reset();
         }
 
         return client;

--- a/backend/Glovelly.Api/Data/Configuration/UserConfiguration.cs
+++ b/backend/Glovelly.Api/Data/Configuration/UserConfiguration.cs
@@ -20,6 +20,8 @@ internal sealed class UserConfiguration : IEntityTypeConfiguration<User>
             .HasPrecision(18, 2);
         entity.Property(user => user.PassengerMileageRate)
             .HasPrecision(18, 2);
+        entity.Property(user => user.TravelOriginPostcode)
+            .HasMaxLength(20);
         entity.Property(user => user.DefaultPaymentWindowDays);
         entity.Property(user => user.InvoiceFilenamePattern)
             .HasMaxLength(200);

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -78,6 +78,7 @@ internal static class AuthEndpoints
                 profileImageUrl = user.FindFirstValue("picture") ?? user.FindFirstValue("profile") ?? string.Empty,
                 mileageRate = localUser.MileageRate,
                 passengerMileageRate = localUser.PassengerMileageRate,
+                travelOriginPostcode = localUser.TravelOriginPostcode,
                 defaultPaymentWindowDays = localUser.DefaultPaymentWindowDays,
                 invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
                 invoiceEmailSubjectPattern = localUser.InvoiceEmailSubjectPattern,
@@ -113,6 +114,7 @@ internal static class AuthEndpoints
 
             localUser.MileageRate = request.MileageRate;
             localUser.PassengerMileageRate = request.PassengerMileageRate;
+            localUser.TravelOriginPostcode = NormalizeOptionalText(request.TravelOriginPostcode);
             localUser.DefaultPaymentWindowDays = request.DefaultPaymentWindowDays;
             localUser.InvoiceFilenamePattern = request.InvoiceFilenamePattern?.Trim();
             localUser.InvoiceEmailSubjectPattern = request.InvoiceEmailSubjectPattern?.Trim();
@@ -151,6 +153,7 @@ internal static class AuthEndpoints
             {
                 mileageRate = localUser.MileageRate,
                 passengerMileageRate = localUser.PassengerMileageRate,
+                travelOriginPostcode = localUser.TravelOriginPostcode,
                 defaultPaymentWindowDays = localUser.DefaultPaymentWindowDays,
                 invoiceFilenamePattern = localUser.InvoiceFilenamePattern,
                 invoiceEmailSubjectPattern = localUser.InvoiceEmailSubjectPattern,
@@ -261,11 +264,18 @@ internal static class AuthEndpoints
         return char.ToLowerInvariant(value[0]) + value[1..];
     }
 
+    private static string? NormalizeOptionalText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
     internal sealed record UserSettingsRequest(
         [Range(0, double.MaxValue, ErrorMessage = "Mileage rate cannot be negative.")]
         decimal? MileageRate,
         [Range(0, double.MaxValue, ErrorMessage = "Passenger mileage rate cannot be negative.")]
         decimal? PassengerMileageRate,
+        [property: StringLength(20, ErrorMessage = "Travel origin postcode must be 20 characters or fewer.")]
+        string? TravelOriginPostcode,
         [property: Range(0, 3650, ErrorMessage = "Default payment window must be between 0 and 3650 days.")]
         int? DefaultPaymentWindowDays,
         string? InvoiceFilenamePattern,

--- a/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
@@ -9,6 +9,7 @@ public static class GigEndpoints
             .MapGigCrudEndpoints()
             .MapGigReceiptEndpoints()
             .MapGigExpenseEndpoints()
+            .MapGigMileageEndpoints()
             .MapGigAttachmentEndpoints();
 
         return group;

--- a/backend/Glovelly.Api/Endpoints/GigMileageEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigMileageEndpoints.cs
@@ -1,0 +1,145 @@
+using System.Security.Claims;
+using Glovelly.Api.Auth;
+using Glovelly.Api.Data;
+using Glovelly.Api.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Glovelly.Api.Endpoints;
+
+internal static class GigMileageEndpoints
+{
+    private const decimal MetersPerMile = 1609.344m;
+
+    public static RouteGroupBuilder MapGigMileageEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/{id:guid}/mileage-estimate", async (
+            Guid id,
+            MileageEstimateEndpointRequest request,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            AppDbContext db,
+            IMileageEstimationService mileageEstimationService,
+            CancellationToken cancellationToken) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            if (!userId.HasValue)
+            {
+                return Results.Unauthorized();
+            }
+
+            var gig = await db.Gigs
+                .WhereVisibleTo(userId)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(value => value.Id == id, cancellationToken);
+
+            if (gig is null)
+            {
+                return Results.NotFound();
+            }
+
+            var sellerProfile = await db.SellerProfiles
+                .AsNoTracking()
+                .FirstOrDefaultAsync(value => value.UserId == userId.Value, cancellationToken);
+
+            var origin = NormalizeLocation(
+                request.OriginPostcode,
+                request.OriginCountry,
+                sellerProfile?.Address.PostalCode,
+                sellerProfile?.Address.Country);
+            var destination = NormalizeDestination(request.Destination, gig.Venue);
+
+            var validationErrors = ValidateRequest(origin, destination);
+            if (validationErrors is not null)
+            {
+                return Results.ValidationProblem(validationErrors);
+            }
+
+            var estimate = await mileageEstimationService.EstimateAsync(
+                new MileageEstimateRequest(origin, destination, request.RoundTrip ?? true),
+                cancellationToken);
+
+            if (!estimate.IsSuccess)
+            {
+                return Results.Problem(
+                    detail: estimate.FailureMessage,
+                    statusCode: StatusCodes.Status503ServiceUnavailable,
+                    extensions: new Dictionary<string, object?>
+                    {
+                        ["code"] = estimate.FailureCode,
+                    });
+            }
+
+            var distanceMiles = Math.Round(estimate.DistanceMeters / MetersPerMile, 1, MidpointRounding.AwayFromZero);
+
+            return Results.Ok(new
+            {
+                distanceMiles,
+                distanceMeters = estimate.DistanceMeters,
+                durationSeconds = estimate.DurationSeconds,
+                roundTrip = request.RoundTrip ?? true,
+                originLabel = estimate.OriginLabel,
+                destinationLabel = estimate.DestinationLabel,
+                estimate.Provider,
+                calculatedAtUtc = estimate.CalculatedAtUtc,
+            });
+        });
+
+        return group;
+    }
+
+    private static Dictionary<string, string[]>? ValidateRequest(string origin, string destination)
+    {
+        var errors = new Dictionary<string, string[]>();
+
+        if (string.IsNullOrWhiteSpace(origin))
+        {
+            errors["originPostcode"] = ["Set a postcode on the seller profile or include a travel origin postcode in the request."];
+        }
+
+        if (string.IsNullOrWhiteSpace(destination))
+        {
+            errors["destination"] = ["Gig venue or destination is required."];
+        }
+
+        return errors.Count == 0 ? null : errors;
+    }
+
+    private static string NormalizeDestination(string? destination, string fallbackDestination)
+    {
+        var value = string.IsNullOrWhiteSpace(destination)
+            ? fallbackDestination
+            : destination;
+
+        return value.Trim();
+    }
+
+    private static string NormalizeLocation(
+        string? requestPostcode,
+        string? requestCountry,
+        string? fallbackPostcode,
+        string? fallbackCountry)
+    {
+        var postcode = string.IsNullOrWhiteSpace(requestPostcode)
+            ? fallbackPostcode
+            : requestPostcode;
+        if (string.IsNullOrWhiteSpace(postcode))
+        {
+            return string.Empty;
+        }
+
+        var country = string.IsNullOrWhiteSpace(requestCountry)
+            ? fallbackCountry
+            : requestCountry;
+
+        return string.IsNullOrWhiteSpace(country)
+            ? postcode.Trim()
+            : $"{postcode.Trim()}, {country.Trim()}";
+    }
+
+    internal sealed record MileageEstimateEndpointRequest(
+        string? OriginPostcode,
+        string? OriginCountry,
+        string? Destination,
+        string? DestinationPlaceId,
+        bool? RoundTrip);
+}

--- a/backend/Glovelly.Api/Endpoints/GigMileageEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigMileageEndpoints.cs
@@ -40,10 +40,14 @@ internal static class GigMileageEndpoints
             var sellerProfile = await db.SellerProfiles
                 .AsNoTracking()
                 .FirstOrDefaultAsync(value => value.UserId == userId.Value, cancellationToken);
+            var localUser = await db.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(value => value.Id == userId.Value, cancellationToken);
 
             var origin = NormalizeLocation(
                 request.OriginPostcode,
                 request.OriginCountry,
+                localUser?.TravelOriginPostcode,
                 sellerProfile?.Address.PostalCode,
                 sellerProfile?.Address.Country);
             var destination = NormalizeDestination(request.Destination, gig.Venue);
@@ -97,7 +101,7 @@ internal static class GigMileageEndpoints
 
         if (string.IsNullOrWhiteSpace(origin))
         {
-            errors["originPostcode"] = ["Set a postcode on the seller profile or include a travel origin postcode in the request."];
+            errors["originPostcode"] = ["Set a travel origin postcode in user settings, set a seller profile postcode, or include an origin postcode in the request."];
         }
 
         if (string.IsNullOrWhiteSpace(destination))
@@ -125,12 +129,11 @@ internal static class GigMileageEndpoints
     private static string NormalizeLocation(
         string? requestPostcode,
         string? requestCountry,
+        string? userSettingsPostcode,
         string? fallbackPostcode,
         string? fallbackCountry)
     {
-        var postcode = string.IsNullOrWhiteSpace(requestPostcode)
-            ? fallbackPostcode
-            : requestPostcode;
+        var postcode = FirstNonBlank(requestPostcode, userSettingsPostcode, fallbackPostcode);
         if (string.IsNullOrWhiteSpace(postcode))
         {
             return string.Empty;
@@ -143,6 +146,11 @@ internal static class GigMileageEndpoints
         return string.IsNullOrWhiteSpace(country)
             ? postcode.Trim()
             : $"{postcode.Trim()}, {country.Trim()}";
+    }
+
+    private static string? FirstNonBlank(params string?[] values)
+    {
+        return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
     }
 
     internal sealed record MileageEstimateEndpointRequest(

--- a/backend/Glovelly.Api/Endpoints/GigMileageEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigMileageEndpoints.cs
@@ -55,7 +55,11 @@ internal static class GigMileageEndpoints
             }
 
             var estimate = await mileageEstimationService.EstimateAsync(
-                new MileageEstimateRequest(origin, destination, request.RoundTrip ?? true),
+                new MileageEstimateRequest(
+                    origin,
+                    destination,
+                    request.RoundTrip ?? true,
+                    NormalizeOptionalText(request.DestinationPlaceId)),
                 cancellationToken);
 
             if (!estimate.IsSuccess)
@@ -111,6 +115,11 @@ internal static class GigMileageEndpoints
             : destination;
 
         return value.Trim();
+    }
+
+    private static string? NormalizeOptionalText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
     }
 
     private static string NormalizeLocation(

--- a/backend/Glovelly.Api/Models/User.cs
+++ b/backend/Glovelly.Api/Models/User.cs
@@ -11,6 +11,7 @@ public sealed class User
     public string? DisplayName { get; set; }
     public decimal? MileageRate { get; set; }
     public decimal? PassengerMileageRate { get; set; }
+    public string? TravelOriginPostcode { get; set; }
     public int? DefaultPaymentWindowDays { get; set; }
     public string? InvoiceFilenamePattern { get; set; }
     public string? InvoiceEmailSubjectPattern { get; set; }

--- a/backend/Glovelly.Api/Services/DisabledMileageEstimationService.cs
+++ b/backend/Glovelly.Api/Services/DisabledMileageEstimationService.cs
@@ -1,0 +1,13 @@
+namespace Glovelly.Api.Services;
+
+public sealed class DisabledMileageEstimationService : IMileageEstimationService
+{
+    public Task<MileageEstimateResult> EstimateAsync(
+        MileageEstimateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(MileageEstimateResult.Failure(
+            "mileage_estimation_not_configured",
+            "Automatic mileage estimation is not configured."));
+    }
+}

--- a/backend/Glovelly.Api/Services/GoogleRoutesMileageEstimationService.cs
+++ b/backend/Glovelly.Api/Services/GoogleRoutesMileageEstimationService.cs
@@ -1,0 +1,214 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+
+namespace Glovelly.Api.Services;
+
+public sealed class GoogleRoutesMileageEstimationService(
+    HttpClient httpClient,
+    IOptions<GoogleRoutesMileageSettings> options) : IMileageEstimationService
+{
+    private const string ProviderName = "google-routes";
+    private const string FieldMask = "originIndex,destinationIndex,duration,distanceMeters,status,condition";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly GoogleRoutesMileageSettings _settings = options.Value;
+
+    public async Task<MileageEstimateResult> EstimateAsync(
+        MileageEstimateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_settings.IsConfigured)
+        {
+            return MileageEstimateResult.Failure(
+                "google_routes_not_configured",
+                "Google Routes mileage estimation is not configured.",
+                ProviderName);
+        }
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _settings.Endpoint)
+        {
+            Content = JsonContent.Create(BuildRequestBody(request), options: JsonOptions),
+        };
+        httpRequest.Headers.Add("X-Goog-Api-Key", _settings.ApiKey!.Trim());
+        httpRequest.Headers.Add("X-Goog-FieldMask", FieldMask);
+
+        using var response = await httpClient.SendAsync(httpRequest, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return MileageEstimateResult.Failure(
+                $"google_routes_http_{(int)response.StatusCode}",
+                $"Google Routes returned HTTP {(int)response.StatusCode}.",
+                ProviderName);
+        }
+
+        GoogleRouteMatrixElement[]? elements;
+        try
+        {
+            elements = JsonSerializer.Deserialize<GoogleRouteMatrixElement[]>(
+                responseBody,
+                JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return MileageEstimateResult.Failure(
+                "google_routes_invalid_response",
+                "Google Routes returned an invalid response.",
+                ProviderName);
+        }
+
+        var element = elements?.FirstOrDefault(value => value.OriginIndex == 0 && value.DestinationIndex == 0)
+            ?? elements?.FirstOrDefault();
+        if (element is null)
+        {
+            return MileageEstimateResult.Failure(
+                "google_routes_empty_response",
+                "Google Routes did not return a route estimate.",
+                ProviderName);
+        }
+
+        if (!string.Equals(element.Condition, "ROUTE_EXISTS", StringComparison.OrdinalIgnoreCase))
+        {
+            return MileageEstimateResult.Failure(
+                NormalizeElementFailureCode(element),
+                NormalizeElementFailureMessage(element),
+                ProviderName);
+        }
+
+        if (!element.DistanceMeters.HasValue)
+        {
+            return MileageEstimateResult.Failure(
+                "google_routes_missing_distance",
+                "Google Routes did not return a route distance.",
+                ProviderName);
+        }
+
+        var multiplier = request.RoundTrip ? 2 : 1;
+        var durationSeconds = ParseDurationSeconds(element.Duration);
+        return MileageEstimateResult.Success(
+            element.DistanceMeters.Value * multiplier,
+            durationSeconds.HasValue ? durationSeconds.Value * multiplier : null,
+            request.Origin,
+            request.Destination,
+            ProviderName,
+            DateTimeOffset.UtcNow);
+    }
+
+    private object BuildRequestBody(MileageEstimateRequest request) => new
+    {
+        origins = new[]
+        {
+            new
+            {
+                waypoint = new
+                {
+                    address = request.Origin,
+                },
+            },
+        },
+        destinations = new[]
+        {
+            new
+            {
+                waypoint = BuildDestinationWaypoint(request),
+            },
+        },
+        travelMode = NormalizeEnumSetting(_settings.TravelMode, "DRIVE"),
+        routingPreference = NormalizeEnumSetting(_settings.RoutingPreference, "TRAFFIC_UNAWARE"),
+    };
+
+    private static object BuildDestinationWaypoint(MileageEstimateRequest request)
+    {
+        return string.IsNullOrWhiteSpace(request.DestinationPlaceId)
+            ? new
+            {
+                address = request.Destination,
+            }
+            : new
+            {
+                placeId = request.DestinationPlaceId,
+            };
+    }
+
+    private static string NormalizeEnumSetting(string? value, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? fallback
+            : value.Trim().ToUpperInvariant();
+    }
+
+    private static int? ParseDurationSeconds(string? duration)
+    {
+        if (string.IsNullOrWhiteSpace(duration) || !duration.EndsWith('s'))
+        {
+            return null;
+        }
+
+        var secondsText = duration[..^1];
+        if (!decimal.TryParse(secondsText, NumberStyles.Number, CultureInfo.InvariantCulture, out var seconds))
+        {
+            return null;
+        }
+
+        return (int)Math.Round(seconds, MidpointRounding.AwayFromZero);
+    }
+
+    private static string NormalizeElementFailureCode(GoogleRouteMatrixElement element)
+    {
+        if (string.Equals(element.Condition, "ROUTE_NOT_FOUND", StringComparison.OrdinalIgnoreCase))
+        {
+            return "google_routes_route_not_found";
+        }
+
+        if (element.Status?.Code is not null)
+        {
+            return $"google_routes_status_{element.Status.Code.Value}";
+        }
+
+        return "google_routes_route_unavailable";
+    }
+
+    private static string NormalizeElementFailureMessage(GoogleRouteMatrixElement element)
+    {
+        if (!string.IsNullOrWhiteSpace(element.Status?.Message))
+        {
+            return element.Status.Message;
+        }
+
+        return string.Equals(element.Condition, "ROUTE_NOT_FOUND", StringComparison.OrdinalIgnoreCase)
+            ? "Google Routes could not find a route for the supplied origin and destination."
+            : "Google Routes could not calculate a route.";
+    }
+
+    private sealed class GoogleRouteMatrixElement
+    {
+        [JsonPropertyName("originIndex")]
+        public int OriginIndex { get; set; }
+
+        [JsonPropertyName("destinationIndex")]
+        public int DestinationIndex { get; set; }
+
+        [JsonPropertyName("condition")]
+        public string? Condition { get; set; }
+
+        [JsonPropertyName("distanceMeters")]
+        public decimal? DistanceMeters { get; set; }
+
+        [JsonPropertyName("duration")]
+        public string? Duration { get; set; }
+
+        [JsonPropertyName("status")]
+        public GoogleRouteStatus? Status { get; set; }
+    }
+
+    private sealed class GoogleRouteStatus
+    {
+        [JsonPropertyName("code")]
+        public int? Code { get; set; }
+
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+    }
+}

--- a/backend/Glovelly.Api/Services/GoogleRoutesMileageSettings.cs
+++ b/backend/Glovelly.Api/Services/GoogleRoutesMileageSettings.cs
@@ -1,0 +1,14 @@
+namespace Glovelly.Api.Services;
+
+public sealed class GoogleRoutesMileageSettings
+{
+    public const string SectionName = "Mileage:GoogleRoutes";
+
+    public string? ApiKey { get; set; }
+    public string Endpoint { get; set; } =
+        "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix";
+    public string TravelMode { get; set; } = "DRIVE";
+    public string RoutingPreference { get; set; } = "TRAFFIC_UNAWARE";
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(ApiKey);
+}

--- a/backend/Glovelly.Api/Services/IMileageEstimationService.cs
+++ b/backend/Glovelly.Api/Services/IMileageEstimationService.cs
@@ -1,0 +1,56 @@
+namespace Glovelly.Api.Services;
+
+public interface IMileageEstimationService
+{
+    Task<MileageEstimateResult> EstimateAsync(
+        MileageEstimateRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record MileageEstimateRequest(
+    string Origin,
+    string Destination,
+    bool RoundTrip);
+
+public sealed record MileageEstimateResult(
+    bool IsSuccess,
+    decimal DistanceMeters,
+    int? DurationSeconds,
+    string OriginLabel,
+    string DestinationLabel,
+    string Provider,
+    DateTimeOffset CalculatedAtUtc,
+    string? FailureCode = null,
+    string? FailureMessage = null)
+{
+    public static MileageEstimateResult Success(
+        decimal distanceMeters,
+        int? durationSeconds,
+        string originLabel,
+        string destinationLabel,
+        string provider,
+        DateTimeOffset calculatedAtUtc) =>
+        new(
+            true,
+            distanceMeters,
+            durationSeconds,
+            originLabel,
+            destinationLabel,
+            provider,
+            calculatedAtUtc);
+
+    public static MileageEstimateResult Failure(
+        string failureCode,
+        string failureMessage,
+        string provider = "none") =>
+        new(
+            false,
+            0m,
+            null,
+            string.Empty,
+            string.Empty,
+            provider,
+            DateTimeOffset.UtcNow,
+            failureCode,
+            failureMessage);
+}

--- a/backend/Glovelly.Api/Services/IMileageEstimationService.cs
+++ b/backend/Glovelly.Api/Services/IMileageEstimationService.cs
@@ -10,7 +10,8 @@ public interface IMileageEstimationService
 public sealed record MileageEstimateRequest(
     string Origin,
     string Destination,
-    bool RoundTrip);
+    bool RoundTrip,
+    string? DestinationPlaceId = null);
 
 public sealed record MileageEstimateResult(
     bool IsSuccess,

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInvoiceWorkflowService, InvoiceWorkflowService>();
         services.AddScoped<IInvoicePdfService, InvoicePdfService>();
         services.AddScoped<IInvoiceDeliveryService, InvoiceDeliveryService>();
+        services.AddScoped<IMileageEstimationService, DisabledMileageEstimationService>();
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceEmailDeliveryChannel>();
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceGoogleDriveDeliveryChannel>();
         services.AddOptions<InvoiceRateSettings>()

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -21,7 +21,17 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInvoiceWorkflowService, InvoiceWorkflowService>();
         services.AddScoped<IInvoicePdfService, InvoicePdfService>();
         services.AddScoped<IInvoiceDeliveryService, InvoiceDeliveryService>();
-        services.AddScoped<IMileageEstimationService, DisabledMileageEstimationService>();
+        services.AddOptions<GoogleRoutesMileageSettings>()
+            .BindConfiguration(GoogleRoutesMileageSettings.SectionName);
+        services.AddHttpClient<GoogleRoutesMileageEstimationService>();
+        services.AddScoped<DisabledMileageEstimationService>();
+        services.AddScoped<IMileageEstimationService>(provider =>
+        {
+            var settings = provider.GetRequiredService<IOptions<GoogleRoutesMileageSettings>>().Value;
+            return settings.IsConfigured
+                ? provider.GetRequiredService<GoogleRoutesMileageEstimationService>()
+                : provider.GetRequiredService<DisabledMileageEstimationService>();
+        });
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceEmailDeliveryChannel>();
         services.AddScoped<IInvoiceDeliveryChannel, InvoiceGoogleDriveDeliveryChannel>();
         services.AddOptions<InvoiceRateSettings>()

--- a/backend/Glovelly.Api/appsettings.Development.json
+++ b/backend/Glovelly.Api/appsettings.Development.json
@@ -15,6 +15,14 @@
     "Mode": "Log",
     "MaxTotalAttachmentBytes": 26214400
   },
+  "Mileage": {
+    "GoogleRoutes": {
+      "ApiKey": "",
+      "Endpoint": "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix",
+      "TravelMode": "DRIVE",
+      "RoutingPreference": "TRAFFIC_UNAWARE"
+    }
+  },
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:5173",

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -30,6 +30,14 @@
     "DefaultMileageRate": 0.45,
     "DefaultPassengerMileageRate": 0.10
   },
+  "Mileage": {
+    "GoogleRoutes": {
+      "ApiKey": "",
+      "Endpoint": "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix",
+      "TravelMode": "DRIVE",
+      "RoutingPreference": "TRAFFIC_UNAWARE"
+    }
+  },
   "Cors": {
     "AllowedOrigins": []
   },

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,110 @@
+# About Glovelly
+
+Glovelly is a small business administration tool built for the slightly awkward reality of freelance and self-employed creative work.
+
+It started from a simple problem: music work generates a surprising amount of admin.
+
+A gig is rarely just a gig. There are clients to remember, venues to get to, fees to track, receipts to keep, mileage to calculate, invoices to send, payments to chase, and enough tiny details to make a perfectly reasonable person consider hiding under a piano.
+
+Glovelly exists to make that quieter.
+
+## Why Glovelly Exists
+
+Like many self-employed musicians, I already had a collection of tools that mostly worked:
+
+- spreadsheets for gigs and fees
+- folders full of receipts
+- notes apps full of odd little reminders
+- banking apps
+- PDF invoices
+- email threads
+- tax return panic
+
+None of these were bad on their own. The problem was that they all lived in different places.
+
+Glovelly is an attempt to bring the important pieces together into one calm, practical space: clients, gigs, expenses, receipts, invoices, payment tracking, and the small operational workflows around them.
+
+It is not trying to be a giant accounting platform. It is not trying to replace professional advice. It is simply trying to make the day-to-day admin of small business life feel less scattered.
+
+## The Name
+
+The name Glovelly does not come from a consultancy exercise, a brand workshop, or a spreadsheet of available domains.
+
+It began as a daft little working name and then, inconveniently, stuck.
+
+That feels appropriate. A lot of useful tools start life as something slightly silly that solves a real problem.
+
+## Built Around Real Work
+
+Glovelly is currently shaped around self-employed music work because that is the world it came from.
+
+That means it cares about things like:
+
+- gigs and dates
+- venues and travel
+- expenses and receipts
+- invoice lines that actually match the work
+- client details
+- seller profile information
+- invoice delivery
+- Google Drive publishing
+- keeping enough records around to make tax and accounting less grim
+
+The goal is not to make admin exciting. That would be suspicious.
+
+The goal is to make it boring in the best possible way: predictable, visible, and under control.
+
+## A Personal Project With Product Ambitions
+
+Glovelly is a personal project, but it is built with proper product habits.
+
+That means:
+
+- authenticated access
+- user enrolment
+- role-based administration
+- privacy and terms documentation
+- secure handling of external integrations
+- Google OAuth for Drive publishing
+- transactional email
+- careful treatment of invoices and business records
+
+Some of that is overkill for a tiny tool.
+
+But it is also part of the point. Glovelly is a place to build something useful, learn properly, and avoid the trap of “it works on my machine and nowhere else.”
+
+## What Glovelly Is Not
+
+Glovelly is not an accountant.
+
+It is not a tax adviser.
+
+It is not a magic compliance machine.
+
+It can help organise records, generate invoices, store receipts, and make useful workflows smoother. The human using it is still responsible for checking that the details are correct and suitable for their situation.
+
+That boundary matters.
+
+## Where It Is Going
+
+The long-term idea is simple:
+
+> Glovelly should help small creative businesses keep their admin together without making the admin itself the main event.
+
+That might mean better invoice workflows, smarter receipt capture, useful tax-year summaries, richer document storage, or integrations with other services.
+
+Or it might just mean the app quietly does the boring stuff well.
+
+Honestly, that would be a pretty good outcome.
+
+## The Spirit Of The Thing
+
+Glovelly is built in the spirit of small, practical software:
+
+- solve the real problem in front of you
+- keep the interface friendly
+- make the data understandable
+- avoid unnecessary ceremony
+- leave room for the odd rubber chicken
+
+If it helps someone finish their admin faster and get back to the actual work, it is doing its job.

--- a/docs/engineering/index.md
+++ b/docs/engineering/index.md
@@ -11,6 +11,7 @@ The goal is durable context rather than exhaustive implementation notes. Keep th
 - [Deployment pipeline](deployment-pipeline.md): container build, GitHub Actions, Artifact Registry, Cloud Run, and runtime configuration.
 - [Database](database.md): PostgreSQL, EF Core, data ownership, and migration posture.
 - [Email](email.md): outbound email abstraction, Resend integration, and delivery assumptions.
+- [Mileage and routes](mileage-routes.md): Google Routes mileage estimation and fallback behavior.
 - [Architecture decisions](decisions/index.md): ADR index for decisions that should outlive individual pull requests.
 
 ## Principles
@@ -20,4 +21,3 @@ The goal is durable context rather than exhaustive implementation notes. Keep th
 - Business data should relate to internal Glovelly users/domain entities, not directly to raw provider claims.
 - Runtime secrets belong in secure runtime configuration, not source control.
 - External providers should sit behind application abstractions where the provider choice is not core domain logic.
-

--- a/docs/engineering/mileage-routes.md
+++ b/docs/engineering/mileage-routes.md
@@ -9,7 +9,7 @@ The feature is intentionally a suggestion workflow. Google calculates a route es
 1. The user opens a saved gig and clicks `Estimate mileage`.
 2. The frontend calls `POST /gigs/{id}/mileage-estimate` with the current gig location as `destination` and `roundTrip: true`.
 3. The backend authorises access through the normal gig visibility rules.
-4. The backend uses the seller profile postcode and country as the origin when the request does not provide one.
+4. The backend uses the user's travel origin postcode as the origin when the request does not provide one, with the seller profile postcode and country as the fallback.
 5. `IMileageEstimationService` calculates the estimate.
 6. The frontend writes the returned `distanceMiles` into the existing travel miles field.
 

--- a/docs/engineering/mileage-routes.md
+++ b/docs/engineering/mileage-routes.md
@@ -1,0 +1,81 @@
+# Mileage And Routes
+
+Glovelly can estimate driving mileage for a saved gig using Google Routes API.
+
+The feature is intentionally a suggestion workflow. Google calculates a route estimate, the frontend fills the existing `TravelMiles` input, and the user can edit the value before saving the gig. Manual mileage remains the source of truth for invoice generation.
+
+## Runtime Flow
+
+1. The user opens a saved gig and clicks `Estimate mileage`.
+2. The frontend calls `POST /gigs/{id}/mileage-estimate` with the current gig location as `destination` and `roundTrip: true`.
+3. The backend authorises access through the normal gig visibility rules.
+4. The backend uses the seller profile postcode and country as the origin when the request does not provide one.
+5. `IMileageEstimationService` calculates the estimate.
+6. The frontend writes the returned `distanceMiles` into the existing travel miles field.
+
+The estimate endpoint does not save the gig. Saving still happens through the normal gig create/update flow.
+
+## Provider
+
+Google Routes is implemented by `GoogleRoutesMileageEstimationService`.
+
+The service calls:
+
+```text
+https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix
+```
+
+It sends:
+
+- `X-Goog-Api-Key`
+- `X-Goog-FieldMask: originIndex,destinationIndex,duration,distanceMeters,status,condition`
+- one address origin
+- one destination, either an address or a Google place ID
+- `travelMode: DRIVE`
+- `routingPreference: TRAFFIC_UNAWARE`
+
+Round-trip estimates are calculated by doubling the returned one-way distance and duration.
+
+## Configuration
+
+Local non-secret defaults live in `appsettings.Development.json`:
+
+```json
+{
+  "Mileage": {
+    "GoogleRoutes": {
+      "Endpoint": "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix",
+      "TravelMode": "DRIVE",
+      "RoutingPreference": "TRAFFIC_UNAWARE"
+    }
+  }
+}
+```
+
+The API key is a secret. For local development, store it with user secrets:
+
+```bash
+cd backend/Glovelly.Api
+dotnet user-secrets set "Mileage:GoogleRoutes:ApiKey" "your-google-routes-api-key"
+```
+
+For deployed environments, provide `Mileage__GoogleRoutes__ApiKey` through Google Secret Manager or equivalent secret-backed runtime configuration.
+
+If no API key is configured, Glovelly uses `DisabledMileageEstimationService` and returns a provider failure. The user can still enter mileage manually.
+
+## Error Handling
+
+The backend returns validation errors when a gig, destination, or origin cannot be resolved.
+
+Provider failures return a non-saving failure response. Common cases include:
+
+- Google Routes API key missing or invalid
+- quota or billing failure
+- unroutable origin/destination
+- malformed provider response
+
+The frontend surfaces the message in the gig status area and leaves the travel miles input editable.
+
+## Follow-Up
+
+Dedicated travel-origin settings should replace the temporary seller-profile origin fallback. Seller profile address is invoice-facing and may not be the user's preferred travel start point.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Glovelly is a personal business platform for self-employed music work. The produ
 ## Start Here
 
 - [UAT and regression testing](uat/index.md): manual tester journeys for checking the product before release.
+- [About Glovelly](about.md): what Glovelly is, why it exists, and the spirit of the project.
 - [Domain notes](domain.md): durable business concepts and vocabulary.
 - [Privacy policy](privacy.md): public privacy notice for Glovelly.
 - [Application terms](terms.md): public terms of service for Glovelly.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -38,6 +38,8 @@
       href: engineering/database.md
     - name: Email
       href: engineering/email.md
+    - name: Mileage and routes
+      href: engineering/mileage-routes.md
     - name: Architecture decisions
       href: engineering/decisions/index.md
       items:

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2,6 +2,8 @@
   items:
     - name: Home
       href: index.md
+    - name: About Glovelly
+      href: about.md
     - name: Domain notes
       href: domain.md
     - name: Privacy policy

--- a/docs/uat/invoices.md
+++ b/docs/uat/invoices.md
@@ -121,7 +121,7 @@ Expected result: the invoice includes both mileage and passenger mileage lines u
 Preconditions:
 
 - Google Routes mileage estimation is configured in the environment.
-- The seller profile has a postcode and country.
+- User settings have a travel origin postcode, or the seller profile has a postcode and country.
 
 1. Create a gig with a clear venue or location and save it.
 2. Edit the saved gig.
@@ -133,7 +133,7 @@ Preconditions:
 8. Generate an invoice from the gig.
 9. Open the invoice lines and PDF preview.
 
-Expected result: the estimate fills the editable travel miles field but does not save until the gig is saved. The generated invoice includes a mileage line using the saved travel miles and the applicable mileage rate.
+Expected result: the estimate fills the editable travel miles field but does not save until the gig is saved. Mileage estimation uses the travel origin postcode when set, otherwise the seller profile postcode. The generated invoice includes a mileage line using the saved travel miles and the applicable mileage rate.
 
 ### Estimated Mileage Manual Fallback
 
@@ -151,12 +151,12 @@ Expected result: failed estimation does not block saving the gig. Manual mileage
 ### Estimated Mileage Origin Requirement
 
 1. Use an environment where Google Routes mileage estimation is configured.
-2. Clear the seller profile postcode or use a test user without a seller profile postcode.
+2. Clear the user settings travel origin postcode and seller profile postcode, or use a test user without either value.
 3. Open a saved gig with a location.
 4. Enable `I was driving for this gig`.
 5. Click `Estimate mileage`.
 
-Expected result: the app explains that a seller profile postcode or request origin is required. The existing travel miles value is not overwritten.
+Expected result: the app explains that a travel origin postcode, seller profile postcode, or request origin is required. The existing travel miles value is not overwritten.
 
 ## Invoice Preview
 

--- a/docs/uat/invoices.md
+++ b/docs/uat/invoices.md
@@ -116,6 +116,48 @@ Expected result: mileage lines disappear while driving is disabled and return wh
 
 Expected result: the invoice includes both mileage and passenger mileage lines using the configured app defaults, not blank or omitted lines. The PDF preview/download shows the same mileage lines as the invoice workspace.
 
+### Estimated Mileage Happy Path
+
+Preconditions:
+
+- Google Routes mileage estimation is configured in the environment.
+- The seller profile has a postcode and country.
+
+1. Create a gig with a clear venue or location and save it.
+2. Edit the saved gig.
+3. Enable `I was driving for this gig`.
+4. Click `Estimate mileage`.
+5. Confirm the travel miles field is filled with a positive value.
+6. Optionally adjust the estimated value.
+7. Save the gig.
+8. Generate an invoice from the gig.
+9. Open the invoice lines and PDF preview.
+
+Expected result: the estimate fills the editable travel miles field but does not save until the gig is saved. The generated invoice includes a mileage line using the saved travel miles and the applicable mileage rate.
+
+### Estimated Mileage Manual Fallback
+
+1. Use an environment where Google Routes mileage estimation is not configured, or temporarily use a gig location that cannot be routed (i.e. 'The Moon').
+2. Create or edit a saved gig.
+3. Enable `I was driving for this gig`.
+4. Click `Estimate mileage`.
+5. Confirm the app shows a clear error in the gig status area.
+6. Manually type a valid travel miles value.
+7. Save the gig.
+8. Generate an invoice from the gig.
+
+Expected result: failed estimation does not block saving the gig. Manual mileage remains editable and still flows into generated invoice mileage lines.
+
+### Estimated Mileage Origin Requirement
+
+1. Use an environment where Google Routes mileage estimation is configured.
+2. Clear the seller profile postcode or use a test user without a seller profile postcode.
+3. Open a saved gig with a location.
+4. Enable `I was driving for this gig`.
+5. Click `Estimate mileage`.
+
+Expected result: the app explains that a seller profile postcode or request origin is required. The existing travel miles value is not overwritten.
+
 ## Invoice Preview
 
 ### Steps

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -114,18 +114,22 @@ Expected result: unsaved admin access edits are never discarded without confirma
 ### Steps
 
 1. Create a client or choose an existing client.
-2. Create a gig with fee, date, venue, status `Planned`, and at least one expense.
-3. Save the gig.
-4. Generate an invoice from that gig.
-5. Open the invoice.
-6. Confirm invoice lines include the performance fee and chargeable expenses.
-7. Download the PDF.
-8. Return to the gig.
-9. Confirm the gig shows as invoiced and links back to the invoice.
+2. Confirm the seller profile has a postcode and country if mileage estimation is configured in this environment.
+3. Create a gig with fee, date, venue, status `Planned`, and at least one expense.
+4. Save the gig.
+5. Edit the saved gig, enable `I was driving for this gig`, and click `Estimate mileage` if Google Routes is configured.
+6. Confirm the travel miles field is filled, or record that mileage estimation was skipped because the environment is not configured.
+7. Save the gig.
+8. Generate an invoice from that gig.
+9. Open the invoice.
+10. Confirm invoice lines include the performance fee, chargeable expenses, and mileage when travel miles were saved.
+11. Download the PDF.
+12. Return to the gig.
+13. Confirm the gig shows as invoiced and links back to the invoice.
 
 ### Expected Results
 
-Generating an invoice links the gig, creates expected lines, and produces a downloadable PDF.
+Generating an invoice links the gig, creates expected lines, includes saved mileage when applicable, and produces a downloadable PDF.
 
 ## Editing An Invoiced Gig
 

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1335,6 +1335,15 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.mileage-estimate-action {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  min-width: 0;
+  align-self: end;
+}
+
 .empty-state {
   padding: 22px;
   border-radius: 20px;

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -6,6 +6,14 @@
   overflow-x: clip;
 }
 
+.app-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 18px;
+  flex-wrap: wrap;
+}
+
 .build-meta {
   margin: 0;
   justify-self: end;
@@ -16,6 +24,27 @@
   color: var(--muted);
   font-size: 0.82rem;
   letter-spacing: 0.04em;
+}
+
+.legal-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px 14px;
+  flex-wrap: wrap;
+  padding: 0 2px;
+}
+
+.legal-links a {
+  color: var(--muted-strong);
+  font-size: 0.84rem;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.legal-links a:hover,
+.legal-links a:focus-visible {
+  color: var(--heading);
 }
 
 .section-layout {
@@ -1575,6 +1604,15 @@ button:disabled {
 
   .content-header.panel {
     padding: 16px;
+  }
+
+  .app-footer {
+    justify-content: flex-start;
+  }
+
+  .build-meta {
+    justify-self: start;
+    border-radius: 16px;
   }
 
   .hero-mascot {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1531,6 +1531,7 @@ function App({ appMetadata }: AppProps) {
         onConnectGoogleDrive={connectGoogleDrive}
         onSubmit={handleUserSettingsSubmit}
         onUpdateField={updateUserSettingsField}
+        sellerProfilePostcode={sellerProfile.postcode}
         status={userSettingsStatus}
       />
 

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -225,6 +225,7 @@ function App({ appMetadata }: AppProps) {
     gigStatus,
     gigs,
     gigsById,
+    estimateGigMileage,
     handleAddGigExpense,
     handleGigSubmit,
     handleToggleGigSelection,
@@ -234,6 +235,7 @@ function App({ appMetadata }: AppProps) {
     isExpenseStatementOpen,
     isGigEditorOpen,
     isGigLoading,
+    isMileageEstimating,
     mergeSavedGig,
     openExpenseStatement,
     openGigReceiptDraft,
@@ -1374,12 +1376,14 @@ function App({ appMetadata }: AppProps) {
         gigs={gigs}
         isGigLoading={isGigLoading}
         isInvoiceLoading={isInvoiceLoading}
+        isMileageEstimating={isMileageEstimating}
         onAddGigExpense={handleAddGigExpense}
         onCloseEditor={closeGigEditor}
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateExpenseStatement={openExpenseStatement}
         onGenerateInvoice={handleGenerateInvoice}
+        onEstimateMileage={estimateGigMileage}
         onDeleteGig={deleteGig}
         onDownloadExpenseAttachment={downloadExpenseAttachment}
         onCloneGig={cloneSelectedGig}

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -262,10 +262,23 @@ export function AppShell({
         </div>
       </section>
 
-      <p className="build-meta">
-        {appMetadata.deploymentName ? `${appMetadata.deploymentName} \u2022 ` : ''}
-        {formatBuildMetadata(appMetadata.commitId, appMetadata.buildTimestamp)}
-      </p>
+      <div className="app-footer">
+        <nav className="legal-links" aria-label="Legal">
+          <a href="https://docs.glovelly.net/about.html" target="_blank" rel="noreferrer">
+            About
+          </a>
+          <a href="https://docs.glovelly.net/privacy.html" target="_blank" rel="noreferrer">
+            Privacy policy
+          </a>
+          <a href="https://docs.glovelly.net/terms.html" target="_blank" rel="noreferrer">
+            Terms of Service
+          </a>
+        </nav>
+        <p className="build-meta">
+          {appMetadata.deploymentName ? `${appMetadata.deploymentName} \u2022 ` : ''}
+          {formatBuildMetadata(appMetadata.commitId, appMetadata.buildTimestamp)}
+        </p>
+      </div>
 
       {children}
     </main>

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -25,12 +25,14 @@ type GigsSectionProps = {
   gigs: Gig[]
   isGigLoading: boolean
   isInvoiceLoading: boolean
+  isMileageEstimating: boolean
   onAddGigExpense: () => void
   onCloseEditor: () => void
   onExpenseAmountChange: (value: string) => void
   onExpenseDescriptionChange: (value: string) => void
   onGenerateExpenseStatement: () => void
   onGenerateInvoice: () => void
+  onEstimateMileage: () => void
   onDeleteGig: () => void
   onDownloadExpenseAttachment: (expense: GigExpenseForm, attachmentId: string) => void
   onCloneGig: () => void
@@ -82,12 +84,14 @@ export function GigsSection({
   gigs,
   isGigLoading,
   isInvoiceLoading,
+  isMileageEstimating,
   onAddGigExpense,
   onCloseEditor,
   onExpenseAmountChange,
   onExpenseDescriptionChange,
   onGenerateExpenseStatement,
   onGenerateInvoice,
+  onEstimateMileage,
   onDeleteGig,
   onDownloadExpenseAttachment,
   onCloneGig,
@@ -490,6 +494,17 @@ export function GigsSection({
                       placeholder="24"
                     />
                   </label>
+
+                  <div className="mileage-estimate-action">
+                    <button
+                      className="ghost-button"
+                      disabled={gigMode !== 'edit' || isMileageEstimating}
+                      onClick={onEstimateMileage}
+                      type="button"
+                    >
+                      {isMileageEstimating ? 'Estimating...' : 'Estimate mileage'}
+                    </button>
+                  </div>
 
                   <label>
                     <span>Passengers</span>

--- a/frontend/glovelly-web/src/components/SignInScreen.tsx
+++ b/frontend/glovelly-web/src/components/SignInScreen.tsx
@@ -38,7 +38,20 @@ export function SignInScreen({
           </button>
         </div>
       </section>
-      <p className="build-meta">{formatBuildMetadata(appMetadata.commitId, appMetadata.buildTimestamp)}</p>
+      <div className="app-footer">
+        <nav className="legal-links" aria-label="Legal">
+          <a href="https://docs.glovelly.net/about.html" target="_blank" rel="noreferrer">
+            About
+          </a>
+          <a href="https://docs.glovelly.net/privacy.html" target="_blank" rel="noreferrer">
+            Privacy policy
+          </a>
+          <a href="https://docs.glovelly.net/terms.html" target="_blank" rel="noreferrer">
+            Terms of Service
+          </a>
+        </nav>
+        <p className="build-meta">{formatBuildMetadata(appMetadata.commitId, appMetadata.buildTimestamp)}</p>
+      </div>
     </main>
   )
 }

--- a/frontend/glovelly-web/src/components/UserSettingsModal.tsx
+++ b/frontend/glovelly-web/src/components/UserSettingsModal.tsx
@@ -15,6 +15,7 @@ type UserSettingsModalProps = {
   onConnectGoogleDrive: () => void
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
   onUpdateField: (field: keyof UserSettingsForm, value: string) => void
+  sellerProfilePostcode: string | null
   status: string
 }
 
@@ -31,25 +32,29 @@ export function UserSettingsModal({
   onConnectGoogleDrive,
   onSubmit,
   onUpdateField,
+  sellerProfilePostcode,
   status,
 }: UserSettingsModalProps) {
   const [focusedField, setFocusedField] = useState<keyof UserSettingsForm | null>(null)
+  const travelOriginPlaceholder = sellerProfilePostcode?.trim() || 'BS1 1AA'
   const settingsNote =
     focusedField === 'mileageRate'
       ? 'Leave blank if you do not want a personal mileage default.'
       : focusedField === 'passengerMileageRate'
         ? 'Leave blank if you do not want a personal passenger mileage default.'
-        : focusedField === 'defaultPaymentWindowDays'
-          ? 'Leave blank to keep the standard 14 day payment window.'
-          : focusedField === 'invoiceFilenamePattern'
-            ? `Available filename tokens: ${invoiceFilenameTokens.join(', ')}.`
-            : focusedField === 'invoiceEmailSubjectPattern'
-              ? `Available subject tokens: ${invoiceFilenameTokens.join(', ')}.`
-              : focusedField === 'invoiceReplyToEmail'
-                ? 'Leave blank if replies should not be directed to a personal mailbox.'
-                : focusedField === 'invoiceUploadFolderId'
-                  ? "Leave blank to use Google Drive's default upload destination."
-                  : 'Choose a setting to see a short note here.'
+        : focusedField === 'travelOriginPostcode'
+          ? 'Used for mileage estimates before falling back to your seller profile postcode.'
+          : focusedField === 'defaultPaymentWindowDays'
+            ? 'Leave blank to keep the standard 14 day payment window.'
+            : focusedField === 'invoiceFilenamePattern'
+              ? `Available filename tokens: ${invoiceFilenameTokens.join(', ')}.`
+              : focusedField === 'invoiceEmailSubjectPattern'
+                ? `Available subject tokens: ${invoiceFilenameTokens.join(', ')}.`
+                : focusedField === 'invoiceReplyToEmail'
+                  ? 'Leave blank if replies should not be directed to a personal mailbox.'
+                  : focusedField === 'invoiceUploadFolderId'
+                    ? "Leave blank to use Google Drive's default upload destination."
+                    : 'Choose a setting to see a short note here.'
   const handleFocus = (field: keyof UserSettingsForm) => {
     setFocusedField(field)
   }
@@ -141,6 +146,20 @@ export function UserSettingsModal({
                 onFocus={() => handleFocus('defaultPaymentWindowDays')}
                 onChange={(event) =>
                   onUpdateField('defaultPaymentWindowDays', event.target.value)
+                }
+              />
+            </label>
+
+            <label>
+              <span>Travel origin postcode</span>
+              <input
+                autoComplete="postal-code"
+                placeholder={travelOriginPlaceholder}
+                type="text"
+                value={form.travelOriginPostcode}
+                onFocus={() => handleFocus('travelOriginPostcode')}
+                onChange={(event) =>
+                  onUpdateField('travelOriginPostcode', event.target.value)
                 }
               />
             </label>

--- a/frontend/glovelly-web/src/forms.ts
+++ b/frontend/glovelly-web/src/forms.ts
@@ -31,6 +31,7 @@ export const emptyAdminForm = (): AdminUserForm => ({
 export const emptyUserSettingsForm = (): UserSettingsForm => ({
   mileageRate: '',
   passengerMileageRate: '',
+  travelOriginPostcode: '',
   defaultPaymentWindowDays: '',
   invoiceFilenamePattern: '',
   invoiceEmailSubjectPattern: '',

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -32,6 +32,17 @@ type NormalizedGigExpensePayload = {
   amount: number
 }
 
+type MileageEstimateResponse = {
+  distanceMiles: number
+  distanceMeters: number
+  durationSeconds: number | null
+  roundTrip: boolean
+  originLabel: string
+  destinationLabel: string
+  provider: string
+  calculatedAtUtc: string
+}
+
 function extractDownloadFilename(contentDisposition: string | null) {
   if (!contentDisposition) {
     return null
@@ -113,6 +124,7 @@ export function useGigsWorkspace({
   const [gigForm, setGigForm] = useState<GigForm>(emptyGigForm)
   const [gigStatus, setGigStatus] = useState(defaultGigStatus)
   const [isGigLoading, setIsGigLoading] = useState(false)
+  const [isMileageEstimating, setIsMileageEstimating] = useState(false)
   const [gigExpenseAmount, setGigExpenseAmount] = useState('')
   const [gigExpenseDescription, setGigExpenseDescription] = useState('')
   const [isExpenseStatementOpen, setIsExpenseStatementOpen] = useState(false)
@@ -439,6 +451,74 @@ export function useGigsWorkspace({
       ...current,
       [field]: value,
     }))
+  }
+
+  const estimateGigMileage = async () => {
+    if (gigMode !== 'edit' || !selectedGig) {
+      setGigStatus('Save the gig before estimating mileage.')
+      return
+    }
+
+    const destination = gigForm.venue.trim()
+    if (!destination) {
+      setGigStatus('Add a location before estimating mileage.')
+      return
+    }
+
+    setIsMileageEstimating(true)
+
+    try {
+      const response = await fetchWithSession(
+        buildApiUrl(`/gigs/${selectedGig.id}/mileage-estimate`),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            destination,
+            roundTrip: true,
+          }),
+        }
+      )
+
+      if (
+        handleSessionExpired(
+          response,
+          onSessionExpired,
+          'Your session expired. Sign in again to estimate mileage.'
+        )
+      ) {
+        return
+      }
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const validationMessages = problem?.errors
+          ? Object.values(problem.errors).flat().join(' ')
+          : problem?.detail ?? problem?.title
+
+        throw new Error(validationMessages || 'Unable to estimate mileage.')
+      }
+
+      const estimate = (await response.json()) as MileageEstimateResponse
+      setGigForm((current) => ({
+        ...current,
+        wasDriving: true,
+        travelMiles: formatEditableNumber(estimate.distanceMiles),
+      }))
+      setGigStatus(
+        `Estimated ${formatEditableNumber(estimate.distanceMiles)} miles from ${estimate.originLabel} to ${estimate.destinationLabel}.`
+      )
+    } catch (error) {
+      setGigStatus(
+        error instanceof Error
+          ? error.message
+          : 'Unable to estimate mileage right now.'
+      )
+    } finally {
+      setIsMileageEstimating(false)
+    }
   }
 
   const handleAddGigExpense = () => {
@@ -1311,6 +1391,7 @@ export function useGigsWorkspace({
     gigStatus,
     gigs,
     gigsById,
+    estimateGigMileage,
     handleAddGigExpense,
     handleGigSubmit,
     handleToggleGigSelection,
@@ -1318,6 +1399,7 @@ export function useGigsWorkspace({
     isExpenseStatementLoading,
     isExpenseStatementOpen,
     isGigLoading,
+    isMileageEstimating,
     mergeSavedGig,
     openGigReceiptDraft,
     openExpenseStatement,

--- a/frontend/glovelly-web/src/hooks/useUserSettings.ts
+++ b/frontend/glovelly-web/src/hooks/useUserSettings.ts
@@ -12,6 +12,7 @@ import type { AuthUser, UserSettingsForm } from '../types'
 type SavedUserSettings = {
   mileageRate: number | null
   passengerMileageRate: number | null
+  travelOriginPostcode: string | null
   defaultPaymentWindowDays: number | null
   invoiceFilenamePattern: string | null
   invoiceEmailSubjectPattern: string | null
@@ -36,6 +37,7 @@ function toUserSettingsForm(settings: SavedUserSettings): UserSettingsForm {
       settings.passengerMileageRate === null
         ? ''
         : String(settings.passengerMileageRate),
+    travelOriginPostcode: settings.travelOriginPostcode ?? '',
     defaultPaymentWindowDays:
       settings.defaultPaymentWindowDays === null
         ? ''
@@ -82,6 +84,7 @@ export function useUserSettings({
       toUserSettingsForm({
         mileageRate: authUser?.mileageRate ?? null,
         passengerMileageRate: authUser?.passengerMileageRate ?? null,
+        travelOriginPostcode: authUser?.travelOriginPostcode ?? null,
         defaultPaymentWindowDays: authUser?.defaultPaymentWindowDays ?? null,
         invoiceFilenamePattern: authUser?.invoiceFilenamePattern ?? null,
         invoiceEmailSubjectPattern: authUser?.invoiceEmailSubjectPattern ?? null,
@@ -121,6 +124,7 @@ export function useUserSettings({
     const passengerMileageRate = parseOptionalDecimal(
       userSettingsForm.passengerMileageRate
     )
+    const travelOriginPostcode = userSettingsForm.travelOriginPostcode.trim()
     const defaultPaymentWindowDaysText = userSettingsForm.defaultPaymentWindowDays.trim()
     const invoiceFilenamePattern = userSettingsForm.invoiceFilenamePattern.trim()
     const invoiceEmailSubjectPattern =
@@ -155,6 +159,7 @@ export function useUserSettings({
         body: JSON.stringify({
           mileageRate,
           passengerMileageRate,
+          travelOriginPostcode: travelOriginPostcode || null,
           defaultPaymentWindowDays,
           invoiceFilenamePattern: invoiceFilenamePattern || null,
           invoiceEmailSubjectPattern: invoiceEmailSubjectPattern || null,
@@ -190,6 +195,7 @@ export function useUserSettings({
               ...current,
               mileageRate: savedSettings.mileageRate,
               passengerMileageRate: savedSettings.passengerMileageRate,
+              travelOriginPostcode: savedSettings.travelOriginPostcode,
               defaultPaymentWindowDays: savedSettings.defaultPaymentWindowDays,
               invoiceFilenamePattern: savedSettings.invoiceFilenamePattern,
               invoiceEmailSubjectPattern: savedSettings.invoiceEmailSubjectPattern,

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -33,6 +33,7 @@ export type AuthUser = {
   profileImageUrl: string
   mileageRate: number | null
   passengerMileageRate: number | null
+  travelOriginPostcode: string | null
   defaultPaymentWindowDays: number | null
   invoiceFilenamePattern: string | null
   invoiceEmailSubjectPattern: string | null
@@ -64,6 +65,7 @@ export type AdminUserForm = {
 export type UserSettingsForm = {
   mileageRate: string
   passengerMileageRate: string
+  travelOriginPostcode: string
   defaultPaymentWindowDays: string
   invoiceFilenamePattern: string
   invoiceEmailSubjectPattern: string


### PR DESCRIPTION
## What changed

- Added backend mileage estimation infrastructure and a Google Routes implementation for estimating gig mileage.
- Added API coverage for mileage estimation and configurable user travel origin settings.
- Added frontend controls for travel origin and mileage estimation in the gigs workflow.
- Added engineering and UAT documentation for mileage routes.
- Added the About article to the docs site and surfaced About, Privacy policy, and Terms of Service links in the app footer/sign-in footer.

## Why

This gives Glovelly a first pass at automatic mileage calculation for gig travel, while keeping the workflow configurable per user. The docs/footer links make the public About, privacy, and terms pages easier to find from the app.

## Validation

- `dotnet test glovelly.sln -m:1`
- `npm --prefix frontend/glovelly-web run lint`
- `dotnet tool run docfx docs/docfx.json`

Note: `gh auth status` reports the local GitHub CLI token is invalid, so this PR was opened via the GitHub connector instead of `gh`.