### PR TITLE
Add Playwright UAT staging workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,9 +118,45 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to Cloud Run
-        if: ${{ (github.event_name != 'pull_request' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
-        id: deploy
+      - name: Deploy to Cloud Run staging
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        id: deploy_staging
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
+          region: ${{ env.GCP_REGION }}
+          image: ${{ env.IMAGE_URI }}:sha-${{ github.sha }}
+          env_vars: |-
+            App__DeploymentName=${{ vars.DEPLOYMENT_NAME }}
+            BlobStorage__BucketName=${{ vars.GCP_BUCKET_NAME }}
+            Email__Mode=Resend
+            Email__AccessRequests__FromDisplayName=Glovelly
+            Email__Invoices__FromDisplayName=Glovelly
+            ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
+            Mcp__OAuth__Issuer=${{ vars.DEPLOYMENT_URL }}
+            Mcp__OAuth__Resource=${{ vars.DEPLOYMENT_URL }}/mcp
+            Mcp__OAuth__Clients__0__DisplayName=ChatGPT
+            Mcp__OAuth__Clients__0__Scopes__0=mcp:read
+          secrets: |-
+            Authentication__Google__ClientId=google-client-id:latest
+            Authentication__Google__ClientSecret=google-client-secret:latest
+            ConnectionStrings__Glovelly=${{ vars.GCP_CONNECTION_STRING_SECRET_ID }}:latest
+            Email__Resend__ApiKey=glovelly-resend-api-key:latest
+            Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest
+            Email__Invoices__FromAddress=glovelly-invoices-from-address:latest
+            Mileage__GoogleRoutes__ApiKey=glovelly-routes-api-key:latest
+            Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest
+            Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest
+            Mcp__OAuth__Clients__0__RedirectUris__0=${{ vars.GCP_CHATGPT_REDIRECT_SECRET_ID }}:latest
+            GLOVELLY_UAT_SECRET=${{ vars.GCP_UAT_SECRET_ID }}:latest
+          secrets_update_strategy: merge
+          flags: >-
+            --allow-unauthenticated
+            --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+
+      - name: Deploy to Cloud Run production
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        id: deploy_production
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
@@ -153,15 +189,19 @@ jobs:
             --allow-unauthenticated
             --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
 
-      - name: Show deployed URL
-        if: ${{ (github.event_name != 'pull_request' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
-        run: echo "Deployed to ${{ steps.deploy.outputs.url }}"
+      - name: Show staging URL
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: echo "Deployed staging to ${{ steps.deploy_staging.outputs.url }}"
+
+      - name: Show production URL
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: echo "Deployed production to ${{ steps.deploy_production.outputs.url }}"
 
       - name: Comment staging URL on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         env:
-          STAGING_URL: ${{ steps.deploy.outputs.url }}
+          STAGING_URL: ${{ steps.deploy_staging.outputs.url }}
         with:
           script: |
             const marker = "<!-- glovelly-staging-preview -->";

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -1,0 +1,110 @@
+name: Glovelly UAT
+
+on:
+  workflow_run:
+    workflows:
+      - Glovelly CI/CD
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  GLOVELLY_UAT_SECRET_ID: ${{ vars.GCP_UAT_SECRET_ID }}
+
+concurrency:
+  group: glovelly-uat-staging
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    name: Playwright UAT against staging
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    runs-on: ubuntu-latest
+    environment: staging
+
+    env:
+      GLOVELLY_UAT_BASE_URL: ${{ vars.DEPLOYMENT_URL }}
+      GLOVELLY_UAT_ARTIFACT_DIR: ${{ github.workspace }}/TestResults/uat
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Load UAT secret from Secret Manager
+        run: |
+          secret_value="$(gcloud secrets versions access latest --secret="$GLOVELLY_UAT_SECRET_ID" --project="$GCP_PROJECT_ID")"
+          if [ -z "$secret_value" ]; then
+            echo "Secret Manager secret '$GLOVELLY_UAT_SECRET_ID' is empty or unavailable."
+            exit 1
+          fi
+          echo "::add-mask::$secret_value"
+          {
+            echo "GLOVELLY_UAT_SECRET<<EOF"
+            echo "$secret_value"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore UAT dependencies
+        run: dotnet restore tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+
+      - name: Build UAT project
+        run: dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj --no-restore --configuration Release
+
+      - name: Install Playwright Chromium
+        run: pwsh tests/Glovelly.Uat.Tests/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
+
+      - name: Verify UAT configuration
+        run: |
+          if [ -z "$GLOVELLY_UAT_BASE_URL" ]; then
+            echo "GLOVELLY_UAT_BASE_URL is not configured. Add it as a staging environment variable."
+            exit 1
+          fi
+          if [ -z "$GLOVELLY_UAT_SECRET" ]; then
+            echo "GLOVELLY_UAT_SECRET is not configured. Create the Secret Manager secret configured by GCP_UAT_SECRET_ID."
+            exit 1
+          fi
+
+      - name: Run Playwright UAT suite
+        run: >-
+          dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+          --no-build
+          --configuration Release
+          --logger "console;verbosity=normal"
+          --logger "trx;LogFileName=uat-test-results.trx"
+          --logger "html;LogFileName=uat-test-report.html"
+          --results-directory "$GLOVELLY_UAT_ARTIFACT_DIR/test-results"
+
+      - name: Upload UAT diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: glovelly-uat-diagnostics
+          path: |
+            TestResults/uat
+          if-no-files-found: warn
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ CodeCoverage/
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
+# Playwright UAT artifacts
+TestResults/uat/
+
 # NUnit
 *.VisualState.xml
 TestResult.xml

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Resend" Version="0.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.0.1" />

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -38,6 +38,12 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
         return factory;
     }
 
+    public GlovellyApiFactory WithEnvironment(string environmentName)
+    {
+        _environmentName = environmentName;
+        return this;
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment(_environmentName);

--- a/backend/Glovelly.Api.Tests/TestAuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/TestAuthEndpointsTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Data;
+using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class TestAuthEndpointsTests
+{
+    private const string UatSecret = "shared-uat-secret";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task Login_IsUnavailableOutsideStaging()
+    {
+        await using var factory = CreateFactory("Production");
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/test-auth/login", null);
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithoutSecret_ReturnsUnauthorized()
+    {
+        await using var factory = CreateFactory("Staging");
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/test-auth/login", null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithInvalidSecret_ReturnsForbidden()
+    {
+        await using var factory = CreateFactory("Staging");
+        var client = factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/test-auth/login");
+        request.Headers.Add("X-Glovelly-Uat-Secret", "wrong-secret");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithValidSecret_SignsInRegressionUserAndSeedsBaselineData()
+    {
+        await using var factory = CreateFactory("Staging");
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+        });
+        var request = new HttpRequestMessage(HttpMethod.Post, "/test-auth/login");
+        request.Headers.Add("X-Glovelly-Uat-Secret", UatSecret);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.Contains("Set-Cookie"));
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(AppDbSeeder.UatRegressionEmail, payload.GetProperty("email").GetString());
+
+        var meResponse = await client.GetAsync("/auth/me");
+
+        Assert.Equal(HttpStatusCode.OK, meResponse.StatusCode);
+        var mePayload = await meResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(AppDbSeeder.UatRegressionEmail, mePayload.GetProperty("email").GetString());
+
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        Assert.NotNull(await dbContext.Users.FindAsync(AppDbSeeder.UatRegressionUserId));
+        Assert.NotNull(await dbContext.Clients.FindAsync(AppDbSeeder.UatRegressionClientId));
+        Assert.NotNull(await dbContext.SellerProfiles.FindAsync(AppDbSeeder.UatRegressionSellerProfileId));
+    }
+
+    private static GlovellyApiFactory CreateFactory(string environmentName)
+    {
+        return new GlovellyApiFactory()
+            .WithConfiguration(new Dictionary<string, string?>
+            {
+                ["Uat:Secret"] = UatSecret,
+            })
+            .WithEnvironment(environmentName);
+    }
+}

--- a/backend/Glovelly.Api/Configuration/StartupSettings.cs
+++ b/backend/Glovelly.Api/Configuration/StartupSettings.cs
@@ -11,8 +11,10 @@ internal sealed record StartupSettings(
     string? BuildTimestamp,
     bool UsePostgres,
     bool IsDevelopment,
+    bool IsStaging,
     bool IsTesting,
-    bool ShouldSeedDevelopmentData)
+    bool ShouldSeedDevelopmentData,
+    bool ShouldSeedUatData)
 {
     public static StartupSettings From(IConfiguration configuration, IWebHostEnvironment environment)
     {
@@ -28,6 +30,8 @@ internal sealed record StartupSettings(
         var buildTimestamp = configuration["App:BuildTimestamp"];
         var usePostgres = !string.IsNullOrWhiteSpace(glovellyConnectionString);
         var isDevelopment = environment.IsDevelopment();
+        var isStaging = environment.IsStaging() ||
+                        string.Equals(deploymentName?.Trim(), "Staging", StringComparison.OrdinalIgnoreCase);
         var isTesting = environment.IsEnvironment("Testing");
 
         return new StartupSettings(
@@ -41,7 +45,9 @@ internal sealed record StartupSettings(
             buildTimestamp,
             usePostgres,
             isDevelopment,
+            isStaging,
             isTesting,
-            ShouldSeedDevelopmentData: !usePostgres && !isTesting);
+            ShouldSeedDevelopmentData: !usePostgres && !isTesting,
+            ShouldSeedUatData: isStaging);
     }
 }

--- a/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
@@ -9,7 +9,8 @@ internal static class WebApplicationExtensions
     public static async Task InitializeDatabaseAsync(
         this WebApplication app,
         IConfiguration configuration,
-        bool shouldSeedDevelopmentData)
+        bool shouldSeedDevelopmentData,
+        bool shouldSeedUatData)
     {
         using var scope = app.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -23,6 +24,11 @@ internal static class WebApplicationExtensions
         else
         {
             await dbContext.Database.EnsureCreatedAsync();
+        }
+
+        if (shouldSeedUatData)
+        {
+            await AppDbSeeder.SeedUatRegressionDataAsync(dbContext);
         }
     }
 

--- a/backend/Glovelly.Api/Data/AppDbSeeder.cs
+++ b/backend/Glovelly.Api/Data/AppDbSeeder.cs
@@ -8,8 +8,102 @@ namespace Glovelly.Api.Data;
 
 public static class AppDbSeeder
 {
+    public static readonly Guid UatRegressionUserId = Guid.Parse("a1111111-1111-4111-8111-111111111111");
+    public static readonly Guid UatRegressionClientId = Guid.Parse("a2222222-2222-4222-8222-222222222222");
+    public static readonly Guid UatRegressionSellerProfileId = Guid.Parse("a3333333-3333-4333-8333-333333333333");
+    public const string UatRegressionGoogleSubject = "glovelly-uat-regression-user";
+    public const string UatRegressionEmail = "regression@glovelly.net";
+    public const string UatRegressionDisplayName = "Glovelly UAT Regression User";
     private static readonly DateTimeOffset SeededCreatedUtc = new(2026, 3, 15, 9, 0, 0, TimeSpan.Zero);
     private static readonly byte[] SeededPdfContent = "Seeded development invoice PDF placeholder"u8.ToArray();
+
+    public static async Task SeedUatRegressionDataAsync(AppDbContext dbContext)
+    {
+        var user = await dbContext.Users.FirstOrDefaultAsync(value => value.Id == UatRegressionUserId);
+        if (user is null)
+        {
+            user = new User
+            {
+                Id = UatRegressionUserId,
+                CreatedUtc = SeededCreatedUtc.UtcDateTime,
+            };
+            dbContext.Users.Add(user);
+        }
+
+        user.GoogleSubject = UatRegressionGoogleSubject;
+        user.Email = UatRegressionEmail;
+        user.DisplayName = UatRegressionDisplayName;
+        user.MileageRate = 0.45m;
+        user.PassengerMileageRate = 0.10m;
+        user.TravelOriginPostcode = "BS1 5AA";
+        user.DefaultPaymentWindowDays = 14;
+        user.InvoiceFilenamePattern = "{invoiceNumber}-{clientName}-{periodDate}";
+        user.InvoiceEmailSubjectPattern = "Invoice {invoiceNumber} for {clientName}";
+        user.InvoiceReplyToEmail = UatRegressionEmail;
+        user.Role = UserRole.User;
+        user.IsActive = true;
+
+        var client = await dbContext.Clients.FirstOrDefaultAsync(value => value.Id == UatRegressionClientId);
+        if (client is null)
+        {
+            client = new Client
+            {
+                Id = UatRegressionClientId,
+                CreatedByUserId = UatRegressionUserId,
+            };
+            dbContext.Clients.Add(client);
+        }
+
+        client.Name = "UAT Regression Client";
+        client.Email = "accounts+uat@glovelly.net";
+        client.MileageRate = 0.45m;
+        client.PassengerMileageRate = 0.10m;
+        client.InvoiceFilenamePattern = "{invoiceNumber}-{clientName}";
+        client.InvoiceEmailSubjectPattern = "UAT invoice {invoiceNumber}";
+        client.UpdatedByUserId = UatRegressionUserId;
+        client.BillingAddress = new Address
+        {
+            Line1 = "1 Regression Yard",
+            City = "Bristol",
+            StateOrCounty = "Bristol",
+            PostalCode = "BS1 5AA",
+            Country = "United Kingdom"
+        };
+
+        var sellerProfile = await dbContext.SellerProfiles
+            .FirstOrDefaultAsync(value => value.UserId == UatRegressionUserId);
+        if (sellerProfile is null)
+        {
+            sellerProfile = new SellerProfile
+            {
+                Id = UatRegressionSellerProfileId,
+                UserId = UatRegressionUserId,
+                CreatedUtc = SeededCreatedUtc,
+                CreatedByUserId = UatRegressionUserId,
+            };
+            dbContext.SellerProfiles.Add(sellerProfile);
+        }
+
+        sellerProfile.SellerName = "Glovelly UAT Music";
+        sellerProfile.Email = UatRegressionEmail;
+        sellerProfile.Phone = "07123 000000";
+        sellerProfile.AccountName = "Glovelly UAT Music";
+        sellerProfile.SortCode = "00-00-00";
+        sellerProfile.AccountNumber = "00000000";
+        sellerProfile.PaymentReferenceNote = "UAT-only invoice payment reference.";
+        sellerProfile.Address = new Address
+        {
+            Line1 = "1 Regression Yard",
+            City = "Bristol",
+            StateOrCounty = "Bristol",
+            PostalCode = "BS1 5AA",
+            Country = "United Kingdom"
+        };
+        sellerProfile.UpdatedUtc = SeededCreatedUtc;
+        sellerProfile.UpdatedByUserId = UatRegressionUserId;
+
+        await dbContext.SaveChangesAsync();
+    }
 
     public static async Task SeedAsync(
         AppDbContext dbContext,

--- a/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthFlowSupport.cs
@@ -55,7 +55,8 @@ internal static class AuthFlowSupport
                path.StartsWithSegments("/invoices") ||
                path.StartsWithSegments("/invoice-lines") ||
                path.StartsWithSegments("/mcp") ||
-               path.StartsWithSegments("/seller-profile");
+               path.StartsWithSegments("/seller-profile") ||
+               path.StartsWithSegments("/test-auth");
     }
 
     public static string GetAuthenticationFailureCode(Exception? exception)

--- a/backend/Glovelly.Api/Endpoints/TestAuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/TestAuthEndpoints.cs
@@ -1,0 +1,105 @@
+using Glovelly.Api.Auth;
+using Glovelly.Api.Configuration;
+using Glovelly.Api.Data;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Glovelly.Api.Endpoints;
+
+internal static class TestAuthEndpoints
+{
+    private const string SecretHeaderName = "X-Glovelly-Uat-Secret";
+
+    public static IEndpointRouteBuilder MapTestAuthEndpoints(this IEndpointRouteBuilder app, StartupSettings settings)
+    {
+        if (!settings.IsStaging)
+        {
+            return app;
+        }
+
+        var group = app.MapGroup("/test-auth").AllowAnonymous();
+
+        group.MapPost("/login", async (
+            HttpContext httpContext,
+            AppDbContext dbContext,
+            IConfiguration configuration,
+            string? returnUrl) =>
+        {
+            var suppliedSecret = httpContext.Request.Headers[SecretHeaderName].FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(suppliedSecret))
+            {
+                return Results.Unauthorized();
+            }
+
+            var configuredSecret = configuration["GLOVELLY_UAT_SECRET"] ?? configuration["Uat:Secret"];
+            if (string.IsNullOrWhiteSpace(configuredSecret))
+            {
+                return Results.Problem(
+                    detail: "Staging UAT authentication is not configured.",
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            if (!SecretsMatch(suppliedSecret, configuredSecret))
+            {
+                return Results.Forbid();
+            }
+
+            await AppDbSeeder.SeedUatRegressionDataAsync(dbContext);
+
+            var user = await dbContext.Users
+                .AsNoTracking()
+                .FirstAsync(value => value.Id == AppDbSeeder.UatRegressionUserId && value.IsActive);
+
+            var claims = new[]
+            {
+                new Claim(GlovellyClaimTypes.UserId, user.Id.ToString()),
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Email, user.Email),
+                new Claim("email", user.Email),
+                new Claim(ClaimTypes.Role, user.Role.ToString()),
+                new Claim("role", user.Role.ToString()),
+                new Claim(ClaimTypes.Name, user.DisplayName ?? user.Email),
+                new Claim("name", user.DisplayName ?? user.Email),
+                new Claim("sub", user.GoogleSubject ?? AppDbSeeder.UatRegressionGoogleSubject),
+            };
+
+            var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+            await httpContext.SignInAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme,
+                new ClaimsPrincipal(identity),
+                new AuthenticationProperties
+                {
+                    IsPersistent = false,
+                    IssuedUtc = DateTimeOffset.UtcNow,
+                });
+
+            if (!string.IsNullOrWhiteSpace(returnUrl))
+            {
+                return Results.Redirect(AuthFlowSupport.BuildSafeRedirectUri(httpContext, returnUrl));
+            }
+
+            return Results.Ok(new
+            {
+                userId = user.Id,
+                email = user.Email,
+                name = user.DisplayName,
+                role = user.Role.ToString(),
+            });
+        });
+
+        return app;
+    }
+
+    private static bool SecretsMatch(string suppliedSecret, string configuredSecret)
+    {
+        var suppliedBytes = Encoding.UTF8.GetBytes(suppliedSecret);
+        var configuredBytes = Encoding.UTF8.GetBytes(configuredSecret);
+
+        return suppliedBytes.Length == configuredBytes.Length &&
+               CryptographicOperations.FixedTimeEquals(suppliedBytes, configuredBytes);
+    }
+}

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -9,11 +9,15 @@ builder.Services.AddGlovellyAuthentication(startupSettings);
 
 var app = builder.Build();
 
-await app.InitializeDatabaseAsync(builder.Configuration, startupSettings.ShouldSeedDevelopmentData);
+await app.InitializeDatabaseAsync(
+    builder.Configuration,
+    startupSettings.ShouldSeedDevelopmentData,
+    startupSettings.ShouldSeedUatData);
 
 app.UseGlovellyHttpPipeline(startupSettings);
 app.MapAppMetadataEndpoints(startupSettings);
 app.MapAuthEndpoints(startupSettings);
+app.MapTestAuthEndpoints(startupSettings);
 app.MapAccessEndpoints(startupSettings);
 app.MapGoogleDriveIntegrationEndpoints(startupSettings);
 app.MapMcpOAuthEndpoints();

--- a/docs/engineering/authentication.md
+++ b/docs/engineering/authentication.md
@@ -54,3 +54,10 @@ User mapping and first-login subject binding happen during Google token validati
 
 Current-user access and policy names live under `backend/Glovelly.Api/Auth/`.
 
+## Staging UAT Authentication
+
+Staging registers `POST /test-auth/login` so browser-based UAT tests can authenticate deterministically without exercising Google on every regression run.
+
+The endpoint is intentionally not registered outside staging. In staging it requires the `X-Glovelly-Uat-Secret` header to match `GLOVELLY_UAT_SECRET` and signs in the seeded `regression@glovelly.net` test-only user with the normal Glovelly auth cookie.
+
+Do not enable this endpoint in production. It exists only to make Playwright regression tests stable; Google authentication should still be covered separately by manual or focused checks.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,6 +62,12 @@ Use [docs/uat/index.md](uat/index.md) for human regression journeys that cut acr
 
 Start with [docs/uat/pre-merge-regression.md](uat/pre-merge-regression.md) for broad pre-merge checks. Use the focused invoice, expense, and enrolment/access pages when a change touches those areas. Keep the journeys scenario-based so they can later be automated as browser tests.
 
+## Browser UAT
+
+Staging seeds a test-only regression user, baseline client, and seller profile for browser automation. Playwright can authenticate by posting to `POST /test-auth/login` with `X-Glovelly-Uat-Secret`; the secret should come from `GLOVELLY_UAT_SECRET` in staging and GitHub Actions.
+
+Tests should create run-specific records using a run ID such as `UAT-<timestamp>-<short-sha>` rather than mutating shared baseline data.
+
 ## What to Add When Changing Behavior
 
 - New backend route: add endpoint tests for success, validation failure, authorization/session behavior when relevant, and user visibility boundaries.

--- a/frontend/glovelly-web/public/sw.js
+++ b/frontend/glovelly-web/public/sw.js
@@ -29,6 +29,7 @@ self.addEventListener('fetch', (event) => {
   const requestUrl = new URL(event.request.url)
   if (
     requestUrl.pathname.startsWith('/auth') ||
+    requestUrl.pathname.startsWith('/test-auth') ||
     requestUrl.pathname.startsWith('/admin') ||
     requestUrl.pathname.startsWith('/clients') ||
     requestUrl.pathname.startsWith('/gigs') ||

--- a/frontend/glovelly-web/vite.config.ts
+++ b/frontend/glovelly-web/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         target: 'http://localhost:5153',
         changeOrigin: true,
       },
+      '/test-auth': {
+        target: 'http://localhost:5153',
+        changeOrigin: true,
+      },
       '/clients': {
         target: 'http://localhost:5153',
         changeOrigin: true,

--- a/tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+++ b/tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Glovelly.Uat.Tests/README.md
+++ b/tests/Glovelly.Uat.Tests/README.md
@@ -1,0 +1,28 @@
+# Glovelly UAT Tests
+
+This project contains Playwright-based UAT and regression smoke tests. It is intentionally kept outside `glovelly.sln` so `dotnet test glovelly.sln` remains a fast backend test command.
+
+## Install Browsers
+
+Build the project, then install Chromium for the Playwright version restored by NuGet:
+
+```bash
+dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+pwsh tests/Glovelly.Uat.Tests/bin/Debug/net10.0/playwright.ps1 install chromium
+```
+
+If PowerShell is not installed, install it first or run the generated `playwright.ps1` script from an environment that has `pwsh` available.
+
+## Run
+
+`GLOVELLY_UAT_BASE_URL` is required and should point at the deployment under test.
+
+```bash
+GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+```
+
+Tests run headless by default. To see the browser:
+
+```bash
+GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net GLOVELLY_UAT_HEADLESS=false dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+```

--- a/tests/Glovelly.Uat.Tests/README.md
+++ b/tests/Glovelly.Uat.Tests/README.md
@@ -11,15 +11,36 @@ dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
 pwsh tests/Glovelly.Uat.Tests/bin/Debug/net10.0/playwright.ps1 install chromium
 ```
 
+CI runs the Release build and installs Linux browser dependencies too:
+
+```bash
+dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj --configuration Release
+pwsh tests/Glovelly.Uat.Tests/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
+```
+
 If PowerShell is not installed, install it first or run the generated `playwright.ps1` script from an environment that has `pwsh` available.
 
 ## Run
 
-`GLOVELLY_UAT_BASE_URL` is required and should point at the deployment under test.
+`GLOVELLY_UAT_BASE_URL` is required and should point at the deployment under test. `GLOVELLY_UAT_SECRET` is required for tests that use staging-only test authentication.
 
 ```bash
 GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
 ```
+
+To mirror CI diagnostics locally:
+
+```bash
+GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net \
+GLOVELLY_UAT_SECRET=<secret> \
+GLOVELLY_UAT_ARTIFACT_DIR=TestResults/uat \
+dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj \
+  --logger "trx;LogFileName=uat-test-results.trx" \
+  --logger "html;LogFileName=uat-test-report.html" \
+  --results-directory TestResults/uat/test-results
+```
+
+On failure, tests write Playwright trace zips to `TestResults/uat/playwright-traces` and screenshots to `TestResults/uat/screenshots`.
 
 Tests run headless by default. To see the browser:
 

--- a/tests/Glovelly.Uat.Tests/SmokeTests.cs
+++ b/tests/Glovelly.Uat.Tests/SmokeTests.cs
@@ -9,11 +9,12 @@ public sealed class SmokeTests : IAsyncLifetime
     private IBrowser? browser;
     private IBrowserContext? context;
     private IPage? page;
+    private bool tracingActive;
 
     private IPage Page => page ?? throw new InvalidOperationException("The Playwright page has not been initialized.");
 
     [Fact]
-    public async Task HomePageLoadsSuccessfully()
+    public Task HomePageLoadsSuccessfully() => RunWithDiagnosticsAsync(nameof(HomePageLoadsSuccessfully), async () =>
     {
         var response = await Page.GotoAsync("/", new PageGotoOptions
         {
@@ -23,10 +24,10 @@ public sealed class SmokeTests : IAsyncLifetime
         Assert.NotNull(response);
         Assert.True(response.Ok, $"Expected the home page to return a successful response, but received HTTP {response.Status}.");
         await Page.GetByRole(AriaRole.Heading, new() { NameRegex = GlovellyHeadingRegex() }).WaitForAsync();
-    }
+    });
 
     [Fact]
-    public async Task SignInEntryPointIsVisible()
+    public Task SignInEntryPointIsVisible() => RunWithDiagnosticsAsync(nameof(SignInEntryPointIsVisible), async () =>
     {
         await Page.GotoAsync("/", new PageGotoOptions
         {
@@ -40,7 +41,7 @@ public sealed class SmokeTests : IAsyncLifetime
             State = WaitForSelectorState.Visible,
         });
         Assert.True(await signInButton.IsEnabledAsync(), "Expected the Google sign-in entry point to be enabled.");
-    }
+    });
 
     public async Task InitializeAsync()
     {
@@ -53,6 +54,13 @@ public sealed class SmokeTests : IAsyncLifetime
         {
             BaseURL = BaseUrl(),
         });
+        await context.Tracing.StartAsync(new TracingStartOptions
+        {
+            Screenshots = true,
+            Snapshots = true,
+            Sources = true,
+        });
+        tracingActive = true;
         page = await context.NewPageAsync();
     }
 
@@ -60,6 +68,12 @@ public sealed class SmokeTests : IAsyncLifetime
     {
         if (context is not null)
         {
+            if (tracingActive)
+            {
+                await context.Tracing.StopAsync();
+                tracingActive = false;
+            }
+
             await context.DisposeAsync();
         }
 
@@ -69,6 +83,47 @@ public sealed class SmokeTests : IAsyncLifetime
         }
 
         playwright?.Dispose();
+    }
+
+    private async Task RunWithDiagnosticsAsync(string testName, Func<Task> testBody)
+    {
+        try
+        {
+            await testBody();
+        }
+        catch
+        {
+            await CaptureFailureDiagnosticsAsync(testName);
+            throw;
+        }
+    }
+
+    private async Task CaptureFailureDiagnosticsAsync(string testName)
+    {
+        var artifactDirectory = ArtifactDirectory();
+        var safeTestName = SafeArtifactName(testName);
+
+        if (page is not null)
+        {
+            var screenshotDirectory = Path.Combine(artifactDirectory, "screenshots");
+            Directory.CreateDirectory(screenshotDirectory);
+            await page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = Path.Combine(screenshotDirectory, $"{safeTestName}.png"),
+                FullPage = true,
+            });
+        }
+
+        if (context is not null && tracingActive)
+        {
+            var traceDirectory = Path.Combine(artifactDirectory, "playwright-traces");
+            Directory.CreateDirectory(traceDirectory);
+            await context.Tracing.StopAsync(new TracingStopOptions
+            {
+                Path = Path.Combine(traceDirectory, $"{safeTestName}.zip"),
+            });
+            tracingActive = false;
+        }
     }
 
     private static string BaseUrl()
@@ -93,6 +148,23 @@ public sealed class SmokeTests : IAsyncLifetime
         var value = Environment.GetEnvironmentVariable("GLOVELLY_UAT_HEADLESS");
 
         return !bool.TryParse(value, out var headless) || headless;
+    }
+
+    private static string ArtifactDirectory()
+    {
+        var directory = Environment.GetEnvironmentVariable("GLOVELLY_UAT_ARTIFACT_DIR")?.Trim();
+
+        return string.IsNullOrWhiteSpace(directory)
+            ? Path.Combine("TestResults", "uat")
+            : directory;
+    }
+
+    private static string SafeArtifactName(string value)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var chars = value.Select(valueChar => invalidChars.Contains(valueChar) ? '-' : valueChar).ToArray();
+
+        return new string(chars);
     }
 
     private static System.Text.RegularExpressions.Regex GlovellyHeadingRegex()

--- a/tests/Glovelly.Uat.Tests/SmokeTests.cs
+++ b/tests/Glovelly.Uat.Tests/SmokeTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public sealed class SmokeTests : IAsyncLifetime
+{
+    private IPlaywright? playwright;
+    private IBrowser? browser;
+    private IBrowserContext? context;
+    private IPage? page;
+
+    private IPage Page => page ?? throw new InvalidOperationException("The Playwright page has not been initialized.");
+
+    [Fact]
+    public async Task HomePageLoadsSuccessfully()
+    {
+        var response = await Page.GotoAsync("/", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.Load,
+        });
+
+        Assert.NotNull(response);
+        Assert.True(response.Ok, $"Expected the home page to return a successful response, but received HTTP {response.Status}.");
+        await Page.GetByRole(AriaRole.Heading, new() { NameRegex = GlovellyHeadingRegex() }).WaitForAsync();
+    }
+
+    [Fact]
+    public async Task SignInEntryPointIsVisible()
+    {
+        await Page.GotoAsync("/", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.Load,
+        });
+
+        var signInButton = Page.GetByRole(AriaRole.Button, new() { Name = "Continue with Google" });
+
+        await signInButton.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+        Assert.True(await signInButton.IsEnabledAsync(), "Expected the Google sign-in entry point to be enabled.");
+    }
+
+    public async Task InitializeAsync()
+    {
+        playwright = await Playwright.CreateAsync();
+        browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = Headless(),
+        });
+        context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = BaseUrl(),
+        });
+        page = await context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (context is not null)
+        {
+            await context.DisposeAsync();
+        }
+
+        if (browser is not null)
+        {
+            await browser.DisposeAsync();
+        }
+
+        playwright?.Dispose();
+    }
+
+    private static string BaseUrl()
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("GLOVELLY_UAT_BASE_URL")?.Trim();
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException("Set GLOVELLY_UAT_BASE_URL to the Glovelly deployment under test, for example https://staging.glovelly.net.");
+        }
+
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
+        {
+            throw new InvalidOperationException("GLOVELLY_UAT_BASE_URL must be an absolute HTTP or HTTPS URL.");
+        }
+
+        return uri.ToString().TrimEnd('/');
+    }
+
+    private static bool Headless()
+    {
+        var value = Environment.GetEnvironmentVariable("GLOVELLY_UAT_HEADLESS");
+
+        return !bool.TryParse(value, out var headless) || headless;
+    }
+
+    private static System.Text.RegularExpressions.Regex GlovellyHeadingRegex()
+    {
+        return new System.Text.RegularExpressions.Regex("Glovelly", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add the Playwright .NET UAT smoke test project and local run documentation
- add staging-only test authentication and seeded regression data for browser automation
- add a staging UAT GitHub Actions workflow with Chromium setup, reports, screenshots, and Playwright traces
- bind the UAT secret only to staging Cloud Run and load it from GCP Secret Manager for UAT runs

## Verification
- dotnet test glovelly.sln -m:1
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj --configuration Release
- dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj --configuration Release --no-build --list-tests

Closes #154
Closes #155
Closes #156