### PR TITLE
Track UAT automation coverage and add expense statement regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,4 @@ rg "TestData\\.|TestAuthContext|factory\.Emails" backend/Glovelly.Api.Tests
 - Do not bypass owner visibility checks for user-owned data; null creator IDs may be intentional for shared/dev seed visibility.
 - Do not add package versions to individual `.csproj` files; use central package management in `Directory.Packages.props`.
 - Do not refactor large coordination files just to tidy them while solving a narrow task.
+- Do not create git commits, amend commits, push commits, or otherwise mutate git history unless the user explicitly asks for that git action.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Glovelly
 
-[![Build and Push Container](https://github.com/alexhowgego/glovelly/actions/workflows/main.yml/badge.svg)](https://github.com/alexhowgego/glovelly/actions/workflows/main.yml)
+[![Glovelly CI/CD](https://github.com/alexhowgego/glovelly/actions/workflows/main.yml/badge.svg)](https://github.com/alexhowgego/glovelly/actions/workflows/main.yml)
+[![Glovelly UAT](https://github.com/alexhowgego/glovelly/actions/workflows/uat.yml/badge.svg)](https://github.com/alexhowgego/glovelly/actions/workflows/uat.yml)
 
 Glovelly is a personal business platform for managing my self-employed music work.
 

--- a/docs/uat/expenses.md
+++ b/docs/uat/expenses.md
@@ -13,6 +13,8 @@ Use these journeys when a change may affect gig expenses, receipt attachments, q
 
 ## Expense Receipt Journey
 
+> **Automation:** Manual
+
 ### Steps
 
 1. Open a saved gig with an expense.
@@ -28,6 +30,8 @@ Receipt metadata, storage, download, and deletion all work without changing the 
 
 ## Quick Receipt Journey
 
+> **Automation:** Manual
+
 ### Steps
 
 1. Use quick receipt capture to upload a receipt.
@@ -41,6 +45,8 @@ Receipt metadata, storage, download, and deletion all work without changing the 
 The draft becomes a normal gig expense with its receipt attached. Existing expenses and attachments remain intact.
 
 ## Expense Reimbursement Journey
+
+> **Automation:** Manual
 
 ### Steps
 
@@ -62,6 +68,8 @@ Reimbursed expenses are visually distinct and excluded from newly generated invo
 Expected result: the expense becomes eligible for generated invoice lines again.
 
 ## Expense Statement Journey
+
+> **Automation:** Automated: `Glovelly.Uat.Tests.ExpenseStatementTests.CanGenerateExpenseStatementPreviewAndDownload`
 
 ### Steps
 

--- a/docs/uat/index.md
+++ b/docs/uat/index.md
@@ -1,5 +1,7 @@
 # UAT And Regression Testing
 
+[![Glovelly UAT](https://github.com/alexhowgego/glovelly/actions/workflows/uat.yml/badge.svg)](https://github.com/alexhowgego/glovelly/actions/workflows/uat.yml)
+
 These pages capture high-value manual regression journeys for Glovelly. They are written for testers who need to use the product, not inspect the implementation.
 
 The aim is not to test every field. The aim is to walk the product like a user would and catch cross-workflow breakage that automated backend tests or frontend build checks may miss.
@@ -16,6 +18,17 @@ If you are running Glovelly locally, the usual startup command is:
 
 Use a fresh browser session if possible. If the environment already contains clients, gigs, invoices, or receipts, make a note of the records you plan to use before changing anything.
 
+## Automation Status
+
+Each journey can show its automated coverage with a short status line:
+
+- **Manual**: no automated browser coverage yet.
+- **Automated**: covered end-to-end by the named Playwright UAT test.
+- **Partially automated**: the named Playwright UAT test covers the main path, but manual judgement or extra variants remain.
+- **Not automatable / judgement-based**: intentionally kept as a human review check.
+
+When adding or changing Playwright UAT coverage, update the matching UAT page in the same pull request so release reviewers can see what still needs human attention.
+
 ## Regression Pages
 
 - [Pre-merge regression](pre-merge-regression.md): the main end-to-end checklist before shipping changes.
@@ -23,6 +36,8 @@ Use a fresh browser session if possible. If the environment already contains cli
 - [Expenses](expenses.md): receipts, quick receipts, reimbursement, and expense statement journeys.
 - [Imported gigs](gig-imports.md): MCP-staged gig imports, review, autosave, accept/reject, notification dots, and commit.
 - [Enrolment and access](enrolment.md): sign-in, seller profile, settings, and admin access checks.
+
+> **Automation:** Partially automated: `Glovelly.Uat.Tests.SmokeTests` covers public smoke endpoints and sign-in entry point visibility; journey-specific automation is noted on each page.
 
 ## Good Testing Notes
 

--- a/docs/uat/invoices.md
+++ b/docs/uat/invoices.md
@@ -13,6 +13,8 @@ Use these journeys when a change may affect invoice creation, generated invoice 
 
 ## Gig To Invoice
 
+> **Automation:** Automated: `Glovelly.Uat.Tests.CoreInvoiceWorkflowTests.AuthenticatedUserCanCreatePreviewAndSendInvoiceToConfiguredRecipient`
+
 ### Steps
 
 1. Create a client or choose an existing client.

--- a/docs/uat/invoices.md
+++ b/docs/uat/invoices.md
@@ -33,6 +33,8 @@ Generating an invoice links the gig, creates expected lines, and produces a down
 
 ## Combined Invoice
 
+> **Automation:** Automated: `Glovelly.Uat.Tests.InvoiceAggregationWorkflowTests.CanGenerateCombinedInvoiceForSameClientGigs`
+
 ### Steps
 
 1. Create two uninvoiced gigs for the same client.
@@ -53,6 +55,8 @@ One invoice is created, both gigs are linked, invoice lines are ordered sensibly
 Expected result: the app blocks generation and explains that selected gigs must belong to the same client.
 
 ## Monthly Invoice
+
+> **Automation:** Automated: `Glovelly.Uat.Tests.InvoiceAggregationWorkflowTests.CanGenerateMonthlyInvoiceForEligibleClientGigs`
 
 ### Steps
 

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -222,6 +222,8 @@ Expected result: expenses are copied only when accepted, receipt attachments are
 
 ## Combined Invoice Journey
 
+> **Automation:** Automated: `Glovelly.Uat.Tests.InvoiceAggregationWorkflowTests.CanGenerateCombinedInvoiceForSameClientGigs`
+
 ### Steps
 
 1. Create two uninvoiced gigs for the same client.
@@ -254,6 +256,8 @@ Run the focused [Imported gigs](gig-imports.md) journey when the change touches 
 Expected result: imported gigs stay in a modal launched from the profile menu, row edits autosave, and the main Clients/Gigs/Invoices navigation is unchanged.
 
 ## Monthly Invoice Journey
+
+> **Automation:** Automated: `Glovelly.Uat.Tests.InvoiceAggregationWorkflowTests.CanGenerateMonthlyInvoiceForEligibleClientGigs`
 
 ### Steps
 

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -22,6 +22,8 @@ For local development, engineers usually run:
 
 ## Core Smoke Journey
 
+> **Automation:** Partially automated: `Glovelly.Uat.Tests.SmokeTests`
+
 ### Steps
 
 1. Sign in.
@@ -111,6 +113,8 @@ Expected result: unsaved gig edits and unsaved expense draft fields are never di
 Expected result: unsaved admin access edits are never discarded without confirmation. Accepted navigation switches the editor to the selected user or a blank add-user form.
 
 ## Gig To Invoice Journey
+
+> **Automation:** Automated: `Glovelly.Uat.Tests.CoreInvoiceWorkflowTests.AuthenticatedUserCanCreatePreviewAndSendInvoiceToConfiguredRecipient`
 
 ### Steps
 
@@ -284,3 +288,5 @@ Pay special attention to workflows that cross boundaries:
 - Expense statements are projections and should not create invoices or mutate gig invoice links.
 
 When a manual journey reveals a bug, record the exact steps and tell the engineer or release owner. The fix should usually include an automated backend test for the server-side rule, and the frontend flow may later become an automated browser test.
+
+Keep these manual journeys aligned with automated coverage by updating the nearest **Automation** line whenever a Playwright UAT test is added, removed, or meaningfully changes scope.

--- a/frontend/glovelly-web/src/components/ClientsSection.tsx
+++ b/frontend/glovelly-web/src/components/ClientsSection.tsx
@@ -164,6 +164,7 @@ export function ClientsSection({
                   <label>
                     Month
                     <input
+                      data-testid="monthly-invoice-month-input"
                       type="month"
                       value={monthlyInvoiceMonth}
                       onChange={(event) =>
@@ -174,6 +175,7 @@ export function ClientsSection({
                   </label>
                   <button
                     className="primary-button"
+                    data-testid="generate-monthly-invoice-button"
                     onClick={onGenerateMonthlyInvoice}
                     type="button"
                     disabled={isInvoiceLoading || !isMonthlyInvoiceReady}
@@ -181,7 +183,7 @@ export function ClientsSection({
                     Generate monthly invoice
                   </button>
                 </div>
-                <span>{monthlyInvoiceHelperText}</span>
+                <span data-testid="monthly-invoice-helper">{monthlyInvoiceHelperText}</span>
               </div>
 
               <div className="detail-grid">

--- a/frontend/glovelly-web/src/components/ExpenseStatementModal.tsx
+++ b/frontend/glovelly-web/src/components/ExpenseStatementModal.tsx
@@ -56,6 +56,7 @@ export function ExpenseStatementModal({
       <section
         aria-modal="true"
         className="settings-modal expense-statement-modal panel"
+        data-testid="expense-statement-modal"
         onClick={(event) => event.stopPropagation()}
         role="dialog"
       >
@@ -79,7 +80,7 @@ export function ExpenseStatementModal({
             <p>{selectedExpenseCount === 1 ? 'expense' : 'expenses'}</p>
           </article>
           <article>
-            <span>{formatCurrency(total)}</span>
+            <span data-testid="expense-statement-total">{formatCurrency(total)}</span>
             <p>selected total</p>
           </article>
         </div>
@@ -145,19 +146,20 @@ export function ExpenseStatementModal({
 
           {previewPdfUrl && (
             <div className="expense-statement-preview">
-              <iframe src={previewPdfUrl} title="Expense statement PDF preview" />
+              <iframe data-testid="expense-statement-preview-frame" src={previewPdfUrl} title="Expense statement PDF preview" />
             </div>
           )}
         </div>
 
         <div className="expense-statement-footer">
-          <span className="status-pill">
+          <span className="status-pill" data-testid="expense-statement-status">
             {status ||
               `${receiptCount} receipt${receiptCount === 1 ? '' : 's'} available for selected expenses.`}
           </span>
           <div className="actions">
             <button
               className="ghost-button"
+              data-testid="expense-statement-preview-button"
               disabled={isSaving || selectedExpenseCount === 0}
               onClick={onPreview}
               type="button"
@@ -166,6 +168,7 @@ export function ExpenseStatementModal({
             </button>
             <button
               className="primary-button"
+              data-testid="expense-statement-download-button"
               disabled={isSaving || selectedExpenseCount === 0}
               onClick={onDownload}
               type="button"
@@ -196,6 +199,7 @@ function ExpenseStatementExpenseRow({
       className={`expense-statement-expense ${
         isReimbursed || isNotClaimable ? 'is-muted' : ''
       }`}
+      data-testid="expense-statement-expense-row"
     >
       <input
         checked={isSelected}

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -249,6 +249,7 @@ export function GigsSection({
               </button>
               <button
                 className="ghost-button"
+                data-testid="expense-statement-button"
                 onClick={onGenerateExpenseStatement}
                 type="button"
                 disabled={
@@ -549,6 +550,7 @@ export function GigsSection({
               <label>
                 Amount
                 <input
+                  data-testid="gig-expense-amount-input"
                   inputMode="decimal"
                   value={gigExpenseAmount}
                   onChange={(event) => onExpenseAmountChange(event.target.value)}
@@ -559,6 +561,7 @@ export function GigsSection({
               <label>
                 Description
                 <input
+                  data-testid="gig-expense-description-input"
                   value={gigExpenseDescription}
                   onChange={(event) => onExpenseDescriptionChange(event.target.value)}
                   placeholder="Parking, hotel, equipment hire..."
@@ -567,6 +570,7 @@ export function GigsSection({
               </label>
               <button
                 className="ghost-button"
+                data-testid="add-gig-expense-button"
                 onClick={onAddGigExpense}
                 type="button"
                 disabled={isGigLoading}
@@ -584,6 +588,7 @@ export function GigsSection({
                   return (
                   <div
                     className={`gig-expense-item ${isReimbursed ? 'is-reimbursed' : ''}`}
+                    data-testid="gig-expense-item"
                     key={`${expense.id || 'new'}-${index}`}
                   >
                     <div className="expense-reimbursement-state">

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -177,6 +177,7 @@ export function InvoicesSection({
             <div className="actions">
               <button
                 className="ghost-button"
+                data-testid="invoice-line-items-button"
                 onClick={onStartEditing}
                 type="button"
                 disabled={!selectedInvoice}
@@ -428,7 +429,7 @@ export function InvoicesSection({
                       const gigId = line.gigId
 
                       return (
-                        <div className="invoice-line-item" key={line.id}>
+                        <div className="invoice-line-item" data-testid="invoice-line-item" key={line.id}>
                           <div>
                             {gigId ? (
                               <button

--- a/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
+++ b/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public sealed class ExpenseStatementTests : UatTestBase
+{
+    [Fact]
+    public Task CanGenerateExpenseStatementPreviewAndDownload() => RunWithDiagnosticsAsync(
+        nameof(CanGenerateExpenseStatementPreviewAndDownload),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Expense Client";
+            var gigTitle = $"{runId} Expense Gig";
+            var expenseDescription = $"{runId} Parking";
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigWithExpenseAsync(clientName, gigTitle, expenseDescription);
+            await GeneratePreviewAndDownloadAsync(gigTitle, expenseDescription);
+        });
+
+    private async Task CreateClientAsync(string clientName)
+    {
+        await Page.GetByTestId("nav-clients").ClickAsync();
+        await Page.GetByTestId("new-client-button").ClickAsync();
+        await Page.GetByTestId("client-form").WaitForAsync();
+
+        await Page.GetByTestId("client-name-input").FillAsync(clientName);
+        await Page.GetByTestId("client-email-input").FillAsync("expenses-uat@example.com");
+        await Page.GetByTestId("client-address-line1-input").FillAsync("2 UAT Expense Street");
+        await Page.GetByTestId("client-city-input").FillAsync("Bristol");
+        await Page.GetByTestId("client-postal-code-input").FillAsync("BS1 5AA");
+        await Page.GetByTestId("client-country-input").FillAsync("United Kingdom");
+        await Page.GetByTestId("client-save-close-button").ClickAsync();
+
+        await ClientCard(clientName).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task CreateGigWithExpenseAsync(string clientName, string gigTitle, string expenseDescription)
+    {
+        await Page.GetByTestId("nav-gigs").ClickAsync();
+        await Page.GetByTestId("new-gig-button").ClickAsync();
+        await Page.GetByTestId("gig-form").WaitForAsync();
+
+        await Page.GetByTestId("gig-client-select").SelectOptionAsync(new[]
+        {
+            new SelectOptionValue { Label = clientName },
+        });
+        await Page.GetByTestId("gig-date-input").FillAsync(DateTime.UtcNow.AddDays(14).ToString("yyyy-MM-dd"));
+        await Page.GetByTestId("gig-title-input").FillAsync(gigTitle);
+        await Page.GetByTestId("gig-venue-input").FillAsync("UAT Expense Hall");
+        await Page.GetByTestId("gig-fee-input").FillAsync("100.00");
+        await Page.GetByTestId("gig-expense-amount-input").FillAsync("62.50");
+        await Page.GetByTestId("gig-expense-description-input").FillAsync(expenseDescription);
+        await Page.GetByTestId("add-gig-expense-button").ClickAsync();
+        await Page.GetByTestId("gig-expense-item").Filter(new LocatorFilterOptions
+        {
+            HasText = expenseDescription,
+        }).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+
+        await Page.GetByTestId("gig-save-close-button").ClickAsync();
+
+        await GigCard(gigTitle).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task GeneratePreviewAndDownloadAsync(string gigTitle, string expenseDescription)
+    {
+        await GigCard(gigTitle).ClickAsync();
+        await Page.GetByTestId("expense-statement-button").ClickAsync();
+        await Page.GetByTestId("expense-statement-modal").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+
+        await Assertions.Expect(Page.GetByTestId("expense-statement-modal")).ToContainTextAsync(gigTitle);
+        await Assertions.Expect(Page.GetByTestId("expense-statement-expense-row")).ToContainTextAsync(expenseDescription);
+        await Assertions.Expect(Page.GetByTestId("expense-statement-total")).ToContainTextAsync("62.50");
+
+        await Page.GetByTestId("expense-statement-preview-button").ClickAsync();
+        await Assertions.Expect(Page.GetByTestId("expense-statement-status")).ToContainTextAsync(
+            "PDF preview ready",
+            new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+        await Page.GetByTestId("expense-statement-preview-frame").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+
+        var download = await Page.RunAndWaitForDownloadAsync(
+            async () => await Page.GetByTestId("expense-statement-download-button").ClickAsync());
+        var downloadedPath = await download.PathAsync();
+
+        Assert.EndsWith(".pdf", download.SuggestedFilename, StringComparison.OrdinalIgnoreCase);
+        Assert.StartsWith("Expense-Statement-", download.SuggestedFilename, StringComparison.OrdinalIgnoreCase);
+        Assert.False(string.IsNullOrWhiteSpace(downloadedPath));
+        Assert.True(new FileInfo(downloadedPath).Length > 0, "Expected the downloaded expense statement PDF to be non-empty.");
+    }
+
+    private ILocator ClientCard(string clientName) => Page.GetByTestId("client-card").Filter(new LocatorFilterOptions
+    {
+        HasText = clientName,
+    });
+
+    private ILocator GigCard(string gigTitle) => Page.GetByTestId("gig-card").Filter(new LocatorFilterOptions
+    {
+        HasText = gigTitle,
+    });
+}

--- a/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
+++ b/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
@@ -58,12 +58,15 @@ public sealed class ExpenseStatementTests : UatTestBase
         await Page.GetByTestId("gig-expense-amount-input").FillAsync("62.50");
         await Page.GetByTestId("gig-expense-description-input").FillAsync(expenseDescription);
         await Page.GetByTestId("add-gig-expense-button").ClickAsync();
-        await Page.GetByTestId("gig-expense-item").Filter(new LocatorFilterOptions
-        {
-            HasText = expenseDescription,
-        }).WaitForAsync(new LocatorWaitForOptions
+        await Page.GetByTestId("gig-expense-item").WaitForAsync(new LocatorWaitForOptions
         {
             State = WaitForSelectorState.Visible,
+        });
+        await Assertions.Expect(Page.GetByTestId("gig-expense-item").Locator("input").First).ToHaveValueAsync(
+            expenseDescription,
+            new LocatorAssertionsToHaveValueOptions
+        {
+            Timeout = 30_000,
         });
 
         await Page.GetByTestId("gig-save-close-button").ClickAsync();

--- a/tests/Glovelly.Uat.Tests/InvoiceAggregationWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceAggregationWorkflowTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public sealed class InvoiceAggregationWorkflowTests : UatTestBase
+{
+    [Fact]
+    public Task CanGenerateCombinedInvoiceForSameClientGigs() => RunWithDiagnosticsAsync(
+        nameof(CanGenerateCombinedInvoiceForSameClientGigs),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Combined Client";
+            var firstGigTitle = $"{runId} Combined Gig 1";
+            var secondGigTitle = $"{runId} Combined Gig 2";
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(clientName, firstGigTitle, DateTime.UtcNow.AddDays(21).ToString("yyyy-MM-dd"));
+            await CreateGigAsync(clientName, secondGigTitle, DateTime.UtcNow.AddDays(22).ToString("yyyy-MM-dd"));
+
+            await SelectGigForBatchInvoiceAsync(firstGigTitle);
+            await SelectGigForBatchInvoiceAsync(secondGigTitle);
+            await Page.GetByTestId("generate-invoice-button").ClickAsync();
+            await OpenGeneratedInvoicePreviewAsync();
+            await AssertInvoiceLinesContainAsync(firstGigTitle, secondGigTitle);
+        });
+
+    [Fact]
+    public Task CanGenerateMonthlyInvoiceForEligibleClientGigs() => RunWithDiagnosticsAsync(
+        nameof(CanGenerateMonthlyInvoiceForEligibleClientGigs),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Monthly Client";
+            var firstGigTitle = $"{runId} Monthly Gig 1";
+            var secondGigTitle = $"{runId} Monthly Gig 2";
+            var invoiceMonthDate = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1).AddMonths(2);
+            var invoiceMonth = invoiceMonthDate.ToString("yyyy-MM");
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(clientName, firstGigTitle, invoiceMonthDate.AddDays(4).ToString("yyyy-MM-dd"));
+            await CreateGigAsync(clientName, secondGigTitle, invoiceMonthDate.AddDays(11).ToString("yyyy-MM-dd"));
+
+            await Page.GetByTestId("nav-clients").ClickAsync();
+            await ClientCard(clientName).ClickAsync();
+            await Page.GetByTestId("monthly-invoice-month-input").FillAsync(invoiceMonth);
+            await Assertions.Expect(Page.GetByTestId("monthly-invoice-helper")).ToContainTextAsync(
+                "2 eligible gig(s)",
+                new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+
+            await Page.GetByTestId("generate-monthly-invoice-button").ClickAsync();
+            await OpenGeneratedInvoicePreviewAsync();
+            await AssertInvoiceLinesContainAsync(firstGigTitle, secondGigTitle);
+        });
+
+    private async Task CreateClientAsync(string clientName)
+    {
+        await Page.GetByTestId("nav-clients").ClickAsync();
+        await Page.GetByTestId("new-client-button").ClickAsync();
+        await Page.GetByTestId("client-form").WaitForAsync();
+
+        await Page.GetByTestId("client-name-input").FillAsync(clientName);
+        await Page.GetByTestId("client-email-input").FillAsync("invoices-uat@example.com");
+        await Page.GetByTestId("client-address-line1-input").FillAsync("3 UAT Invoice Street");
+        await Page.GetByTestId("client-city-input").FillAsync("Bristol");
+        await Page.GetByTestId("client-postal-code-input").FillAsync("BS1 5AA");
+        await Page.GetByTestId("client-country-input").FillAsync("United Kingdom");
+        await Page.GetByTestId("client-save-close-button").ClickAsync();
+
+        await ClientCard(clientName).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task CreateGigAsync(string clientName, string gigTitle, string gigDate)
+    {
+        await Page.GetByTestId("nav-gigs").ClickAsync();
+        await Page.GetByTestId("new-gig-button").ClickAsync();
+        await Page.GetByTestId("gig-form").WaitForAsync();
+
+        await Page.GetByTestId("gig-client-select").SelectOptionAsync(new[]
+        {
+            new SelectOptionValue { Label = clientName },
+        });
+        await Page.GetByTestId("gig-date-input").FillAsync(gigDate);
+        await Page.GetByTestId("gig-title-input").FillAsync(gigTitle);
+        await Page.GetByTestId("gig-venue-input").FillAsync("UAT Invoice Hall");
+        await Page.GetByTestId("gig-fee-input").FillAsync("125.00");
+        await Page.GetByTestId("gig-save-close-button").ClickAsync();
+
+        await GigCard(gigTitle).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task SelectGigForBatchInvoiceAsync(string gigTitle)
+    {
+        var card = GigCard(gigTitle);
+        await card.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+        await card.Locator("input[type=checkbox]").CheckAsync();
+    }
+
+    private async Task OpenGeneratedInvoicePreviewAsync()
+    {
+        await Page.GetByTestId("invoice-preview-modal").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+        await Page.GetByTestId("invoice-preview-frame").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+        await Page.GetByTestId("open-invoice-button").ClickAsync();
+        await Page.GetByTestId("invoice-line-items-button").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
+
+    private async Task AssertInvoiceLinesContainAsync(params string[] expectedGigTitles)
+    {
+        await Page.GetByTestId("invoice-line-items-button").ClickAsync();
+
+        foreach (var expectedGigTitle in expectedGigTitles)
+        {
+            await Page.GetByTestId("invoice-line-item").Filter(new LocatorFilterOptions
+            {
+                HasText = expectedGigTitle,
+            }).WaitForAsync(new LocatorWaitForOptions
+            {
+                State = WaitForSelectorState.Visible,
+                Timeout = 30_000,
+            });
+        }
+    }
+
+    private ILocator ClientCard(string clientName) => Page.GetByTestId("client-card").Filter(new LocatorFilterOptions
+    {
+        HasText = clientName,
+    });
+
+    private ILocator GigCard(string gigTitle) => Page.GetByTestId("gig-card").Filter(new LocatorFilterOptions
+    {
+        HasText = gigTitle,
+    });
+}


### PR DESCRIPTION
## Summary
- add UAT workflow badge and automation status annotations to UAT docs
- add stable expense statement selectors for browser coverage
- add Playwright UAT coverage for expense statement preview and PDF download

## Verification
- npm --prefix frontend/glovelly-web run build
- npm --prefix frontend/glovelly-web run lint
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj --configuration Release

Closes #161