### PR TITLE
Gate production deployment on staging UAT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,12 @@ on:
       - main
     paths:
       - ".github/workflows/main.yml"
+      - ".github/workflows/uat.yml"
       - ".dockerignore"
       - "Dockerfile"
       - "backend/**"
       - "frontend/**"
+      - "tests/**"
       - "glovelly.sln"
   pull_request:
     types:
@@ -18,10 +20,12 @@ on:
       - reopened
     paths:
       - ".github/workflows/main.yml"
+      - ".github/workflows/uat.yml"
       - ".dockerignore"
       - "Dockerfile"
       - "backend/**"
       - "frontend/**"
+      - "tests/**"
       - "glovelly.sln"
   workflow_dispatch:
     inputs:
@@ -56,9 +60,13 @@ env:
   IMAGE_URI: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/glovelly/glovelly
 
 jobs:
-  container:
+  build:
+    name: Build and test image
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'pull_request' && 'staging' || (github.event_name == 'workflow_dispatch' && inputs.target_environment || 'production') }}
+    environment: staging
+
+    outputs:
+      image_uri: ${{ steps.image.outputs.uri }}
 
     steps:
       - name: Check out repository
@@ -112,6 +120,10 @@ jobs:
             type=sha,prefix=sha-,format=long
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Capture deployable image URI
+        id: image
+        run: echo "uri=${IMAGE_URI}:sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Build and optionally push container image
         id: build
         uses: docker/build-push-action@v6
@@ -127,16 +139,39 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  deploy_staging:
+    name: Deploy staging
+    needs: build
+    runs-on: ubuntu-latest
+    environment: staging
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production' && github.ref == 'refs/heads/main')
+
+    outputs:
+      url: ${{ steps.deploy_staging.outputs.url }}
+
+    steps:
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Deploy to Cloud Run staging
-        if: >-
-          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging')
         id: deploy_staging
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
           region: ${{ env.GCP_REGION }}
-          image: ${{ env.IMAGE_URI }}:sha-${{ github.sha }}
+          image: ${{ needs.build.outputs.image_uri }}
           env_vars: |-
             App__DeploymentName=${{ vars.DEPLOYMENT_NAME }}
             BlobStorage__BucketName=${{ vars.GCP_BUCKET_NAME }}
@@ -165,54 +200,8 @@ jobs:
             --allow-unauthenticated
             --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
 
-      - name: Deploy to Cloud Run production
-        if: >-
-          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production' && github.ref == 'refs/heads/main')
-        id: deploy_production
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          service: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
-          region: ${{ env.GCP_REGION }}
-          image: ${{ env.IMAGE_URI }}:sha-${{ github.sha }}
-          env_vars: |-
-            App__DeploymentName=${{ vars.DEPLOYMENT_NAME }}
-            BlobStorage__BucketName=${{ vars.GCP_BUCKET_NAME }}
-            Email__Mode=Resend
-            Email__AccessRequests__FromDisplayName=Glovelly
-            Email__Invoices__FromDisplayName=Glovelly
-            ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
-            Mcp__OAuth__Issuer=${{ vars.DEPLOYMENT_URL }}
-            Mcp__OAuth__Resource=${{ vars.DEPLOYMENT_URL }}/mcp
-            Mcp__OAuth__Clients__0__DisplayName=ChatGPT
-            Mcp__OAuth__Clients__0__Scopes__0=mcp:read
-          secrets: |-
-            Authentication__Google__ClientId=google-client-id:latest
-            Authentication__Google__ClientSecret=google-client-secret:latest
-            ConnectionStrings__Glovelly=${{ vars.GCP_CONNECTION_STRING_SECRET_ID }}:latest
-            Email__Resend__ApiKey=glovelly-resend-api-key:latest
-            Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest
-            Email__Invoices__FromAddress=glovelly-invoices-from-address:latest
-            Mileage__GoogleRoutes__ApiKey=glovelly-routes-api-key:latest
-            Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest
-            Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest
-            Mcp__OAuth__Clients__0__RedirectUris__0=${{ vars.GCP_CHATGPT_REDIRECT_SECRET_ID }}:latest
-          secrets_update_strategy: merge
-          flags: >-
-            --allow-unauthenticated
-            --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-
       - name: Show staging URL
-        if: >-
-          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging')
         run: echo "Deployed staging to ${{ steps.deploy_staging.outputs.url }}"
-
-      - name: Show production URL
-        if: >-
-          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production' && github.ref == 'refs/heads/main')
-        run: echo "Deployed production to ${{ steps.deploy_production.outputs.url }}"
 
       - name: Comment staging URL on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -248,3 +237,90 @@ jobs:
                 body,
               });
             }
+
+  staging_uat:
+    name: Run staging UAT
+    needs: deploy_staging
+    uses: ./.github/workflows/uat.yml
+    with:
+      environment_name: staging
+      require_uat_secret: true
+      require_invoice_recipient: true
+      artifact_name: glovelly-staging-uat-diagnostics
+
+  deploy_production:
+    name: Deploy production
+    needs:
+      - build
+      - staging_uat
+    runs-on: ubuntu-latest
+    environment: production
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production' && github.ref == 'refs/heads/main')
+
+    outputs:
+      url: ${{ steps.deploy_production.outputs.url }}
+
+    steps:
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy to Cloud Run production
+        id: deploy_production
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
+          region: ${{ env.GCP_REGION }}
+          image: ${{ needs.build.outputs.image_uri }}
+          env_vars: |-
+            App__DeploymentName=${{ vars.DEPLOYMENT_NAME }}
+            BlobStorage__BucketName=${{ vars.GCP_BUCKET_NAME }}
+            Email__Mode=Resend
+            Email__AccessRequests__FromDisplayName=Glovelly
+            Email__Invoices__FromDisplayName=Glovelly
+            ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
+            Mcp__OAuth__Issuer=${{ vars.DEPLOYMENT_URL }}
+            Mcp__OAuth__Resource=${{ vars.DEPLOYMENT_URL }}/mcp
+            Mcp__OAuth__Clients__0__DisplayName=ChatGPT
+            Mcp__OAuth__Clients__0__Scopes__0=mcp:read
+          secrets: |-
+            Authentication__Google__ClientId=google-client-id:latest
+            Authentication__Google__ClientSecret=google-client-secret:latest
+            ConnectionStrings__Glovelly=${{ vars.GCP_CONNECTION_STRING_SECRET_ID }}:latest
+            Email__Resend__ApiKey=glovelly-resend-api-key:latest
+            Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest
+            Email__Invoices__FromAddress=glovelly-invoices-from-address:latest
+            Mileage__GoogleRoutes__ApiKey=glovelly-routes-api-key:latest
+            Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest
+            Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest
+            Mcp__OAuth__Clients__0__RedirectUris__0=${{ vars.GCP_CHATGPT_REDIRECT_SECRET_ID }}:latest
+          secrets_update_strategy: merge
+          flags: >-
+            --allow-unauthenticated
+            --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+
+      - name: Show production URL
+        run: echo "Deployed production to ${{ steps.deploy_production.outputs.url }}"
+
+  production_smoke:
+    name: Run production smoke tests
+    needs: deploy_production
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/uat.yml
+    with:
+      environment_name: production
+      test_filter: Suite=Smoke
+      require_uat_secret: false
+      require_invoice_recipient: false
+      artifact_name: glovelly-production-smoke-diagnostics

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,15 @@ on:
       - "frontend/**"
       - "glovelly.sln"
   workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Deployment target
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
 
 permissions:
   contents: read
@@ -49,7 +58,7 @@ env:
 jobs:
   container:
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'pull_request' && 'staging' || 'production' }}
+    environment: ${{ github.event_name == 'pull_request' && 'staging' || (github.event_name == 'workflow_dispatch' && inputs.target_environment || 'production') }}
 
     steps:
       - name: Check out repository
@@ -119,7 +128,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to Cloud Run staging
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging')
         id: deploy_staging
         uses: google-github-actions/deploy-cloudrun@v2
         with:
@@ -155,7 +166,9 @@ jobs:
             --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
 
       - name: Deploy to Cloud Run production
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production' && github.ref == 'refs/heads/main')
         id: deploy_production
         uses: google-github-actions/deploy-cloudrun@v2
         with:
@@ -190,11 +203,15 @@ jobs:
             --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
 
       - name: Show staging URL
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging')
         run: echo "Deployed staging to ${{ steps.deploy_staging.outputs.url }}"
 
       - name: Show production URL
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production' && github.ref == 'refs/heads/main')
         run: echo "Deployed production to ${{ steps.deploy_production.outputs.url }}"
 
       - name: Comment staging URL on PR

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -36,6 +36,7 @@ jobs:
     env:
       GLOVELLY_UAT_BASE_URL: ${{ vars.DEPLOYMENT_URL }}
       GLOVELLY_UAT_ARTIFACT_DIR: ${{ github.workspace }}/TestResults/uat
+      GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL: ${{ vars.GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL }}
 
     steps:
       - name: Check out repository
@@ -86,6 +87,10 @@ jobs:
           fi
           if [ -z "$GLOVELLY_UAT_SECRET" ]; then
             echo "GLOVELLY_UAT_SECRET is not configured. Create the Secret Manager secret configured by GCP_UAT_SECRET_ID."
+            exit 1
+          fi
+          if [ -z "$GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL" ]; then
+            echo "GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL is not configured. Add it as a controlled staging environment variable."
             exit 1
           fi
 

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -104,6 +104,32 @@ jobs:
           --logger "html;LogFileName=uat-test-report.html"
           --results-directory "$GLOVELLY_UAT_ARTIFACT_DIR/test-results"
 
+      - name: Publish UAT test results
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: Playwright UAT Results
+          path: ${{ env.GLOVELLY_UAT_ARTIFACT_DIR }}/test-results/*.trx
+          reporter: dotnet-trx
+          fail-on-error: false
+
+      - name: Summarize UAT diagnostics
+        if: always()
+        run: |
+          {
+            echo "### Playwright UAT Diagnostics"
+            echo ""
+            echo "GitHub-native test results are published in the \`Playwright UAT Results\` check when a TRX file is available."
+            echo ""
+            echo "Full diagnostics are uploaded in the \`glovelly-uat-diagnostics\` artifact:"
+            echo ""
+            echo "- HTML report: \`TestResults/uat/test-results/uat-test-report.html\`"
+            echo "- Screenshots: \`TestResults/uat/screenshots\`"
+            echo "- Playwright traces: \`TestResults/uat/playwright-traces\`"
+            echo ""
+            echo "Open a trace locally with: \`npx playwright show-trace <trace.zip>\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload UAT diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -1,12 +1,62 @@
 name: Glovelly UAT
 
 on:
-  workflow_run:
-    workflows:
-      - Glovelly CI/CD
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      environment_name:
+        description: GitHub environment containing deployment variables
+        required: true
+        type: string
+      test_filter:
+        description: Optional dotnet test filter
+        required: false
+        type: string
+        default: ""
+      require_uat_secret:
+        description: Load staging-only UAT authentication secret
+        required: false
+        type: boolean
+        default: true
+      require_invoice_recipient:
+        description: Require configured invoice recipient email
+        required: false
+        type: boolean
+        default: true
+      artifact_name:
+        description: Diagnostics artifact name
+        required: false
+        type: string
+        default: glovelly-uat-diagnostics
   workflow_dispatch:
+    inputs:
+      environment_name:
+        description: GitHub environment containing deployment variables
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+      test_filter:
+        description: Optional dotnet test filter, for example Suite=Smoke
+        required: false
+        default: ""
+        type: string
+      require_uat_secret:
+        description: Load staging-only UAT authentication secret
+        required: true
+        default: true
+        type: boolean
+      require_invoice_recipient:
+        description: Require configured invoice recipient email
+        required: true
+        default: true
+        type: boolean
+      artifact_name:
+        description: Diagnostics artifact name
+        required: true
+        default: glovelly-uat-diagnostics
+        type: string
 
 permissions:
   contents: read
@@ -19,39 +69,38 @@ env:
   GLOVELLY_UAT_SECRET_ID: ${{ vars.GCP_UAT_SECRET_ID }}
 
 concurrency:
-  group: glovelly-uat-staging
+  group: glovelly-uat-${{ inputs.environment_name || 'staging' }}
   cancel-in-progress: true
 
 jobs:
   playwright:
-    name: Playwright UAT against staging
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'pull_request' &&
-       github.event.workflow_run.head_repository.full_name == github.repository)
+    name: Playwright against ${{ inputs.environment_name || 'staging' }}
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ inputs.environment_name || 'staging' }}
 
     env:
       GLOVELLY_UAT_BASE_URL: ${{ vars.DEPLOYMENT_URL }}
       GLOVELLY_UAT_ARTIFACT_DIR: ${{ github.workspace }}/TestResults/uat
       GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL: ${{ vars.GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL }}
+      GLOVELLY_UAT_TEST_FILTER: ${{ inputs.test_filter }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud
+        if: inputs.require_uat_secret != false
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
+        if: inputs.require_uat_secret != false
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Load UAT secret from Secret Manager
+        if: inputs.require_uat_secret != false
         run: |
           secret_value="$(gcloud secrets versions access latest --secret="$GLOVELLY_UAT_SECRET_ID" --project="$GCP_PROJECT_ID")"
           if [ -z "$secret_value" ]; then
@@ -82,27 +131,33 @@ jobs:
       - name: Verify UAT configuration
         run: |
           if [ -z "$GLOVELLY_UAT_BASE_URL" ]; then
-            echo "GLOVELLY_UAT_BASE_URL is not configured. Add it as a staging environment variable."
+            echo "GLOVELLY_UAT_BASE_URL is not configured. Add DEPLOYMENT_URL as an environment variable."
             exit 1
           fi
-          if [ -z "$GLOVELLY_UAT_SECRET" ]; then
+          if [ "${{ inputs.require_uat_secret }}" = "true" ] && [ -z "$GLOVELLY_UAT_SECRET" ]; then
             echo "GLOVELLY_UAT_SECRET is not configured. Create the Secret Manager secret configured by GCP_UAT_SECRET_ID."
             exit 1
           fi
-          if [ -z "$GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL" ]; then
+          if [ "${{ inputs.require_invoice_recipient }}" = "true" ] && [ -z "$GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL" ]; then
             echo "GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL is not configured. Add it as a controlled staging environment variable."
             exit 1
           fi
 
       - name: Run Playwright UAT suite
-        run: >-
-          dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
-          --no-build
-          --configuration Release
-          --logger "console;verbosity=normal"
-          --logger "trx;LogFileName=uat-test-results.trx"
-          --logger "html;LogFileName=uat-test-report.html"
-          --results-directory "$GLOVELLY_UAT_ARTIFACT_DIR/test-results"
+        run: |
+          test_args=(
+            tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+            --no-build
+            --configuration Release
+            --logger "console;verbosity=normal"
+            --logger "trx;LogFileName=uat-test-results.trx"
+            --logger "html;LogFileName=uat-test-report.html"
+            --results-directory "$GLOVELLY_UAT_ARTIFACT_DIR/test-results"
+          )
+          if [ -n "$GLOVELLY_UAT_TEST_FILTER" ]; then
+            test_args+=(--filter "$GLOVELLY_UAT_TEST_FILTER")
+          fi
+          dotnet test "${test_args[@]}"
 
       - name: Publish UAT test results
         if: always()
@@ -121,7 +176,7 @@ jobs:
             echo ""
             echo "GitHub-native test results are published in the \`Playwright UAT Results\` check when a TRX file is available."
             echo ""
-            echo "Full diagnostics are uploaded in the \`glovelly-uat-diagnostics\` artifact:"
+            echo "Full diagnostics are uploaded in the \`${{ inputs.artifact_name }}\` artifact:"
             echo ""
             echo "- HTML report: \`TestResults/uat/test-results/uat-test-report.html\`"
             echo "- Screenshots: \`TestResults/uat/screenshots\`"
@@ -134,7 +189,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: glovelly-uat-diagnostics
+          name: ${{ inputs.artifact_name }}
           path: |
             TestResults/uat
           if-no-files-found: warn

--- a/backend/Glovelly.Api.Tests/AppMetadataEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AppMetadataEndpointsTests.cs
@@ -1,0 +1,28 @@
+using Glovelly.Api.Tests.Infrastructure;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class AppMetadataEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public AppMetadataEndpointsTests(GlovellyApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Health_ReturnsOkStatus()
+    {
+        var response = await _client.GetAsync("/health");
+
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<HealthPayload>();
+        Assert.Equal("ok", payload?.Status);
+    }
+
+    private sealed record HealthPayload(string Status);
+}

--- a/backend/Glovelly.Api/Endpoints/AppMetadataEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AppMetadataEndpoints.cs
@@ -32,6 +32,14 @@ internal static class AppMetadataEndpoints
             });
         });
 
+        app.MapGet("/health", () => Results.Ok(new
+        {
+            status = "ok",
+            deploymentName = string.IsNullOrWhiteSpace(settings.DeploymentName)
+                ? null
+                : settings.DeploymentName.Trim(),
+        })).AllowAnonymous();
+
         return app;
     }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,6 +68,8 @@ Staging seeds a test-only regression user, baseline client, and seller profile f
 
 The core invoice browser regression creates a run-specific client using `GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL` and sends the invoice through the configured email provider. Configure that value as a controlled staging/GitHub environment variable so UAT delivery goes to an approved inbox rather than seeded or personal client data.
 
+For branch UAT, first manually run the `Glovelly CI/CD` workflow for the branch with `target_environment` set to `staging`. The `Glovelly UAT` workflow does not deploy the application; it only runs Playwright against `GLOVELLY_UAT_BASE_URL`, so run it after the staging deployment has completed.
+
 Tests should create run-specific records using a run ID such as `UAT-<timestamp>-<short-sha>` rather than mutating shared baseline data.
 
 ## What to Add When Changing Behavior

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,6 +66,8 @@ Start with [docs/uat/pre-merge-regression.md](uat/pre-merge-regression.md) for b
 
 Staging seeds a test-only regression user, baseline client, and seller profile for browser automation. Playwright can authenticate by posting to `POST /test-auth/login` with `X-Glovelly-Uat-Secret`; the secret should come from `GLOVELLY_UAT_SECRET` in staging and GitHub Actions.
 
+The core invoice browser regression creates a run-specific client using `GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL` and sends the invoice through the configured email provider. Configure that value as a controlled staging/GitHub environment variable so UAT delivery goes to an approved inbox rather than seeded or personal client data.
+
 Tests should create run-specific records using a run ID such as `UAT-<timestamp>-<short-sha>` rather than mutating shared baseline data.
 
 ## What to Add When Changing Behavior

--- a/frontend/glovelly-web/public/sw.js
+++ b/frontend/glovelly-web/public/sw.js
@@ -38,7 +38,8 @@ self.addEventListener('fetch', (event) => {
     requestUrl.pathname.startsWith('/invoice-lines') ||
     requestUrl.pathname.startsWith('/seller-profile') ||
     requestUrl.pathname.startsWith('/mcp') ||
-    requestUrl.pathname === '/app/metadata'
+    requestUrl.pathname === '/app/metadata' ||
+    requestUrl.pathname === '/health'
   ) {
     return
   }

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -257,6 +257,7 @@ export function AppShell({
                 <button
                   key={item.id}
                   className={`charm-item ${activeSection === item.id ? 'selected' : ''}`}
+                  data-testid={`nav-${item.id}`}
                   onClick={() => onSectionChange(item.id)}
                   type="button"
                   disabled={item.disabled}

--- a/frontend/glovelly-web/src/components/ClientsSection.tsx
+++ b/frontend/glovelly-web/src/components/ClientsSection.tsx
@@ -69,7 +69,7 @@ export function ClientsSection({
               <p className="section-label">Directory</p>
               <h2>Clients</h2>
             </div>
-            <button className="ghost-button" onClick={onResetForm} type="button">
+            <button className="ghost-button" data-testid="new-client-button" onClick={onResetForm} type="button">
               New client
             </button>
           </div>
@@ -77,6 +77,7 @@ export function ClientsSection({
           <label className="search-field">
             <span>Search</span>
             <input
+              data-testid="client-search-input"
               type="search"
               placeholder="Name, email, city..."
               value={searchQuery}
@@ -89,6 +90,7 @@ export function ClientsSection({
               <button
                 key={client.id}
                 className={`client-card ${selectedClient?.id === client.id ? 'selected' : ''}`}
+                data-testid="client-card"
                 onClick={() => onSelectClient(client.id)}
                 type="button"
               >
@@ -222,6 +224,7 @@ export function ClientsSection({
           <form
             aria-hidden={!isEditorOpen}
             className="editor-panel panel"
+            data-testid="client-form"
             onSubmit={onSubmit}
           >
             <div className="panel-heading">
@@ -236,6 +239,7 @@ export function ClientsSection({
               <label>
                 <span>Client name</span>
                 <input
+                  data-testid="client-name-input"
                   required
                   value={form.name}
                   onChange={(event) => onUpdateField('name', event.target.value)}
@@ -246,6 +250,7 @@ export function ClientsSection({
               <label>
                 <span>Email</span>
                 <input
+                  data-testid="client-email-input"
                   required
                   type="email"
                   value={form.email}
@@ -257,6 +262,7 @@ export function ClientsSection({
               <label className="full-width">
                 <span>Address line 1</span>
                 <input
+                  data-testid="client-address-line1-input"
                   required
                   value={form.billingAddress.line1}
                   onChange={(event) => onUpdateAddressField('line1', event.target.value)}
@@ -276,6 +282,7 @@ export function ClientsSection({
               <label>
                 <span>City</span>
                 <input
+                  data-testid="client-city-input"
                   required
                   value={form.billingAddress.city}
                   onChange={(event) => onUpdateAddressField('city', event.target.value)}
@@ -297,6 +304,7 @@ export function ClientsSection({
               <label>
                 <span>Postal code</span>
                 <input
+                  data-testid="client-postal-code-input"
                   value={form.billingAddress.postalCode ?? ''}
                   onChange={(event) => onUpdateAddressField('postalCode', event.target.value)}
                   placeholder="M3 5JZ"
@@ -306,6 +314,7 @@ export function ClientsSection({
               <label>
                 <span>Country</span>
                 <input
+                  data-testid="client-country-input"
                   value={form.billingAddress.country ?? ''}
                   onChange={(event) => onUpdateAddressField('country', event.target.value)}
                   placeholder="United Kingdom"
@@ -317,6 +326,7 @@ export function ClientsSection({
               <button
                 className="primary-button"
                 data-close-after-save="true"
+                data-testid="client-save-close-button"
                 type="submit"
                 disabled={isLoading}
               >

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -132,15 +132,16 @@ export function GigsSection({
               <p className="section-label">Bookings</p>
               <h2>Gigs</h2>
             </div>
-            <button className="ghost-button" onClick={onResetForm} type="button">
+            <button className="ghost-button" data-testid="new-gig-button" onClick={onResetForm} type="button">
               New gig
             </button>
           </div>
 
           <label className="search-field">
             <span>Search</span>
-            <input
-              type="search"
+              <input
+                data-testid="gig-search-input"
+                type="search"
               placeholder="Client, title, venue..."
               value={gigSearchQuery}
               onChange={(event) => onSearchQueryChange(event.target.value)}
@@ -175,6 +176,7 @@ export function GigsSection({
                 <button
                   key={gig.id}
                   className={`client-card ${selectedGig?.id === gig.id ? 'selected' : ''}`}
+                  data-testid="gig-card"
                   onClick={() => onSelectGig(gig.id)}
                   type="button"
                 >
@@ -228,6 +230,7 @@ export function GigsSection({
             <div className="actions">
               <button
                 className="primary-button"
+                data-testid="generate-invoice-button"
                 onClick={onGenerateInvoice}
                 type="button"
                 disabled={
@@ -391,6 +394,7 @@ export function GigsSection({
           <form
             aria-hidden={!isEditorOpen}
             className="editor-panel panel"
+            data-testid="gig-form"
             onSubmit={onSubmit}
           >
             <div className="panel-heading">
@@ -405,6 +409,7 @@ export function GigsSection({
               <label>
                 <span>Client</span>
                 <select
+                  data-testid="gig-client-select"
                   required
                   value={gigForm.clientId}
                   onChange={(event) => onUpdateGigField('clientId', event.target.value)}
@@ -421,6 +426,7 @@ export function GigsSection({
               <label>
                 <span>Date</span>
                 <input
+                  data-testid="gig-date-input"
                   required
                   type="date"
                   value={gigForm.date}
@@ -431,6 +437,7 @@ export function GigsSection({
               <label className="full-width">
                 <span>Title / description</span>
                 <input
+                  data-testid="gig-title-input"
                   required
                   value={gigForm.title}
                   onChange={(event) => onUpdateGigField('title', event.target.value)}
@@ -441,6 +448,7 @@ export function GigsSection({
               <label className="full-width">
                 <span>Location / venue</span>
                 <input
+                  data-testid="gig-venue-input"
                   required
                   value={gigForm.venue}
                   onChange={(event) => onUpdateGigField('venue', event.target.value)}
@@ -451,6 +459,7 @@ export function GigsSection({
               <label>
                 <span>Fee</span>
                 <input
+                  data-testid="gig-fee-input"
                   required
                   inputMode="decimal"
                   value={gigForm.fee}
@@ -702,6 +711,7 @@ export function GigsSection({
               <button
                 className="primary-button"
                 data-close-after-save="true"
+                data-testid="gig-save-close-button"
                 type="submit"
                 disabled={isGigLoading || clients.length === 0}
               >

--- a/frontend/glovelly-web/src/components/InvoiceGenerationPreviewModal.tsx
+++ b/frontend/glovelly-web/src/components/InvoiceGenerationPreviewModal.tsx
@@ -30,6 +30,7 @@ export function InvoiceGenerationPreviewModal({
       <section
         aria-modal="true"
         className="settings-modal invoice-generation-preview-modal panel"
+        data-testid="invoice-preview-modal"
         onClick={(event) => event.stopPropagation()}
         role="dialog"
       >
@@ -45,7 +46,7 @@ export function InvoiceGenerationPreviewModal({
 
         <div className="invoice-generation-preview-frame">
           {pdfUrl ? (
-            <iframe src={pdfUrl} title={`Invoice ${invoice.invoiceNumber} PDF preview`} />
+            <iframe data-testid="invoice-preview-frame" src={pdfUrl} title={`Invoice ${invoice.invoiceNumber} PDF preview`} />
           ) : (
             <div className="empty-state roomy">
               <strong>{isLoading ? 'Preparing invoice preview...' : 'Preview unavailable.'}</strong>
@@ -55,7 +56,7 @@ export function InvoiceGenerationPreviewModal({
         </div>
 
         <div className="expense-statement-footer">
-          <span className="status-pill">{status || 'Invoice generated.'}</span>
+          <span className="status-pill" data-testid="invoice-preview-status">{status || 'Invoice generated.'}</span>
           <div className="actions">
             <button
               className="ghost-button"
@@ -65,7 +66,7 @@ export function InvoiceGenerationPreviewModal({
             >
               Download PDF
             </button>
-            <button className="primary-button" onClick={onOpenInvoice} type="button">
+            <button className="primary-button" data-testid="open-invoice-button" onClick={onOpenInvoice} type="button">
               Open invoice
             </button>
           </div>

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -90,7 +90,7 @@ export function InvoicesSection({
               <p className="section-label">Billing</p>
               <h2>Invoices</h2>
             </div>
-            <span className="status-pill">
+            <span className="status-pill" data-testid="invoice-status">
               <span>{invoiceStatus}</span>
               {googleDrivePublishLink ? (
                 <a
@@ -112,6 +112,7 @@ export function InvoicesSection({
           <label className="search-field">
             <span>Search</span>
             <input
+              data-testid="invoice-search-input"
               type="search"
               placeholder="Invoice number, client or description..."
               value={invoiceSearchQuery}
@@ -142,6 +143,7 @@ export function InvoicesSection({
                 <button
                   key={invoice.id}
                   className={`client-card ${selectedInvoice?.id === invoice.id ? 'selected' : ''}`}
+                  data-testid="invoice-card"
                   onClick={() => onSelectInvoice(invoice.id)}
                   type="button"
                 >
@@ -196,6 +198,7 @@ export function InvoicesSection({
               </button>
               <button
                 className="ghost-button"
+                data-testid="invoice-preview-button"
                 onClick={() => selectedInvoice && void onPreviewPdf(selectedInvoice)}
                 type="button"
                 disabled={!selectedInvoice || isInvoiceLoading}
@@ -217,6 +220,7 @@ export function InvoicesSection({
               </button>
               <button
                 className="ghost-button"
+                data-testid="invoice-send-button"
                 onClick={() => selectedInvoice && void onSendEmail(selectedInvoice)}
                 type="button"
                 disabled={!selectedInvoice || isInvoiceLoading}

--- a/tests/Glovelly.Uat.Tests/CoreInvoiceWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/CoreInvoiceWorkflowTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.Playwright;
+using System.Net.Mail;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public sealed class CoreInvoiceWorkflowTests : UatTestBase
+{
+    [Fact]
+    public Task AuthenticatedUserCanCreatePreviewAndSendInvoiceToConfiguredRecipient() => RunWithDiagnosticsAsync(
+        nameof(AuthenticatedUserCanCreatePreviewAndSendInvoiceToConfiguredRecipient),
+        async () =>
+        {
+            var recipientEmail = ConfiguredInvoiceRecipientEmail();
+            var runId = CreateRunId();
+            var clientName = $"{runId} Invoice Client";
+            var gigTitle = $"{runId} Invoice Gig";
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName, recipientEmail);
+            await CreateGigAsync(clientName, gigTitle);
+            await GenerateInvoiceAndOpenPreviewAsync();
+            await OpenPreviewedInvoiceAsync();
+            await SendInvoiceAndExpectSuccessAsync(runId);
+        });
+
+    private async Task CreateClientAsync(string clientName, string recipientEmail)
+    {
+        await Page.GetByTestId("nav-clients").ClickAsync();
+        await Page.GetByTestId("new-client-button").ClickAsync();
+        await Page.GetByTestId("client-form").WaitForAsync();
+
+        await Page.GetByTestId("client-name-input").FillAsync(clientName);
+        await Page.GetByTestId("client-email-input").FillAsync(recipientEmail);
+        await Page.GetByTestId("client-address-line1-input").FillAsync("1 UAT Invoice Street");
+        await Page.GetByTestId("client-city-input").FillAsync("Bristol");
+        await Page.GetByTestId("client-postal-code-input").FillAsync("BS1 5AA");
+        await Page.GetByTestId("client-country-input").FillAsync("United Kingdom");
+        await Page.GetByTestId("client-save-close-button").ClickAsync();
+
+        await ClientCard(clientName).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task CreateGigAsync(string clientName, string gigTitle)
+    {
+        await Page.GetByTestId("nav-gigs").ClickAsync();
+        await Page.GetByTestId("new-gig-button").ClickAsync();
+        await Page.GetByTestId("gig-form").WaitForAsync();
+
+        await Page.GetByTestId("gig-client-select").SelectOptionAsync(new[]
+        {
+            new SelectOptionValue { Label = clientName },
+        });
+        await Page.GetByTestId("gig-date-input").FillAsync(DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-dd"));
+        await Page.GetByTestId("gig-title-input").FillAsync(gigTitle);
+        await Page.GetByTestId("gig-venue-input").FillAsync("UAT Regression Hall");
+        await Page.GetByTestId("gig-fee-input").FillAsync("125.00");
+        await Page.GetByTestId("gig-save-close-button").ClickAsync();
+
+        await GigCard(gigTitle).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task GenerateInvoiceAndOpenPreviewAsync()
+    {
+        await Page.GetByTestId("generate-invoice-button").ClickAsync();
+        await Page.GetByTestId("invoice-preview-modal").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+        await Page.GetByTestId("invoice-preview-frame").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+        await ExpectContainsAsync(Page.GetByTestId("invoice-preview-status"), "ready to review");
+    }
+
+    private async Task OpenPreviewedInvoiceAsync()
+    {
+        await Page.GetByTestId("open-invoice-button").ClickAsync();
+        await Page.GetByTestId("nav-invoices").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+        await Page.GetByTestId("invoice-send-button").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task SendInvoiceAndExpectSuccessAsync(string runId)
+    {
+        Page.Dialog += (_, dialog) =>
+        {
+            _ = dialog.Type switch
+            {
+                "prompt" => dialog.AcceptAsync($"Automated UAT invoice delivery for {runId}."),
+                _ => dialog.DismissAsync(),
+            };
+        };
+
+        await Page.GetByTestId("invoice-send-button").ClickAsync();
+        await ExpectContainsAsync(Page.GetByTestId("invoice-status"), "delivered and left as Draft");
+    }
+
+    private ILocator ClientCard(string clientName) => Page.GetByTestId("client-card").Filter(new LocatorFilterOptions
+    {
+        HasText = clientName,
+    });
+
+    private ILocator GigCard(string gigTitle) => Page.GetByTestId("gig-card").Filter(new LocatorFilterOptions
+    {
+        HasText = gigTitle,
+    });
+
+    private static async Task ExpectContainsAsync(ILocator locator, string expectedText)
+    {
+        await Assertions.Expect(locator).ToContainTextAsync(expectedText, new LocatorAssertionsToContainTextOptions
+        {
+            IgnoreCase = true,
+            Timeout = 30_000,
+        });
+    }
+
+    private static string ConfiguredInvoiceRecipientEmail()
+    {
+        var recipientEmail = RequiredEnvironmentVariable(
+            "GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL",
+            "Set GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL to the controlled inbox used by the real invoice delivery UAT.");
+
+        try
+        {
+            _ = new MailAddress(recipientEmail);
+            return recipientEmail;
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidOperationException("GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL must be a valid email address.", exception);
+        }
+    }
+}

--- a/tests/Glovelly.Uat.Tests/README.md
+++ b/tests/Glovelly.Uat.Tests/README.md
@@ -24,10 +24,20 @@ If PowerShell is not installed, install it first or run the generated `playwrigh
 
 `GLOVELLY_UAT_BASE_URL` is required and should point at the deployment under test. `GLOVELLY_UAT_SECRET` is required for tests that use staging-only test authentication. `GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL` is required for invoice delivery tests and should point at a controlled inbox because the core invoice regression sends through the configured email provider.
 
-For branch UAT, first run the `Glovelly CI/CD` workflow manually on the branch with `target_environment` set to `staging`. After that staging deployment completes, run the `Glovelly UAT` workflow manually against the same staging URL.
+The `Glovelly CI/CD` workflow deploys staging and calls the reusable `Glovelly UAT` workflow before production deployment is allowed to continue. Production smoke tests call the same reusable workflow after deployment with the `Suite=Smoke` filter and do not use staging-only authentication.
+
+For branch UAT, run the `Glovelly CI/CD` workflow manually on the branch with `target_environment` set to `staging`. The workflow deploys staging and then runs the full Playwright UAT suite against it.
 
 ```bash
 GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+```
+
+To run only the production-safe smoke suite locally:
+
+```bash
+GLOVELLY_UAT_BASE_URL=https://glovelly.net \
+dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj \
+  --filter "Suite=Smoke"
 ```
 
 To mirror CI diagnostics locally:

--- a/tests/Glovelly.Uat.Tests/README.md
+++ b/tests/Glovelly.Uat.Tests/README.md
@@ -24,6 +24,8 @@ If PowerShell is not installed, install it first or run the generated `playwrigh
 
 `GLOVELLY_UAT_BASE_URL` is required and should point at the deployment under test. `GLOVELLY_UAT_SECRET` is required for tests that use staging-only test authentication. `GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL` is required for invoice delivery tests and should point at a controlled inbox because the core invoice regression sends through the configured email provider.
 
+For branch UAT, first run the `Glovelly CI/CD` workflow manually on the branch with `target_environment` set to `staging`. After that staging deployment completes, run the `Glovelly UAT` workflow manually against the same staging URL.
+
 ```bash
 GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
 ```

--- a/tests/Glovelly.Uat.Tests/README.md
+++ b/tests/Glovelly.Uat.Tests/README.md
@@ -22,7 +22,7 @@ If PowerShell is not installed, install it first or run the generated `playwrigh
 
 ## Run
 
-`GLOVELLY_UAT_BASE_URL` is required and should point at the deployment under test. `GLOVELLY_UAT_SECRET` is required for tests that use staging-only test authentication.
+`GLOVELLY_UAT_BASE_URL` is required and should point at the deployment under test. `GLOVELLY_UAT_SECRET` is required for tests that use staging-only test authentication. `GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL` is required for invoice delivery tests and should point at a controlled inbox because the core invoice regression sends through the configured email provider.
 
 ```bash
 GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
@@ -33,6 +33,7 @@ To mirror CI diagnostics locally:
 ```bash
 GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net \
 GLOVELLY_UAT_SECRET=<secret> \
+GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL=uat-invoices@example.com \
 GLOVELLY_UAT_ARTIFACT_DIR=TestResults/uat \
 dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj \
   --logger "trx;LogFileName=uat-test-results.trx" \

--- a/tests/Glovelly.Uat.Tests/SmokeTests.cs
+++ b/tests/Glovelly.Uat.Tests/SmokeTests.cs
@@ -3,16 +3,8 @@ using Xunit;
 
 namespace Glovelly.Uat.Tests;
 
-public sealed class SmokeTests : IAsyncLifetime
+public sealed class SmokeTests : UatTestBase
 {
-    private IPlaywright? playwright;
-    private IBrowser? browser;
-    private IBrowserContext? context;
-    private IPage? page;
-    private bool tracingActive;
-
-    private IPage Page => page ?? throw new InvalidOperationException("The Playwright page has not been initialized.");
-
     [Fact]
     public Task HomePageLoadsSuccessfully() => RunWithDiagnosticsAsync(nameof(HomePageLoadsSuccessfully), async () =>
     {
@@ -42,130 +34,6 @@ public sealed class SmokeTests : IAsyncLifetime
         });
         Assert.True(await signInButton.IsEnabledAsync(), "Expected the Google sign-in entry point to be enabled.");
     });
-
-    public async Task InitializeAsync()
-    {
-        playwright = await Playwright.CreateAsync();
-        browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = Headless(),
-        });
-        context = await browser.NewContextAsync(new BrowserNewContextOptions
-        {
-            BaseURL = BaseUrl(),
-        });
-        await context.Tracing.StartAsync(new TracingStartOptions
-        {
-            Screenshots = true,
-            Snapshots = true,
-            Sources = true,
-        });
-        tracingActive = true;
-        page = await context.NewPageAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (context is not null)
-        {
-            if (tracingActive)
-            {
-                await context.Tracing.StopAsync();
-                tracingActive = false;
-            }
-
-            await context.DisposeAsync();
-        }
-
-        if (browser is not null)
-        {
-            await browser.DisposeAsync();
-        }
-
-        playwright?.Dispose();
-    }
-
-    private async Task RunWithDiagnosticsAsync(string testName, Func<Task> testBody)
-    {
-        try
-        {
-            await testBody();
-        }
-        catch
-        {
-            await CaptureFailureDiagnosticsAsync(testName);
-            throw;
-        }
-    }
-
-    private async Task CaptureFailureDiagnosticsAsync(string testName)
-    {
-        var artifactDirectory = ArtifactDirectory();
-        var safeTestName = SafeArtifactName(testName);
-
-        if (page is not null)
-        {
-            var screenshotDirectory = Path.Combine(artifactDirectory, "screenshots");
-            Directory.CreateDirectory(screenshotDirectory);
-            await page.ScreenshotAsync(new PageScreenshotOptions
-            {
-                Path = Path.Combine(screenshotDirectory, $"{safeTestName}.png"),
-                FullPage = true,
-            });
-        }
-
-        if (context is not null && tracingActive)
-        {
-            var traceDirectory = Path.Combine(artifactDirectory, "playwright-traces");
-            Directory.CreateDirectory(traceDirectory);
-            await context.Tracing.StopAsync(new TracingStopOptions
-            {
-                Path = Path.Combine(traceDirectory, $"{safeTestName}.zip"),
-            });
-            tracingActive = false;
-        }
-    }
-
-    private static string BaseUrl()
-    {
-        var baseUrl = Environment.GetEnvironmentVariable("GLOVELLY_UAT_BASE_URL")?.Trim();
-
-        if (string.IsNullOrWhiteSpace(baseUrl))
-        {
-            throw new InvalidOperationException("Set GLOVELLY_UAT_BASE_URL to the Glovelly deployment under test, for example https://staging.glovelly.net.");
-        }
-
-        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
-        {
-            throw new InvalidOperationException("GLOVELLY_UAT_BASE_URL must be an absolute HTTP or HTTPS URL.");
-        }
-
-        return uri.ToString().TrimEnd('/');
-    }
-
-    private static bool Headless()
-    {
-        var value = Environment.GetEnvironmentVariable("GLOVELLY_UAT_HEADLESS");
-
-        return !bool.TryParse(value, out var headless) || headless;
-    }
-
-    private static string ArtifactDirectory()
-    {
-        var directory = Environment.GetEnvironmentVariable("GLOVELLY_UAT_ARTIFACT_DIR")?.Trim();
-
-        return string.IsNullOrWhiteSpace(directory)
-            ? Path.Combine("TestResults", "uat")
-            : directory;
-    }
-
-    private static string SafeArtifactName(string value)
-    {
-        var invalidChars = Path.GetInvalidFileNameChars();
-        var chars = value.Select(valueChar => invalidChars.Contains(valueChar) ? '-' : valueChar).ToArray();
-
-        return new string(chars);
-    }
 
     private static System.Text.RegularExpressions.Regex GlovellyHeadingRegex()
     {

--- a/tests/Glovelly.Uat.Tests/SmokeTests.cs
+++ b/tests/Glovelly.Uat.Tests/SmokeTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.Playwright;
+using System.Net.Http.Json;
 using Xunit;
 
 namespace Glovelly.Uat.Tests;
 
+[Trait("Suite", "Smoke")]
 public sealed class SmokeTests : UatTestBase
 {
     [Fact]
@@ -35,8 +37,49 @@ public sealed class SmokeTests : UatTestBase
         Assert.True(await signInButton.IsEnabledAsync(), "Expected the Google sign-in entry point to be enabled.");
     });
 
+    [Fact]
+    public async Task HealthEndpointRespondsSuccessfully()
+    {
+        using var httpClient = CreateHttpClient();
+        using var response = await httpClient.GetAsync("/health");
+
+        Assert.True(response.IsSuccessStatusCode, $"Expected /health to return a successful response, but received HTTP {(int)response.StatusCode}.");
+
+        var payload = await response.Content.ReadFromJsonAsync<HealthPayload>();
+        Assert.Equal("ok", payload?.Status);
+    }
+
+    [Fact]
+    public async Task AppMetadataEndpointRespondsSuccessfully()
+    {
+        using var httpClient = CreateHttpClient();
+        using var response = await httpClient.GetAsync("/app/metadata");
+
+        Assert.True(response.IsSuccessStatusCode, $"Expected /app/metadata to return a successful response, but received HTTP {(int)response.StatusCode}.");
+
+        var payload = await response.Content.ReadFromJsonAsync<AppMetadataPayload>();
+        Assert.Contains("Glovelly", payload?.Title ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("/manifest.webmanifest")]
+    [InlineData("/gordon-192.png")]
+    public async Task KeyStaticAssetLoadsSuccessfully(string path)
+    {
+        using var httpClient = CreateHttpClient();
+        using var response = await httpClient.GetAsync(path);
+
+        Assert.True(response.IsSuccessStatusCode, $"Expected {path} to return a successful response, but received HTTP {(int)response.StatusCode}.");
+        var content = await response.Content.ReadAsByteArrayAsync();
+        Assert.NotEmpty(content);
+    }
+
     private static System.Text.RegularExpressions.Regex GlovellyHeadingRegex()
     {
         return new System.Text.RegularExpressions.Regex("Glovelly", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
     }
+
+    private sealed record HealthPayload(string Status);
+
+    private sealed record AppMetadataPayload(string Title);
 }

--- a/tests/Glovelly.Uat.Tests/UatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/UatTestBase.cs
@@ -1,0 +1,194 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public abstract class UatTestBase : IAsyncLifetime
+{
+    private IPlaywright? playwright;
+    private IBrowser? browser;
+    private IBrowserContext? context;
+    private IPage? page;
+    private bool tracingActive;
+
+    protected IPage Page => page ?? throw new InvalidOperationException("The Playwright page has not been initialized.");
+
+    public async Task InitializeAsync()
+    {
+        playwright = await Playwright.CreateAsync();
+        browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = Headless(),
+        });
+        context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = BaseUrl(),
+        });
+        await context.Tracing.StartAsync(new TracingStartOptions
+        {
+            Screenshots = true,
+            Snapshots = true,
+            Sources = true,
+        });
+        tracingActive = true;
+        page = await context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (context is not null)
+        {
+            if (tracingActive)
+            {
+                await context.Tracing.StopAsync();
+                tracingActive = false;
+            }
+
+            await context.DisposeAsync();
+        }
+
+        if (browser is not null)
+        {
+            await browser.DisposeAsync();
+        }
+
+        playwright?.Dispose();
+    }
+
+    protected async Task RunWithDiagnosticsAsync(string testName, Func<Task> testBody)
+    {
+        try
+        {
+            await testBody();
+        }
+        catch
+        {
+            await CaptureFailureDiagnosticsAsync(testName);
+            throw;
+        }
+    }
+
+    protected async Task AuthenticateWithUatSecretAsync()
+    {
+        var secret = RequiredEnvironmentVariable(
+            "GLOVELLY_UAT_SECRET",
+            "Set GLOVELLY_UAT_SECRET to authenticate with the staging-only UAT endpoint.");
+
+        await Page.GotoAsync("/", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.Load,
+        });
+
+        var status = await Page.EvaluateAsync<int>(
+            """
+            async (secret) => {
+              const response = await fetch('/test-auth/login', {
+                method: 'POST',
+                headers: { 'X-Glovelly-Uat-Secret': secret },
+                credentials: 'include'
+              });
+              return response.status;
+            }
+            """,
+            secret);
+
+        Assert.Equal(200, status);
+
+        await Page.GotoAsync("/", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.Load,
+        });
+        await Page.GetByTestId("nav-clients").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    protected static string RequiredEnvironmentVariable(string name, string message)
+    {
+        var value = Environment.GetEnvironmentVariable(name)?.Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(message);
+        }
+
+        return value;
+    }
+
+    protected static string CreateRunId()
+    {
+        var shortSha = Environment.GetEnvironmentVariable("GITHUB_SHA")?.Trim();
+        shortSha = string.IsNullOrWhiteSpace(shortSha) ? Guid.NewGuid().ToString("N")[..8] : shortSha[..Math.Min(shortSha.Length, 8)];
+
+        return $"UAT-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}-{shortSha}";
+    }
+
+    private async Task CaptureFailureDiagnosticsAsync(string testName)
+    {
+        var artifactDirectory = ArtifactDirectory();
+        var safeTestName = SafeArtifactName(testName);
+
+        if (page is not null)
+        {
+            var screenshotDirectory = Path.Combine(artifactDirectory, "screenshots");
+            Directory.CreateDirectory(screenshotDirectory);
+            await page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = Path.Combine(screenshotDirectory, $"{safeTestName}.png"),
+                FullPage = true,
+            });
+        }
+
+        if (context is not null && tracingActive)
+        {
+            var traceDirectory = Path.Combine(artifactDirectory, "playwright-traces");
+            Directory.CreateDirectory(traceDirectory);
+            await context.Tracing.StopAsync(new TracingStopOptions
+            {
+                Path = Path.Combine(traceDirectory, $"{safeTestName}.zip"),
+            });
+            tracingActive = false;
+        }
+    }
+
+    private static string BaseUrl()
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("GLOVELLY_UAT_BASE_URL")?.Trim();
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException("Set GLOVELLY_UAT_BASE_URL to the Glovelly deployment under test, for example https://staging.glovelly.net.");
+        }
+
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
+        {
+            throw new InvalidOperationException("GLOVELLY_UAT_BASE_URL must be an absolute HTTP or HTTPS URL.");
+        }
+
+        return uri.ToString().TrimEnd('/');
+    }
+
+    private static bool Headless()
+    {
+        var value = Environment.GetEnvironmentVariable("GLOVELLY_UAT_HEADLESS");
+
+        return !bool.TryParse(value, out var headless) || headless;
+    }
+
+    private static string ArtifactDirectory()
+    {
+        var directory = Environment.GetEnvironmentVariable("GLOVELLY_UAT_ARTIFACT_DIR")?.Trim();
+
+        return string.IsNullOrWhiteSpace(directory)
+            ? Path.Combine("TestResults", "uat")
+            : directory;
+    }
+
+    private static string SafeArtifactName(string value)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var chars = value.Select(valueChar => invalidChars.Contains(valueChar) ? '-' : valueChar).ToArray();
+
+        return new string(chars);
+    }
+}

--- a/tests/Glovelly.Uat.Tests/UatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/UatTestBase.cs
@@ -123,6 +123,15 @@ public abstract class UatTestBase : IAsyncLifetime
         return $"UAT-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}-{shortSha}";
     }
 
+    protected static HttpClient CreateHttpClient()
+    {
+        return new HttpClient
+        {
+            BaseAddress = new Uri(BaseUrl(), UriKind.Absolute),
+            Timeout = TimeSpan.FromSeconds(15),
+        };
+    }
+
     private async Task CaptureFailureDiagnosticsAsync(string testName)
     {
         var artifactDirectory = ArtifactDirectory();


### PR DESCRIPTION
## Summary
- add production-safe smoke coverage and a lightweight /health endpoint
- make the Playwright UAT workflow reusable for staging UAT and production smoke runs
- gate production deployment on successful staging UAT, then run smoke tests after production deploy

## Verification
- dotnet test glovelly.sln -m:1
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj --configuration Release
- git diff --check
- workflow YAML parsed with Ruby YAML parser

Closes #158