### PR TITLE
Improve dashboard and workspace UI density

### DIFF
--- a/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
+++ b/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
@@ -416,8 +416,228 @@ public static class DevelopmentDataSeeder
             }
         };
 
-        return new DevelopmentSeedFixture(clients, invoices, invoiceLines, gigs);
+        var additionalInvoices = BuildAdditionalDevelopmentInvoices(
+            seededAdminUserId,
+            foxAndFinchId,
+            northlightId,
+            riversideId);
+        var additionalInvoiceLines = BuildAdditionalDevelopmentInvoiceLines(additionalInvoices, seededAdminUserId);
+        var additionalGigs = BuildAdditionalDevelopmentGigs(
+            seededAdminUserId,
+            foxAndFinchId,
+            northlightId,
+            riversideId,
+            additionalInvoices);
+
+        return new DevelopmentSeedFixture(
+            clients,
+            invoices.Concat(additionalInvoices).ToArray(),
+            invoiceLines.Concat(additionalInvoiceLines).ToArray(),
+            gigs.Concat(additionalGigs).ToArray());
     }
+
+    private static Invoice[] BuildAdditionalDevelopmentInvoices(
+        Guid? seededAdminUserId,
+        Guid foxAndFinchId,
+        Guid northlightId,
+        Guid riversideId)
+    {
+        var clientIds = new[] { foxAndFinchId, northlightId, riversideId };
+        var statuses = new[]
+        {
+            InvoiceStatus.Overdue,
+            InvoiceStatus.Issued,
+            InvoiceStatus.Draft,
+            InvoiceStatus.Paid,
+            InvoiceStatus.Cancelled
+        };
+        var descriptions = new[]
+        {
+            "Autumn gala reception at The Whitworth Gallery.",
+            "Corporate awards evening at Leeds Civic Hall.",
+            "Chamber set for Northlight summer wedding showcase.",
+            "Community matinee series at Riverside Arts Centre.",
+            "Private salon concert for Fox & Finch guests.",
+            "Orchestral outreach workshop weekend.",
+            "Lakeside ceremony music and evening reception.",
+            "Product launch drinks reception in Manchester.",
+            "Heritage festival family performance day.",
+            "Christmas market brass and strings programme.",
+            "Charity auction dinner entertainment.",
+            "Open-air theatre interval performance.",
+            "New season preview event at The Lantern Room.",
+            "Wedding breakfast and first dance package.",
+            "Artist residency closing concert."
+        };
+
+        return Enumerable.Range(0, 15)
+            .Select(index =>
+            {
+                var invoiceDate = new DateOnly(2026, 3, 18).AddDays(index * 5);
+                var status = statuses[index % statuses.Length];
+                var issuedAt = status is InvoiceStatus.Issued or InvoiceStatus.Overdue or InvoiceStatus.Paid
+                    ? new DateTimeOffset(invoiceDate, new TimeOnly(9, 0), TimeSpan.Zero)
+                    : (DateTimeOffset?)null;
+
+                return new Invoice
+                {
+                    Id = DevelopmentGuid(2000 + index),
+                    InvoiceNumber = $"GLV-2026-{index + 4:000}",
+                    ClientId = clientIds[index % clientIds.Length],
+                    InvoiceDate = invoiceDate,
+                    DueDate = invoiceDate.AddDays(14),
+                    Status = status,
+                    StatusUpdatedUtc = issuedAt ?? SeededCreatedUtc.AddDays(index),
+                    FirstIssuedUtc = issuedAt,
+                    FirstIssuedByUserId = issuedAt.HasValue ? seededAdminUserId : null,
+                    DeliveryCount = issuedAt.HasValue ? 1 : 0,
+                    LastDeliveryChannel = issuedAt.HasValue ? "Email" : null,
+                    LastDeliveryRecipient = issuedAt.HasValue ? "seeded-client@example.com" : null,
+                    LastDeliveredUtc = issuedAt?.AddMinutes(10),
+                    LastDeliveredByUserId = issuedAt.HasValue ? seededAdminUserId : null,
+                    Description = descriptions[index],
+                    CreatedByUserId = seededAdminUserId,
+                    UpdatedByUserId = seededAdminUserId
+                };
+            })
+            .ToArray();
+    }
+
+    private static InvoiceLine[] BuildAdditionalDevelopmentInvoiceLines(
+        IReadOnlyList<Invoice> invoices,
+        Guid? seededAdminUserId)
+    {
+        var lineSubjects = new[]
+        {
+            "Autumn Gala Reception",
+            "Corporate Awards Evening",
+            "Summer Wedding Showcase",
+            "Community Matinee Series",
+            "Private Salon Concert",
+            "Outreach Workshop Weekend",
+            "Lakeside Ceremony Package",
+            "Manchester Product Launch",
+            "Heritage Festival Day",
+            "Christmas Market Programme",
+            "Charity Auction Dinner",
+            "Open-Air Theatre Interval",
+            "New Season Preview",
+            "Wedding Breakfast Package",
+            "Residency Closing Concert"
+        };
+
+        return invoices
+            .SelectMany((invoice, index) => new[]
+            {
+                new InvoiceLine
+                {
+                    Id = DevelopmentGuid(3000 + (index * 2)),
+                    InvoiceId = invoice.Id,
+                    SortOrder = 1,
+                    Type = InvoiceLineType.PerformanceFee,
+                    Description = $"Performance fee for {lineSubjects[index]}",
+                    Quantity = 1m,
+                    UnitPrice = 350m + (index * 35m),
+                    IsSystemGenerated = true,
+                    CreatedByUserId = seededAdminUserId,
+                    CreatedUtc = SeededCreatedUtc.AddDays(index)
+                },
+                new InvoiceLine
+                {
+                    Id = DevelopmentGuid(3001 + (index * 2)),
+                    InvoiceId = invoice.Id,
+                    SortOrder = 2,
+                    Type = InvoiceLineType.Mileage,
+                    Description = $"Mileage for {lineSubjects[index]}",
+                    Quantity = 10m + index,
+                    UnitPrice = 0.45m,
+                    CalculationNotes = "Generated development data for large-list testing.",
+                    IsSystemGenerated = true,
+                    CreatedByUserId = seededAdminUserId,
+                    CreatedUtc = SeededCreatedUtc.AddDays(index)
+                }
+            })
+            .ToArray();
+    }
+
+    private static Gig[] BuildAdditionalDevelopmentGigs(
+        Guid? seededAdminUserId,
+        Guid foxAndFinchId,
+        Guid northlightId,
+        Guid riversideId,
+        IReadOnlyList<Invoice> additionalInvoices)
+    {
+        var clients = new[] { foxAndFinchId, northlightId, riversideId };
+        var venues = new[]
+        {
+            "The Lantern Room, York",
+            "Assembly Hall, Sheffield",
+            "Botanical House, Liverpool",
+            "Old Market Theatre, Brighton",
+            "St George's Hall, Bristol",
+            "The Pump Rooms, Bath"
+        };
+        var statuses = new[]
+        {
+            GigStatus.Confirmed,
+            GigStatus.Completed,
+            GigStatus.Draft,
+            GigStatus.Cancelled,
+            GigStatus.Confirmed,
+            GigStatus.Completed
+        };
+        var titles = new[]
+        {
+            "Autumn Gala Reception",
+            "Corporate Awards Evening",
+            "Summer Wedding Showcase",
+            "Community Matinee Series",
+            "Private Salon Concert",
+            "Outreach Workshop Weekend",
+            "Lakeside Ceremony Package",
+            "Manchester Product Launch",
+            "Heritage Festival Day",
+            "Christmas Market Programme",
+            "Charity Auction Dinner",
+            "Open-Air Theatre Interval",
+            "New Season Preview",
+            "Wedding Breakfast Package",
+            "Residency Closing Concert",
+            "Botanical House Drinks Reception",
+            "Riverside Youth Ensemble Day",
+            "Northlight Anniversary Party"
+        };
+
+        return Enumerable.Range(0, 18)
+            .Select(index =>
+            {
+                var status = statuses[index % statuses.Length];
+                var date = new DateOnly(2026, 4, 10).AddDays(index * 4);
+                var invoice = index % 4 == 0 ? additionalInvoices[index % additionalInvoices.Count] : null;
+
+                return new Gig
+                {
+                    Id = DevelopmentGuid(4000 + index),
+                    ClientId = clients[index % clients.Length],
+                    InvoiceId = invoice?.Id,
+                    Title = titles[index],
+                    Date = date,
+                    Venue = venues[index % venues.Length],
+                    Fee = 275m + (index * 45m),
+                    TravelMiles = 8m + (index * 3m),
+                    PassengerCount = index % 3,
+                    Notes = "Development example for scrolling, filtering and priority sorting.",
+                    WasDriving = index % 2 == 0,
+                    Status = status,
+                    InvoicedAt = invoice is null ? null : new DateTimeOffset(invoice.InvoiceDate, new TimeOnly(9, 0), TimeSpan.Zero),
+                    CreatedByUserId = seededAdminUserId,
+                    UpdatedByUserId = seededAdminUserId
+                };
+            })
+            .ToArray();
+    }
+
+    private static Guid DevelopmentGuid(int value) => Guid.Parse($"00000000-0000-0000-0000-{value:000000000000}");
 
     private static async Task SaveFixtureAsync(
         DevelopmentDataSeedContext context,

--- a/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
+++ b/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
@@ -411,6 +411,47 @@ public static class DevelopmentDataSeeder
                         ReimbursementUpdatedAt = new DateTimeOffset(2026, 4, 8, 10, 30, 0, TimeSpan.Zero),
                         ReimbursementMethod = "Invoice GLV-2026-002",
                         ReimbursementNote = "Seeded example of a reimbursed expense that should not regenerate as a chargeable invoice line."
+                    },
+                    new GigExpense
+                    {
+                        Id = DevelopmentGuid(5000),
+                        SortOrder = 3,
+                        Description = "Parking",
+                        Amount = 9.80m,
+                        ReimbursementStatus = GigExpenseReimbursementStatus.Unreimbursed
+                    },
+                    new GigExpense
+                    {
+                        Id = DevelopmentGuid(5001),
+                        SortOrder = 4,
+                        Description = "Train fare",
+                        Amount = 27.40m,
+                        ReimbursementStatus = GigExpenseReimbursementStatus.Unreimbursed
+                    },
+                    new GigExpense
+                    {
+                        Id = DevelopmentGuid(5002),
+                        SortOrder = 5,
+                        Description = "Replacement strings",
+                        Amount = 18.00m,
+                        ReimbursementStatus = GigExpenseReimbursementStatus.NotClaimable,
+                        ReimbursementUpdatedByUserId = seededAdminUserId,
+                        ReimbursementUpdatedAt = new DateTimeOffset(2026, 5, 11, 19, 0, 0, TimeSpan.Zero),
+                        ReimbursementNote = "Personal consumables, not billed to the client."
+                    },
+                    new GigExpense
+                    {
+                        Id = DevelopmentGuid(5003),
+                        SortOrder = 6,
+                        Description = "Accommodation deposit",
+                        Amount = 85.00m,
+                        ReimbursementStatus = GigExpenseReimbursementStatus.Reimbursed,
+                        ReimbursementInvoiceId = invoices[1].Id,
+                        ReimbursementUpdatedByUserId = seededAdminUserId,
+                        ReimbursedAt = new DateTimeOffset(2026, 4, 8, 10, 30, 0, TimeSpan.Zero),
+                        ReimbursementUpdatedAt = new DateTimeOffset(2026, 4, 8, 10, 30, 0, TimeSpan.Zero),
+                        ReimbursementMethod = "Invoice GLV-2026-002",
+                        ReimbursementNote = "Venue reimbursed accommodation directly."
                     }
                 ]
             }

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -38,6 +38,24 @@ For local development, engineers usually run:
 
 Navigation, session state, and core reads are healthy.
 
+## Dashboard Summary
+
+> **Automation:** Manual UAT
+
+### Steps
+
+1. Sign in with at least one draft, issued, or overdue invoice available.
+2. Confirm the dashboard shows an outstanding balance that includes draft, issued, and overdue invoice totals, but excludes paid and cancelled invoices.
+3. Confirm the `Next gig` card shows the earliest non-cancelled upcoming gig.
+4. Click `Open gig` and confirm the app opens Gigs with that gig selected.
+5. Identify a recent past or current uninvoiced gig with status `Planned` or `Completed`.
+6. Confirm the invoice prompt shows that gig and click `Generate invoice`.
+7. Confirm the invoice preview opens, the gig becomes linked to the generated invoice, and returning to the dashboard no longer offers that gig as the invoice prompt.
+
+### Expected Results
+
+The top-level dashboard surfaces actionable work without relying on stale search filters or manual workspace navigation.
+
 ## Connected Services
 
 When changes touch Google Calendar, run the focused [Google Calendar](calendar.md) journey.

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -40,7 +40,7 @@ Navigation, session state, and core reads are healthy.
 
 ## Dashboard Summary
 
-> **Automation:** Manual UAT
+> **Automation:** Automated UAT: `Glovelly.Uat.Tests.DashboardSummaryTests.DashboardHighlightsNextGigOutstandingBalanceAndInvoicePrompt`; manual balance edge-case spot checks remain useful when paid, cancelled, issued, and overdue invoices already exist together.
 
 ### Steps
 

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1250,6 +1250,60 @@
   background: var(--surface-elevated);
 }
 
+.compact-list-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 12px;
+  align-items: end;
+}
+
+.compact-list-toolbar label {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.compact-list-toolbar span {
+  color: var(--muted-strong);
+  font-size: 0.78rem;
+}
+
+.compact-list-toolbar select {
+  height: 40px;
+  min-height: 40px;
+  border-radius: 12px;
+}
+
+.compact-sort-direction {
+  width: 40px;
+  height: 40px;
+  min-height: 40px;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 95%, transparent);
+  border-radius: 12px;
+  background: var(--surface-elevated);
+  color: var(--heading);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.compact-sort-direction:hover,
+.compact-sort-direction:focus-visible {
+  background: var(--surface-accent);
+  border-color: color-mix(in srgb, var(--heading) 28%, var(--surface-border));
+  transform: translateY(-1px);
+}
+
 .compact-record-row {
   width: 100%;
   min-width: 0;
@@ -1288,6 +1342,24 @@
     minmax(0, 0.72fr)
     minmax(0, 0.7fr)
     minmax(0, 0.7fr);
+}
+
+.client-record-row {
+  grid-template-columns:
+    minmax(0, 1.25fr)
+    minmax(0, 1.25fr)
+    minmax(0, 0.8fr)
+    minmax(0, 0.8fr);
+}
+
+.admin-record-row {
+  grid-template-columns:
+    minmax(0, 1.25fr)
+    minmax(0, 1.2fr)
+    minmax(0, 0.55fr)
+    minmax(0, 0.65fr)
+    minmax(0, 0.65fr)
+    minmax(0, 0.9fr);
 }
 
 .compact-record-header {
@@ -1974,13 +2046,23 @@ button:disabled {
     border-radius: 16px;
   }
 
+  .compact-list-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .compact-sort-direction {
+    justify-self: start;
+  }
+
   .compact-record-header {
     display: none;
   }
 
   .compact-record-row,
   .gig-record-row,
-  .invoice-record-row {
+  .invoice-record-row,
+  .client-record-row,
+  .admin-record-row {
     grid-template-columns: 1fr;
     gap: 5px;
   }

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1205,6 +1205,10 @@
   gap: 16px;
 }
 
+.panel-heading > div:first-child {
+  min-width: 0;
+}
+
 .search-field,
 .form-grid label {
   display: grid;
@@ -1872,8 +1876,18 @@ button.compact-record-row.selected {
 .actions,
 .form-actions {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
+}
+
+.actions {
+  align-items: center;
+}
+
+.panel-heading .actions {
+  max-width: min(100%, 620px);
+  justify-content: flex-end;
+  gap: 6px;
 }
 
 .detail-grid {
@@ -1993,16 +2007,37 @@ button.compact-record-row.selected {
 .ghost-button,
 .danger-button {
   border-radius: 999px;
-  padding: 12px 18px;
+  padding: 10px 15px;
+  min-height: 40px;
   border: 1px solid transparent;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
+  font-size: 0.92rem;
+  line-height: 1.15;
+  white-space: nowrap;
   transition:
     transform 180ms ease,
     box-shadow 180ms ease,
     background 180ms ease;
+}
+
+.panel-heading .primary-button,
+.panel-heading .ghost-button,
+.panel-heading .danger-button {
+  min-height: 34px;
+  padding: 7px 11px;
+  font-size: 0.82rem;
+}
+
+.form-actions .primary-button,
+.form-actions .ghost-button,
+.form-actions .danger-button {
+  min-height: 44px;
+  padding: 12px 18px;
+  font-size: 0.95rem;
 }
 
 .primary-button {
@@ -2208,6 +2243,10 @@ button:disabled {
 
   .panel-heading {
     flex-direction: column;
+  }
+
+  .panel-heading .actions {
+    justify-content: flex-start;
   }
 
   .settings-header-actions {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1250,28 +1250,82 @@
   background: var(--surface-elevated);
 }
 
-.compact-list-toolbar {
+.compact-list-controls {
+  position: sticky;
+  top: 0;
+  z-index: 4;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
-  gap: 12px;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-panel) 94%, var(--surface-elevated));
+  box-shadow: var(--surface-shadow-soft);
+}
+
+.compact-list-main-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(140px, 0.42fr) max-content;
+  gap: 10px;
   align-items: end;
 }
 
-.compact-list-toolbar label {
+.compact-list-controls label {
   display: grid;
   gap: 6px;
   min-width: 0;
 }
 
-.compact-list-toolbar span {
+.compact-list-controls span {
   color: var(--muted-strong);
   font-size: 0.78rem;
 }
 
-.compact-list-toolbar select {
+.compact-search-field {
+  min-width: 0;
+}
+
+.compact-list-controls select {
   height: 40px;
   min-height: 40px;
   border-radius: 12px;
+}
+
+.compact-filter-chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.compact-filter-chip {
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 90%, transparent);
+  border-radius: 999px;
+  background: var(--surface-elevated);
+  color: var(--muted-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.compact-filter-chip:hover,
+.compact-filter-chip:focus-visible,
+.compact-filter-chip.selected {
+  background: var(--surface-accent);
+  border-color: color-mix(in srgb, #f47d2a 42%, var(--surface-border));
+  color: var(--heading);
+}
+
+.compact-filter-chip:hover,
+.compact-filter-chip:focus-visible {
+  transform: translateY(-1px);
 }
 
 .compact-sort-direction {
@@ -2046,8 +2100,12 @@ button:disabled {
     border-radius: 16px;
   }
 
-  .compact-list-toolbar {
-    grid-template-columns: 1fr;
+  .compact-list-main-controls {
+    grid-template-columns: minmax(0, 1fr) max-content;
+  }
+
+  .compact-search-field {
+    grid-column: 1 / -1;
   }
 
   .compact-sort-direction {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -26,7 +26,7 @@
   letter-spacing: 0.04em;
 }
 
-.return-to-top-button {
+.primary-button.return-to-top-button {
   display: none;
 }
 
@@ -1154,6 +1154,53 @@
   animation: editor-panel-enter 220ms ease;
 }
 
+.gig-editor-panel {
+  gap: 14px;
+}
+
+.gig-editor-panel .panel-heading {
+  gap: 10px;
+}
+
+.gig-editor-panel .form-grid {
+  gap: 10px;
+}
+
+.gig-editor-panel .form-grid label,
+.gig-editor-panel .invoice-adjustment-form label {
+  gap: 5px;
+}
+
+.gig-editor-panel input,
+.gig-editor-panel select {
+  min-height: 40px;
+  border-radius: 13px;
+  padding-inline: 12px;
+}
+
+.gig-editor-panel textarea {
+  min-height: 82px;
+  max-height: 120px;
+  border-radius: 13px;
+  padding: 10px 12px;
+}
+
+.gig-editor-panel .checkbox-field {
+  min-height: 40px;
+  padding: 8px 12px;
+  border-radius: 14px;
+}
+
+.gig-editor-panel .gig-timeline-note {
+  padding: 10px 12px;
+  border-radius: 14px;
+}
+
+.gig-editor-panel .invoice-adjustment-form {
+  gap: 8px;
+  margin-top: 0;
+}
+
 .editor-slot {
   width: 0;
   min-width: 0;
@@ -1654,8 +1701,8 @@ button.compact-record-row.selected {
 .gig-expense-list {
   display: flex;
   flex-direction: column;
-  min-height: 180px;
-  max-height: clamp(220px, 34svh, 380px);
+  min-height: clamp(280px, 38svh, 380px);
+  max-height: clamp(360px, 58svh, 640px);
   overflow: auto;
   overscroll-behavior: contain;
   border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
@@ -1668,10 +1715,10 @@ button.compact-record-row.selected {
 .gig-expense-item {
   flex: 0 0 auto;
   display: grid;
-  gap: 8px;
+  gap: 6px;
   grid-template-columns: minmax(0, 1fr) minmax(88px, 0.36fr) auto;
   align-items: end;
-  padding: 10px 12px;
+  padding: 8px 10px;
   border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 74%, transparent);
   background: transparent;
 }
@@ -1690,15 +1737,15 @@ button.compact-record-row.selected {
   grid-column: 1 / -1;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
 .expense-status-badge {
   display: inline-flex;
   align-items: center;
-  min-height: 24px;
-  padding: 3px 8px;
+  min-height: 22px;
+  padding: 2px 7px;
   border-radius: 999px;
   background: var(--surface-subtle);
   border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
@@ -1720,7 +1767,7 @@ button.compact-record-row.selected {
 
 .gig-expense-item label {
   display: grid;
-  gap: 4px;
+  gap: 3px;
   min-width: 0;
 }
 
@@ -1732,20 +1779,20 @@ button.compact-record-row.selected {
 .gig-expense-item button {
   justify-self: end;
   align-self: end;
-  min-height: 38px;
-  padding: 8px 12px;
+  min-height: 34px;
+  padding: 7px 10px;
 }
 
 .gig-expense-item input,
 .gig-expense-item select {
-  min-height: 38px;
+  min-height: 34px;
   border-radius: 12px;
 }
 
 .expense-attachments {
   grid-column: 1 / -1;
   display: grid;
-  gap: 6px;
+  gap: 5px;
   min-width: 0;
   padding-top: 2px;
 }
@@ -1768,7 +1815,7 @@ button.compact-record-row.selected {
 .expense-attachment-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  padding: 8px 10px;
+  padding: 7px 8px;
   border-radius: 8px;
   background: var(--surface-soft);
 }
@@ -2158,29 +2205,6 @@ button:disabled {
 }
 
 @media (max-width: 1180px) {
-  .return-to-top-button {
-    position: fixed;
-    right: max(14px, env(safe-area-inset-right));
-    bottom: max(14px, env(safe-area-inset-bottom));
-    z-index: 60;
-    display: inline-flex;
-    opacity: 0;
-    pointer-events: none;
-    box-shadow: var(--surface-shadow-strong);
-    transform: translateY(10px);
-    transition:
-      opacity 180ms ease,
-      transform 180ms ease,
-      box-shadow 180ms ease,
-      background 180ms ease;
-  }
-
-  .return-to-top-button.visible {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
-  }
-
   .hero-panel,
   .workspace,
   .admin-workspace,
@@ -2231,6 +2255,29 @@ button:disabled {
 }
 
 @media (max-width: 760px) {
+  .primary-button.return-to-top-button {
+    position: fixed;
+    right: max(14px, env(safe-area-inset-right));
+    bottom: max(14px, env(safe-area-inset-bottom));
+    z-index: 60;
+    display: inline-flex;
+    opacity: 0;
+    pointer-events: none;
+    box-shadow: var(--surface-shadow-strong);
+    transform: translateY(10px);
+    transition:
+      opacity 180ms ease,
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      background 180ms ease;
+  }
+
+  .primary-button.return-to-top-button.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
   .app-shell {
     padding: 10px;
     gap: 12px;
@@ -2543,13 +2590,9 @@ button:disabled {
   }
 
   .gig-expense-list {
-    max-height: 38svh;
+    min-height: min(360px, 50svh);
+    max-height: 54svh;
     border-radius: 14px;
-  }
-
-  .gig-expense-item {
-    gap: 7px;
-    padding: 10px;
   }
 
   .expense-status-select,

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1738,6 +1738,7 @@ button.compact-record-row.selected {
   grid-column: 1 / -1;
   display: grid;
   gap: 6px;
+  min-width: 0;
   padding-top: 2px;
 }
 
@@ -1747,14 +1748,18 @@ button.compact-record-row.selected {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  min-width: 0;
 }
 
 .expense-attachment-list {
   display: grid;
   gap: 8px;
+  min-width: 0;
 }
 
 .expense-attachment-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   padding: 8px 10px;
   border-radius: 8px;
   background: var(--surface-soft);
@@ -1762,6 +1767,17 @@ button.compact-record-row.selected {
 
 .expense-attachment-item button {
   grid-column: auto;
+  min-width: 0;
+}
+
+.expense-attachment-item .link-button {
+  overflow-wrap: anywhere;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.expense-attachment-item .ghost-button {
+  white-space: nowrap;
 }
 
 .file-button {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -914,6 +914,60 @@
   font-size: 1.02rem;
 }
 
+.dashboard-summary {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.1fr) repeat(2, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.dashboard-card {
+  border-radius: 22px;
+  padding: 18px;
+  background: var(--surface-highlight);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 90%, transparent);
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.dashboard-card strong {
+  color: var(--heading);
+  font-size: 1.02rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.dashboard-card span {
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+.dashboard-card > .section-label {
+  margin-bottom: 2px;
+}
+
+.outstanding-card strong {
+  display: block;
+  font-family: var(--display);
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  color: var(--heading);
+  line-height: 0.95;
+}
+
+.invoice-action-card {
+  background:
+    linear-gradient(135deg, color-mix(in srgb, #f47d2a 18%, transparent), transparent 64%),
+    var(--surface-highlight);
+}
+
+.compact-action {
+  justify-self: start;
+  margin-top: 6px;
+  padding: 9px 14px;
+  min-height: 40px;
+}
+
 .hero-metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -1760,6 +1814,7 @@ button:disabled {
     border-radius: 22px;
   }
 
+  .dashboard-summary,
   .hero-metrics,
   .form-grid,
   .detail-grid,

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -593,8 +593,7 @@
 }
 
 .expense-statement-gig-header,
-.expense-statement-footer,
-.expense-statement-expense {
+.expense-statement-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -622,6 +621,10 @@
 }
 
 .expense-statement-expense {
+  display: grid;
+  align-items: center;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 12px;
   border-radius: 8px;
   padding: 10px 12px;
   background: var(--surface-elevated);
@@ -997,6 +1000,7 @@
   display: grid;
   gap: 24px;
   grid-template-columns: minmax(0, 0.95fr) minmax(0, 1fr) auto;
+  align-items: start;
 }
 
 .admin-zone {
@@ -1013,12 +1017,14 @@
   display: grid;
   gap: 24px;
   grid-template-columns: minmax(0, 0.9fr) minmax(0, 1fr) auto;
+  align-items: start;
 }
 
 .gig-workspace {
   display: grid;
   gap: 24px;
   grid-template-columns: minmax(0, 0.9fr) minmax(0, 1fr) auto;
+  align-items: start;
 }
 
 .gig-import-workspace {
@@ -1140,10 +1146,6 @@
   max-width: 100%;
 }
 
-.panel:has(> .compact-record-list) {
-  min-height: min(680px, calc(100svh - 180px));
-}
-
 .editor-panel {
   animation: editor-panel-enter 220ms ease;
 }
@@ -1250,10 +1252,44 @@
   overflow-y: auto;
   min-width: 0;
   min-height: 260px;
-  max-height: min(58svh, 620px);
+  max-height: min(66svh, 760px);
   border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
   border-radius: 18px;
   background: var(--surface-elevated);
+}
+
+@media (min-width: 1181px) {
+  .editor-slot:not(.open) {
+    height: 0;
+    max-height: 0;
+    contain: size layout paint;
+  }
+
+  .workspace > .panel:has(> .compact-record-list),
+  .admin-workspace > .panel:has(> .compact-record-list),
+  .gig-workspace > .panel:has(> .compact-record-list),
+  .editor-slot.open {
+    height: var(--workspace-detail-height);
+    min-height: 0;
+  }
+
+  .workspace > .panel:has(> .compact-record-list),
+  .admin-workspace > .panel:has(> .compact-record-list),
+  .gig-workspace > .panel:has(> .compact-record-list) {
+    overflow: hidden;
+  }
+
+  .editor-slot.open > .panel {
+    height: 100%;
+    max-height: none;
+    overflow: auto;
+  }
+
+  .compact-record-list {
+    flex-basis: auto;
+    min-height: 0;
+    max-height: none;
+  }
 }
 
 .compact-list-controls {
@@ -1265,12 +1301,16 @@
   padding: 12px;
   border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
   border-radius: 18px;
-  background: #fbf8f2;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, #f47d2a 8%, transparent), transparent 58%),
+    #fbf8f2;
   box-shadow: var(--surface-shadow-soft);
 }
 
 :root[data-theme='dark'] .compact-list-controls {
-  background: #18212d;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, #f47d2a 10%, transparent), transparent 58%),
+    #18212d;
 }
 
 .compact-list-main-controls {
@@ -1328,7 +1368,9 @@
 .compact-filter-chip:hover,
 .compact-filter-chip:focus-visible,
 .compact-filter-chip.selected {
-  background: var(--surface-accent);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, #f47d2a 14%, transparent), transparent 62%),
+    var(--surface-accent);
   border-color: color-mix(in srgb, #f47d2a 42%, var(--surface-border));
   color: var(--heading);
 }
@@ -1459,7 +1501,9 @@ button.compact-record-row {
 button.compact-record-row:hover,
 button.compact-record-row:focus-visible,
 button.compact-record-row.selected {
-  background: var(--surface-accent);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, #f47d2a 12%, transparent), transparent 64%),
+    var(--surface-accent);
   box-shadow: inset 3px 0 0 color-mix(in srgb, #f47d2a 72%, var(--surface-border));
 }
 
@@ -1600,24 +1644,38 @@ button.compact-record-row.selected {
 }
 
 .gig-expense-list {
-  display: grid;
-  gap: 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 180px;
+  max-height: clamp(220px, 34svh, 380px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
+  border-radius: 18px;
+  background: var(--surface-elevated);
+  -webkit-overflow-scrolling: touch;
+  scrollbar-gutter: stable;
 }
 
 .gig-expense-item {
+  flex: 0 0 auto;
   display: grid;
-  gap: 10px;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 140px);
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) minmax(88px, 0.36fr) auto;
   align-items: end;
-  padding: 14px 16px;
-  border-radius: 18px;
-  background: var(--surface-elevated);
-  border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
+  padding: 10px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 74%, transparent);
+  background: transparent;
+}
+
+.gig-expense-item:last-child {
+  border-bottom: 0;
 }
 
 .gig-expense-item.is-reimbursed {
-  background: color-mix(in srgb, #2b8c67 8%, var(--surface-elevated));
-  border-color: color-mix(in srgb, #2b8c67 35%, var(--surface-border));
+  background:
+    linear-gradient(135deg, color-mix(in srgb, #2b8c67 10%, transparent), transparent 60%),
+    transparent;
 }
 
 .expense-reimbursement-state {
@@ -1648,31 +1706,39 @@ button.compact-record-row.selected {
 }
 
 .expense-status-select {
-  grid-column: 1 / -1;
-  max-width: 220px;
+  grid-column: 1 / span 2;
+  max-width: none;
 }
 
 .gig-expense-item label {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
 }
 
 .gig-expense-item span {
-  font-size: 0.86rem;
+  font-size: 0.78rem;
   color: var(--muted-strong);
 }
 
 .gig-expense-item button {
-  grid-column: 1 / -1;
-  justify-self: start;
+  justify-self: end;
+  align-self: end;
+  min-height: 38px;
+  padding: 8px 12px;
+}
+
+.gig-expense-item input,
+.gig-expense-item select {
+  min-height: 38px;
+  border-radius: 12px;
 }
 
 .expense-attachments {
   grid-column: 1 / -1;
   display: grid;
-  gap: 8px;
-  padding-top: 4px;
+  gap: 6px;
+  padding-top: 2px;
 }
 
 .expense-attachment-header,
@@ -1935,6 +2001,20 @@ button.compact-record-row.selected {
   border-color: var(--surface-border);
 }
 
+.editor-toggle {
+  position: relative;
+}
+
+.editor-toggle.active {
+  background:
+    linear-gradient(135deg, color-mix(in srgb, #f47d2a 16%, transparent), transparent 62%),
+    var(--surface-accent);
+  border-color: color-mix(in srgb, #f47d2a 46%, var(--surface-border));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, #f47d2a 18%, transparent),
+    var(--surface-shadow-soft);
+}
+
 .danger-button {
   background: color-mix(in srgb, #a12828 22%, transparent);
   color: var(--danger-text);
@@ -2065,6 +2145,8 @@ button:disabled {
   .editor-slot > .panel,
   .editor-slot.open > .panel {
     width: 100%;
+    height: auto;
+    overflow: visible;
     min-width: 0;
     transform: none;
   }
@@ -2305,15 +2387,19 @@ button:disabled {
   }
 
   .content-header.panel {
+    position: relative;
     padding: 12px;
     gap: 12px;
   }
 
   .content-header-body {
     gap: 12px;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
   }
 
   .content-header-copy {
+    grid-column: 1;
     gap: 8px;
   }
 
@@ -2353,7 +2439,44 @@ button:disabled {
   }
 
   .hero-mascot {
+    display: inline-flex;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: fit-content;
+    gap: 0;
+    padding: 6px;
+    border-radius: 16px;
+    z-index: 25;
+  }
+
+  .hero-mascot div {
     display: none;
+  }
+
+  .hero-mascot img {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+  }
+
+  .gig-expense-list {
+    max-height: 38svh;
+    border-radius: 14px;
+  }
+
+  .gig-expense-item {
+    gap: 7px;
+    padding: 10px;
+  }
+
+  .expense-status-select,
+  .gig-expense-item button {
+    grid-column: 1 / -1;
+  }
+
+  .gig-expense-item button {
+    justify-self: start;
   }
 
   .charm-bar {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1238,6 +1238,136 @@
   contain-intrinsic-size: 500px;
 }
 
+.compact-record-list {
+  display: grid;
+  align-content: start;
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-width: 0;
+  max-height: min(62svh, 720px);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
+  border-radius: 18px;
+  background: var(--surface-elevated);
+}
+
+.compact-record-row {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  display: grid;
+  gap: 12px;
+  align-items: center;
+  border: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 74%, transparent);
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+
+.compact-record-row:last-child {
+  border-bottom: 0;
+}
+
+.gig-record-row {
+  grid-template-columns:
+    28px
+    minmax(0, 1.45fr)
+    minmax(0, 0.95fr)
+    minmax(0, 0.72fr)
+    minmax(0, 1fr)
+    minmax(0, 0.65fr)
+    minmax(0, 0.75fr);
+}
+
+.invoice-record-row {
+  grid-template-columns:
+    minmax(0, 1.25fr)
+    minmax(0, 1fr)
+    minmax(0, 0.72fr)
+    minmax(0, 0.72fr)
+    minmax(0, 0.7fr)
+    minmax(0, 0.7fr);
+}
+
+.compact-record-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 14px;
+  background: color-mix(in srgb, var(--surface-subtle) 92%, var(--surface-elevated));
+  color: var(--muted-strong);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+button.compact-record-row {
+  min-height: 50px;
+  padding: 9px 14px;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    box-shadow 160ms ease;
+}
+
+button.compact-record-row:hover,
+button.compact-record-row:focus-visible,
+button.compact-record-row.selected {
+  background: var(--surface-accent);
+  box-shadow: inset 3px 0 0 color-mix(in srgb, #f47d2a 72%, var(--surface-border));
+}
+
+.compact-record-row strong,
+.compact-record-row span,
+.compact-record-row small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-record-row strong {
+  color: var(--heading);
+}
+
+.compact-record-row span,
+.compact-record-row small {
+  color: var(--muted);
+}
+
+.compact-record-row .compact-status-cell {
+  color: var(--heading);
+  font-weight: 700;
+}
+
+.compact-money-cell {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.compact-primary-cell {
+  display: grid;
+  gap: 2px;
+}
+
+.compact-primary-cell span {
+  display: none;
+}
+
+.compact-select-toggle {
+  min-width: 0;
+  overflow: hidden;
+  justify-self: center;
+}
+
 .client-card {
   text-align: left;
   border: 1px solid var(--surface-border);
@@ -1636,7 +1766,8 @@
 .primary-button,
 .ghost-button,
 .danger-button,
-.client-card {
+.client-card,
+.compact-record-row {
   font: inherit;
 }
 
@@ -1836,6 +1967,39 @@ button:disabled {
 
   .status-pill {
     border-radius: 16px;
+  }
+
+  .compact-record-list {
+    max-height: 52svh;
+    border-radius: 16px;
+  }
+
+  .compact-record-header {
+    display: none;
+  }
+
+  .compact-record-row,
+  .gig-record-row,
+  .invoice-record-row {
+    grid-template-columns: 1fr;
+    gap: 5px;
+  }
+
+  button.compact-record-row {
+    min-height: 0;
+    padding: 12px 14px;
+  }
+
+  .compact-primary-cell span {
+    display: block;
+  }
+
+  .gig-record-row .compact-select-toggle {
+    margin-bottom: 2px;
+  }
+
+  .compact-money-cell {
+    text-align: left;
   }
 
   .content-header-top {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -26,6 +26,10 @@
   letter-spacing: 0.04em;
 }
 
+.return-to-top-button {
+  display: none;
+}
+
 .legal-links {
   display: inline-flex;
   align-items: center;
@@ -2154,6 +2158,29 @@ button:disabled {
 }
 
 @media (max-width: 1180px) {
+  .return-to-top-button {
+    position: fixed;
+    right: max(14px, env(safe-area-inset-right));
+    bottom: max(14px, env(safe-area-inset-bottom));
+    z-index: 60;
+    display: inline-flex;
+    opacity: 0;
+    pointer-events: none;
+    box-shadow: var(--surface-shadow-strong);
+    transform: translateY(10px);
+    transition:
+      opacity 180ms ease,
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      background 180ms ease;
+  }
+
+  .return-to-top-button.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
   .hero-panel,
   .workspace,
   .admin-workspace,

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1140,6 +1140,10 @@
   max-width: 100%;
 }
 
+.panel:has(> .compact-record-list) {
+  min-height: min(680px, calc(100svh - 180px));
+}
+
 .editor-panel {
   animation: editor-panel-enter 220ms ease;
 }
@@ -1239,12 +1243,14 @@
 }
 
 .compact-record-list {
-  display: grid;
-  align-content: start;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 320px;
   overflow-x: hidden;
   overflow-y: auto;
   min-width: 0;
-  max-height: min(62svh, 720px);
+  min-height: 260px;
+  max-height: min(58svh, 620px);
   border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
   border-radius: 18px;
   background: var(--surface-elevated);
@@ -1259,8 +1265,12 @@
   padding: 12px;
   border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
   border-radius: 18px;
-  background: color-mix(in srgb, var(--surface-panel) 94%, var(--surface-elevated));
+  background: #fbf8f2;
   box-shadow: var(--surface-shadow-soft);
+}
+
+:root[data-theme='dark'] .compact-list-controls {
+  background: #18212d;
 }
 
 .compact-list-main-controls {
@@ -1359,6 +1369,7 @@
 }
 
 .compact-record-row {
+  flex: 0 0 auto;
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
@@ -1419,6 +1430,7 @@
 .compact-record-header {
   position: sticky;
   top: 0;
+  flex: 0 0 auto;
   z-index: 2;
   display: grid;
   width: 100%;
@@ -1879,9 +1891,7 @@ button.compact-record-row.selected {
 
 .empty-state {
   padding: 22px;
-  border-radius: 20px;
-  border: 1px dashed color-mix(in srgb, var(--muted-strong) 30%, transparent);
-  background: var(--surface-soft);
+  text-align: center;
 }
 
 .roomy {
@@ -2062,13 +2072,28 @@ button:disabled {
 
 @media (max-width: 760px) {
   .app-shell {
-    padding: 16px;
+    padding: 10px;
+    gap: 12px;
   }
 
   .hero-panel,
   .panel {
-    padding: 20px;
-    border-radius: 22px;
+    padding: 14px;
+    border-radius: 18px;
+    gap: 14px;
+  }
+
+  .section-layout,
+  .content-shell,
+  .workspace,
+  .admin-workspace,
+  .gig-workspace,
+  .admin-zone {
+    gap: 14px;
+  }
+
+  .panel:has(> .compact-record-list) {
+    min-height: 0;
   }
 
   .dashboard-summary,
@@ -2096,12 +2121,20 @@ button:disabled {
   }
 
   .compact-record-list {
-    max-height: 52svh;
-    border-radius: 16px;
+    min-height: 220px;
+    max-height: 44svh;
+    border-radius: 14px;
+  }
+
+  .compact-list-controls {
+    gap: 8px;
+    padding: 10px;
+    border-radius: 14px;
   }
 
   .compact-list-main-controls {
     grid-template-columns: minmax(0, 1fr) max-content;
+    gap: 8px;
   }
 
   .compact-search-field {
@@ -2121,13 +2154,127 @@ button:disabled {
   .invoice-record-row,
   .client-record-row,
   .admin-record-row {
-    grid-template-columns: 1fr;
-    gap: 5px;
+    gap: 3px 8px;
+    align-items: start;
+    line-height: 1.25;
   }
 
   button.compact-record-row {
-    min-height: 0;
-    padding: 12px 14px;
+    min-height: 44px;
+    padding: 9px 10px;
+  }
+
+  .gig-record-row {
+    grid-template-columns: 20px minmax(0, 1fr) max-content;
+  }
+
+  .gig-record-row .compact-select-toggle {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+
+  .gig-record-row .compact-primary-cell {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .gig-record-row > span:nth-of-type(1),
+  .gig-record-row > span:nth-of-type(5) {
+    display: none;
+  }
+
+  .gig-record-row > span:nth-of-type(2) {
+    grid-column: 3;
+    grid-row: 1;
+    text-align: right;
+  }
+
+  .gig-record-row > span:nth-of-type(3) {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .gig-record-row > span:nth-of-type(4) {
+    grid-column: 3;
+    grid-row: 2;
+    text-align: right;
+  }
+
+  .invoice-record-row,
+  .client-record-row {
+    grid-template-columns: minmax(0, 1fr) max-content;
+  }
+
+  .invoice-record-row .compact-primary-cell,
+  .client-record-row .compact-primary-cell {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .invoice-record-row > span:nth-of-type(1),
+  .invoice-record-row > span:nth-of-type(3),
+  .client-record-row > span:nth-of-type(1) {
+    display: none;
+  }
+
+  .invoice-record-row > span:nth-of-type(2),
+  .client-record-row > span:nth-of-type(4) {
+    grid-column: 2;
+    grid-row: 1;
+    text-align: right;
+  }
+
+  .invoice-record-row > span:nth-of-type(4),
+  .client-record-row > span:nth-of-type(2) {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .invoice-record-row > span:nth-of-type(5),
+  .client-record-row > span:nth-of-type(3) {
+    grid-column: 2;
+    grid-row: 2;
+    text-align: right;
+  }
+
+  .admin-record-row {
+    grid-template-columns: minmax(0, 1fr) max-content max-content;
+  }
+
+  .admin-record-row .compact-primary-cell {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .admin-record-row > span:nth-of-type(1),
+  .admin-record-row > span:nth-of-type(5) {
+    display: none;
+  }
+
+  .admin-record-row > span:nth-of-type(2) {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .admin-record-row > span:nth-of-type(3) {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .admin-record-row > span:nth-of-type(4) {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .compact-filter-chips {
+    gap: 6px;
+  }
+
+  .compact-filter-chip {
+    min-height: 28px;
+    padding: 4px 8px;
+    font-size: 0.78rem;
   }
 
   .compact-primary-cell span {
@@ -2144,6 +2291,7 @@ button:disabled {
 
   .content-header-top {
     flex-direction: column;
+    gap: 12px;
   }
 
   .header-actions {
@@ -2157,7 +2305,42 @@ button:disabled {
   }
 
   .content-header.panel {
-    padding: 16px;
+    padding: 12px;
+    gap: 12px;
+  }
+
+  .content-header-body {
+    gap: 12px;
+  }
+
+  .content-header-copy {
+    gap: 8px;
+  }
+
+  .content-header-copy .hero-text {
+    display: none;
+  }
+
+  .content-header-copy h2 {
+    font-size: clamp(1.55rem, 8vw, 2.2rem);
+  }
+
+  .dashboard-summary {
+    gap: 8px;
+  }
+
+  .dashboard-card {
+    padding: 12px;
+    border-radius: 16px;
+    gap: 5px;
+  }
+
+  .dashboard-card span:nth-of-type(n + 2) {
+    display: none;
+  }
+
+  .outstanding-card strong {
+    font-size: clamp(1.5rem, 9vw, 2.2rem);
   }
 
   .app-footer {
@@ -2170,16 +2353,16 @@ button:disabled {
   }
 
   .hero-mascot {
-    grid-template-columns: 64px minmax(0, 1fr);
-    gap: 12px;
-    padding: 12px;
-    border-radius: 18px;
+    display: none;
   }
 
-  .hero-mascot img {
-    width: 64px;
-    height: 64px;
-    border-radius: 16px;
+  .charm-bar {
+    gap: 8px;
+  }
+
+  .charm-item {
+    padding: 10px 12px;
+    border-radius: 14px;
   }
 
   .charm-item span:last-child {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -124,17 +124,59 @@
   min-width: fit-content;
 }
 
-.quick-receipt-button {
+.primary-button.quick-receipt-button {
+  width: 52px;
+  min-width: 52px;
+  height: 52px;
   min-height: 52px;
-  padding-inline: 18px;
-  gap: 8px;
+  padding: 0;
+  border: 1px solid var(--surface-border);
+  border-radius: 18px;
+  background: transparent;
+  box-shadow: none;
+  gap: 0;
   white-space: nowrap;
   cursor: pointer;
 }
 
-.quick-receipt-button span {
-  font-size: 1.2rem;
+.primary-button.quick-receipt-button:hover,
+.primary-button.quick-receipt-button:focus-visible {
+  background: transparent;
+  box-shadow: none;
+}
+
+.quick-receipt-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--brand-gradient-soft);
+  color: white;
+  flex: 0 0 38px;
   line-height: 1;
+  box-shadow: var(--surface-shadow-soft);
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.quick-receipt-button:hover .quick-receipt-icon,
+.quick-receipt-button:focus-visible .quick-receipt-icon {
+  transform: translateY(-1px);
+  box-shadow: var(--surface-shadow-soft);
+}
+
+.quick-receipt-icon svg {
+  width: 21px;
+  height: 21px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
 }
 
 .quick-receipt-button input,
@@ -144,6 +186,16 @@
   block-size: 1px;
   opacity: 0;
   pointer-events: none;
+}
+
+.quick-receipt-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .content-header-copy,
@@ -2515,9 +2567,37 @@ button:disabled {
     justify-content: space-between;
   }
 
-  .quick-receipt-button {
-    flex: 1;
+  .primary-button.quick-receipt-button {
+    position: fixed;
+    top: max(10px, env(safe-area-inset-top));
+    left: max(10px, env(safe-area-inset-left));
+    z-index: 70;
+    width: 52px;
+    min-width: 52px;
+    height: 52px;
+    min-height: 52px;
+    flex: 0 0 52px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
     justify-content: center;
+  }
+
+  .primary-button.quick-receipt-button:hover,
+  .primary-button.quick-receipt-button:focus-visible {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .quick-receipt-button .quick-receipt-icon {
+    opacity: 0.62;
+  }
+
+  .quick-receipt-button.mobile-scrolled .quick-receipt-icon,
+  .quick-receipt-button:hover .quick-receipt-icon,
+  .quick-receipt-button:focus-visible .quick-receipt-icon {
+    opacity: 1;
   }
 
   .content-header.panel {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -587,7 +587,7 @@
 }
 
 .expense-statement-body.has-preview {
-  grid-template-columns: minmax(280px, 0.58fr) minmax(620px, 1.42fr);
+  grid-template-columns: 1fr;
   align-items: stretch;
 }
 
@@ -2535,14 +2535,22 @@ button:disabled {
   .content-header-copy {
     grid-column: 1;
     gap: 8px;
+    padding-right: 66px;
   }
 
   .content-header-copy .hero-text {
     display: none;
   }
 
-  .content-header-copy h2 {
-    font-size: clamp(1.55rem, 8vw, 2.2rem);
+  .content-header-copy h1 {
+    max-width: 11ch;
+    font-size: clamp(1.7rem, 7vw, 2.05rem);
+    line-height: 0.98;
+    text-wrap: balance;
+  }
+
+  .content-header-copy .eyebrow {
+    letter-spacing: 0.14em;
   }
 
   .dashboard-summary {
@@ -2643,9 +2651,44 @@ button:disabled {
     max-height: min(100svh - 28px, 860px);
   }
 
+  .invoice-generation-preview-modal {
+    gap: 12px;
+    overflow: auto;
+  }
+
+  .invoice-generation-preview-frame iframe {
+    height: 62svh;
+    min-height: 430px;
+  }
+
   .expense-statement-modal {
     height: min(100svh - 28px, 860px);
     overflow: auto;
+    grid-template-rows: auto auto auto auto auto;
+    gap: 10px;
+  }
+
+  .expense-statement-modal .panel-heading,
+  .expense-statement-footer {
+    gap: 10px;
+  }
+
+  .expense-statement-summary {
+    gap: 8px;
+  }
+
+  .expense-statement-summary article {
+    padding: 9px 10px;
+  }
+
+  .expense-statement-summary span {
+    font-size: 1rem;
+  }
+
+  .expense-statement-options .checkbox-field {
+    min-height: 40px;
+    padding: 8px 10px;
+    border-radius: 14px;
   }
 
   .gig-imports-modal {
@@ -2662,6 +2705,7 @@ button:disabled {
   .expense-statement-body.without-preview {
     grid-template-columns: 1fr;
     overflow: visible;
+    gap: 10px;
   }
 
   .expense-statement-options {
@@ -2669,15 +2713,17 @@ button:disabled {
   }
 
   .expense-statement-gigs {
-    max-height: 38svh;
-  }
-
-  .expense-statement-preview iframe {
-    height: 55svh;
-    min-height: 320px;
+    max-height: 54svh;
   }
 
   .expense-statement-preview {
-    min-height: 0;
+    min-height: 360px;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .expense-statement-preview iframe {
+    height: 48svh;
+    min-height: 360px;
   }
 }

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -496,9 +496,9 @@
 
 .expense-statement-modal {
   display: grid;
-  gap: 18px;
-  width: min(100%, 1120px);
-  height: min(100svh - 48px, 860px);
+  gap: 14px;
+  width: min(100%, 1280px);
+  height: min(100svh - 32px, 920px);
   grid-template-rows: auto auto auto minmax(0, 1fr) auto;
   overflow: hidden;
 }
@@ -510,7 +510,7 @@
 
 .expense-statement-summary {
   display: grid;
-  gap: 12px;
+  gap: 10px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
@@ -518,7 +518,7 @@
 .expense-statement-preview,
 .expense-statement-gig {
   border-radius: 8px;
-  padding: 14px 16px;
+  padding: 12px 14px;
   background: var(--surface-subtle);
   border: 1px solid color-mix(in srgb, var(--surface-border) 84%, transparent);
 }
@@ -526,6 +526,7 @@
 .expense-statement-preview {
   padding: 0;
   overflow: hidden;
+  min-height: 520px;
 }
 
 .expense-statement-preview iframe {
@@ -576,13 +577,17 @@
   gap: 10px;
 }
 
+.expense-statement-options {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .expense-statement-body {
   min-height: 0;
   overflow: hidden;
 }
 
 .expense-statement-body.has-preview {
-  grid-template-columns: minmax(320px, 0.95fr) minmax(420px, 1.05fr);
+  grid-template-columns: minmax(280px, 0.58fr) minmax(620px, 1.42fr);
   align-items: stretch;
 }
 
@@ -2659,6 +2664,10 @@ button:disabled {
     overflow: visible;
   }
 
+  .expense-statement-options {
+    grid-template-columns: 1fr;
+  }
+
   .expense-statement-gigs {
     max-height: 38svh;
   }
@@ -2666,5 +2675,9 @@ button:disabled {
   .expense-statement-preview iframe {
     height: 55svh;
     min-height: 320px;
+  }
+
+  .expense-statement-preview {
+    min-height: 0;
   }
 }

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -187,6 +187,7 @@ function App({ appMetadata }: AppProps) {
     gigExpenseDescription,
     gigForm,
     gigMode,
+    gigQuickFilter,
     gigSearchQuery,
     gigSort,
     gigStatus,
@@ -217,6 +218,7 @@ function App({ appMetadata }: AppProps) {
     setGigExpenseAmount,
     setGigExpenseDescription,
     setGigs,
+    setGigQuickFilter,
     setGigSearchQuery,
     setGigSort,
     setGigStatus,
@@ -282,6 +284,7 @@ function App({ appMetadata }: AppProps) {
     handlePublishInvoiceGoogleDrive,
     handleSendInvoiceEmail,
     invoices,
+    invoiceQuickFilter,
     invoiceSearchQuery,
     invoiceSort,
     invoiceStatus,
@@ -295,6 +298,7 @@ function App({ appMetadata }: AppProps) {
     setInvoices,
     setInvoiceStatus,
     setIsInvoiceLoading,
+    setInvoiceQuickFilter,
     setSelectedInvoiceId,
     setInvoiceSearchQuery,
     setInvoiceSort,
@@ -1414,6 +1418,7 @@ function App({ appMetadata }: AppProps) {
         gigForm={gigForm}
         isEditorOpen={isGigEditorOpen}
         gigMode={gigMode}
+        gigQuickFilter={gigQuickFilter}
         gigSearchQuery={gigSearchQuery}
         gigSort={gigSort}
         gigStatus={gigStatus}
@@ -1438,6 +1443,7 @@ function App({ appMetadata }: AppProps) {
         onDeleteExpenseAttachment={deleteExpenseAttachment}
         onRemoveGigExpense={removeGigExpense}
         onResetForm={startGigCreate}
+        onQuickFilterChange={setGigQuickFilter}
         onSearchQueryChange={setGigSearchQuery}
         onSelectGig={selectGig}
         onSortChange={setGigSort}
@@ -1462,6 +1468,7 @@ function App({ appMetadata }: AppProps) {
         draftInvoiceCount={draftInvoiceCount}
         filteredInvoices={filteredInvoices}
         isEditorOpen={isInvoiceEditorOpen}
+        invoiceQuickFilter={invoiceQuickFilter}
         invoiceSearchQuery={invoiceSearchQuery}
         invoiceSort={invoiceSort}
         invoiceStatus={invoiceStatus}
@@ -1487,6 +1494,7 @@ function App({ appMetadata }: AppProps) {
         onPublishGoogleDrive={handlePublishInvoiceGoogleDriveWithIssuePrompt}
         onReissue={handleInvoiceReissueWithPreview}
         onSendEmail={handleSendInvoiceEmailWithIssuePrompt}
+        onQuickFilterChange={setInvoiceQuickFilter}
         onSearchQueryChange={setInvoiceSearchQuery}
         onSelectInvoice={setSelectedInvoiceId}
         onSortChange={setInvoiceSort}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -15,7 +15,7 @@ import {
   SignInScreen,
   UserSettingsModal,
 } from './AppSections'
-import type { AppNavigationItem, HeaderMetric } from './AppSections'
+import type { AppNavigationItem, DashboardSummary } from './AppSections'
 import {
   buildApiUrl,
   buildReturnUrl,
@@ -30,6 +30,7 @@ import {
   buildInvoiceFilenamePreview,
   invoiceFilenameTokens,
 } from './invoicePreview'
+import { formatCurrency, formatDate } from './formatters'
 import { useAdminWorkspace } from './hooks/useAdminWorkspace'
 import { useClientsWorkspace } from './hooks/useClientsWorkspace'
 import { useGigsWorkspace } from './hooks/useGigsWorkspace'
@@ -219,8 +220,6 @@ function App({ appMetadata }: AppProps) {
     setSelectedGigIds,
     startGigCreate,
     startGigEdit,
-    uninvoicedGigCount,
-    upcomingGigCount,
     updateGigExpenseField,
     updateGigField,
     updateExpenseReimbursement,
@@ -282,7 +281,6 @@ function App({ appMetadata }: AppProps) {
     isInvoiceEditorOpen,
     issuedInvoiceCount,
     isInvoiceLoading,
-    overdueInvoiceCount,
     resetInvoicesWorkspace,
     selectedInvoice,
     setAdjustmentAmount,
@@ -688,7 +686,6 @@ function App({ appMetadata }: AppProps) {
     setMonthlyInvoiceStatus('')
   }, [selectedClient?.id, monthlyInvoiceMonth])
 
-  const outstandingInvoiceCount = issuedInvoiceCount + overdueInvoiceCount
   const sellerProfileMissingLabels = useMemo(() => {
     const labels: Record<string, string> = {
       sellerName: 'seller name',
@@ -744,24 +741,73 @@ function App({ appMetadata }: AppProps) {
     (count, batch) => count + batch.pendingCount + batch.acceptedCount,
     0
   )
-  const headerMetrics: HeaderMetric[] = [
-    {
-      value: upcomingGigCount,
-      label: 'upcoming gigs',
-    },
-    {
-      value: uninvoicedGigCount,
-      label: 'uninvoiced gigs',
-    },
-    {
-      value: outstandingInvoiceCount,
-      label: 'outstanding invoices',
-    },
-    {
-      value: draftInvoiceCount,
-      label: 'draft invoices',
-    },
-  ]
+  const nextDashboardGig = useMemo(() => {
+    const today = new Date().toISOString().slice(0, 10)
+
+    return [...gigs]
+      .filter((gig) => gig.status !== 'Cancelled' && gig.date >= today)
+      .sort((left, right) => {
+        const dateComparison = left.date.localeCompare(right.date)
+        if (dateComparison !== 0) {
+          return dateComparison
+        }
+
+        return left.title.localeCompare(right.title)
+      })[0] ?? null
+  }, [gigs])
+
+  const dashboardInvoiceCandidate = useMemo(() => {
+    const today = new Date().toISOString().slice(0, 10)
+
+    return [...gigs]
+      .filter(
+        (gig) =>
+          !gig.isInvoiced &&
+          gig.status !== 'Cancelled' &&
+          gig.status !== 'Draft' &&
+          gig.date <= today
+      )
+      .sort((left, right) => {
+        const dateComparison = right.date.localeCompare(left.date)
+        if (dateComparison !== 0) {
+          return dateComparison
+        }
+
+        const statusPriority = (gig: Gig) => (gig.status === 'Completed' ? 0 : 1)
+        const statusComparison = statusPriority(left) - statusPriority(right)
+        if (statusComparison !== 0) {
+          return statusComparison
+        }
+
+        return left.title.localeCompare(right.title)
+      })[0] ?? null
+  }, [gigs])
+
+  const dashboardSummary: DashboardSummary = useMemo(() => {
+    const outstandingInvoices = invoices.filter(
+      (invoice) => invoice.status !== 'Paid' && invoice.status !== 'Cancelled'
+    )
+    const toGigSummary = (gig: Gig) => ({
+      title: gig.title,
+      clientName: clientNamesById.get(gig.clientId) ?? 'Unknown client',
+      dateLabel: formatDate(gig.date),
+      venue: gig.venue || 'No venue set',
+    })
+
+    return {
+      outstandingBalanceLabel: formatCurrency(
+        outstandingInvoices.reduce((total, invoice) => total + invoice.total, 0)
+      ),
+      outstandingInvoiceCount: outstandingInvoices.length,
+      nextGig: nextDashboardGig ? toGigSummary(nextDashboardGig) : null,
+      invoiceCandidate: dashboardInvoiceCandidate
+        ? {
+            ...toGigSummary(dashboardInvoiceCandidate),
+            feeLabel: formatCurrency(dashboardInvoiceCandidate.fee),
+          }
+        : null,
+    }
+  }, [clientNamesById, dashboardInvoiceCandidate, invoices, nextDashboardGig])
 
   const signIn = () => {
     const loginUrl = buildApiUrl(
@@ -961,28 +1007,30 @@ function App({ appMetadata }: AppProps) {
     return updatedInvoice
   }
 
-  const handleGenerateInvoice = async () => {
-    if (selectedGigs.length > 0) {
-      const distinctClientIds = new Set(selectedGigs.map((gig) => gig.clientId))
+  const handleGenerateInvoice = async (explicitGig?: Gig) => {
+    const invoiceGigs = explicitGig ? [] : selectedGigs
+
+    if (invoiceGigs.length > 0) {
+      const distinctClientIds = new Set(invoiceGigs.map((gig) => gig.clientId))
       if (distinctClientIds.size > 1) {
         setGigStatus('Selected gigs must all belong to the same client.')
         return
       }
 
-      const alreadyInvoicedGig = selectedGigs.find((gig) => gig.isInvoiced)
+      const alreadyInvoicedGig = invoiceGigs.find((gig) => gig.isInvoiced)
       if (alreadyInvoicedGig) {
         setGigStatus(`"${alreadyInvoicedGig.title}" is already linked to an invoice.`)
         return
       }
 
       setIsInvoiceLoading(true)
-      setGigStatus(`Generating invoice for ${selectedGigs.length} selected gig(s)...`)
+      setGigStatus(`Generating invoice for ${invoiceGigs.length} selected gig(s)...`)
 
       try {
         const response = await fetchWithSession(
           buildApiUrl('/gigs/generate-invoice'),
           jsonRequestInit('POST', {
-            gigIds: selectedGigs.map((gig) => gig.id),
+            gigIds: invoiceGigs.map((gig) => gig.id),
           })
         )
 
@@ -1001,7 +1049,7 @@ function App({ appMetadata }: AppProps) {
 
         const generatedInvoice = (await response.json()) as Invoice
         const nowIso = new Date().toISOString()
-        const selectedIds = new Set(selectedGigs.map((gig) => gig.id))
+        const selectedIds = new Set(invoiceGigs.map((gig) => gig.id))
 
         setInvoices((current) => [
           generatedInvoice,
@@ -1022,7 +1070,7 @@ function App({ appMetadata }: AppProps) {
         )
         setSelectedGigIds([])
         setGigStatus(
-          `Invoice ${generatedInvoice.invoiceNumber} generated from ${selectedGigs.length} selected gig(s).`
+          `Invoice ${generatedInvoice.invoiceNumber} generated from ${invoiceGigs.length} selected gig(s).`
         )
         setInvoiceStatus(
           sellerProfile.isInvoiceReady
@@ -1039,7 +1087,9 @@ function App({ appMetadata }: AppProps) {
       return
     }
 
-    if (!selectedGig) {
+    const invoiceGig = explicitGig ?? selectedGig
+
+    if (!invoiceGig) {
       setGigStatus('Select one or more gigs first.')
       return
     }
@@ -1049,7 +1099,7 @@ function App({ appMetadata }: AppProps) {
 
     try {
       const response = await fetchWithSession(
-        buildApiUrl(`/gigs/${selectedGig.id}/generate-invoice`),
+        buildApiUrl(`/gigs/${invoiceGig.id}/generate-invoice`),
         {
           method: 'POST',
         }
@@ -1061,7 +1111,7 @@ function App({ appMetadata }: AppProps) {
           invoiceId?: string
         }
 
-        const existingInvoiceId = conflict.invoiceId ?? selectedGig.invoiceId
+        const existingInvoiceId = conflict.invoiceId ?? invoiceGig.invoiceId
         if (existingInvoiceId) {
           setSelectedInvoiceId(existingInvoiceId)
           setActiveSection('invoices')
@@ -1084,7 +1134,7 @@ function App({ appMetadata }: AppProps) {
       setSelectedInvoiceId(generatedInvoice.id)
       setGigs((current) =>
         current.map((gig) =>
-          gig.id === selectedGig.id
+          gig.id === invoiceGig.id
             ? {
                 ...gig,
                 invoiceId: generatedInvoice.id,
@@ -1106,6 +1156,29 @@ function App({ appMetadata }: AppProps) {
     } finally {
       setIsInvoiceLoading(false)
     }
+  }
+
+  const openDashboardNextGig = () => {
+    if (!nextDashboardGig) {
+      return
+    }
+
+    setSelectedGigId(nextDashboardGig.id)
+    setSelectedGigIds([])
+    setGigSearchQuery('')
+    setActiveSection('gigs')
+  }
+
+  const generateDashboardInvoice = () => {
+    if (!dashboardInvoiceCandidate) {
+      return
+    }
+
+    setSelectedGigId(dashboardInvoiceCandidate.id)
+    setSelectedGigIds([])
+    setGigSearchQuery('')
+    setActiveSection('gigs')
+    void handleGenerateInvoice(dashboardInvoiceCandidate)
   }
 
   const handleGenerateMonthlyInvoice = async () => {
@@ -1340,7 +1413,7 @@ function App({ appMetadata }: AppProps) {
         onExpenseAmountChange={setGigExpenseAmount}
         onExpenseDescriptionChange={setGigExpenseDescription}
         onGenerateExpenseStatement={openExpenseStatement}
-        onGenerateInvoice={handleGenerateInvoice}
+        onGenerateInvoice={() => void handleGenerateInvoice()}
         onEstimateMileage={estimateGigMileage}
         onDeleteGig={deleteGig}
         onDownloadExpenseAttachment={downloadExpenseAttachment}
@@ -1414,10 +1487,11 @@ function App({ appMetadata }: AppProps) {
       authUser={authUser}
       currentSection={currentSection}
       currentSectionContent={currentSectionContent}
-      headerMetrics={headerMetrics}
+      dashboardSummary={dashboardSummary}
       isAdmin={isAdmin}
       isAdminLoading={isAdminLoading}
       isGigLoading={isGigLoading}
+      isInvoiceLoading={isInvoiceLoading}
       isLoading={isLoading}
       isProfileMenuOpen={isProfileMenuOpen}
       isQuickReceiptSaving={isQuickReceiptSaving}
@@ -1425,7 +1499,9 @@ function App({ appMetadata }: AppProps) {
       isUserSettingsSaving={isUserSettingsSaving}
       navigationItems={navigationItems}
       pendingGigImportCount={pendingGigImportCount}
+      onGenerateDashboardInvoice={generateDashboardInvoice}
       onOpenGigImports={openGigImports}
+      onOpenNextGig={openDashboardNextGig}
       onOpenSellerProfile={openSellerProfile}
       onOpenUserSettings={openUserSettings}
       onProfileMenuToggle={toggleProfileMenu}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -107,6 +107,7 @@ function App({ appMetadata }: AppProps) {
     adminForm,
     adminMode,
     adminSearchQuery,
+    adminSort,
     adminStatus,
     adminUsers,
     closeAdminEditor,
@@ -121,6 +122,7 @@ function App({ appMetadata }: AppProps) {
     selectedAdminUser,
     selectAdminUser,
     setAdminSearchQuery,
+    setAdminSort,
     startAdminCreate,
     startAdminEdit,
     totalAdmins,
@@ -133,6 +135,7 @@ function App({ appMetadata }: AppProps) {
     clientNamesById,
     clientSettingsForm,
     clientSettingsStatus,
+    clientSort,
     clients,
     closeClientEditor,
     closeClientSettings,
@@ -150,6 +153,7 @@ function App({ appMetadata }: AppProps) {
     searchQuery,
     selectedClient,
     selectClient,
+    setClientSort,
     setSearchQuery,
     startCreating,
     startEditing,
@@ -184,6 +188,7 @@ function App({ appMetadata }: AppProps) {
     gigForm,
     gigMode,
     gigSearchQuery,
+    gigSort,
     gigStatus,
     gigs,
     gigsById,
@@ -213,6 +218,7 @@ function App({ appMetadata }: AppProps) {
     setGigExpenseDescription,
     setGigs,
     setGigSearchQuery,
+    setGigSort,
     setGigStatus,
     setIncludeStatementReceiptAppendix,
     setIncludeStatementReceiptAttachments,
@@ -277,6 +283,7 @@ function App({ appMetadata }: AppProps) {
     handleSendInvoiceEmail,
     invoices,
     invoiceSearchQuery,
+    invoiceSort,
     invoiceStatus,
     isInvoiceEditorOpen,
     issuedInvoiceCount,
@@ -290,6 +297,7 @@ function App({ appMetadata }: AppProps) {
     setIsInvoiceLoading,
     setSelectedInvoiceId,
     setInvoiceSearchQuery,
+    setInvoiceSort,
     startInvoiceEdit,
   } = useInvoicesWorkspace({
     clientNamesById,
@@ -1343,6 +1351,7 @@ function App({ appMetadata }: AppProps) {
       <ClientsSection
         filteredClients={filteredClients}
         form={form}
+        clientSort={clientSort}
         canDeleteSelectedClient={clientDeleteEligibility.canDelete}
         clientDeleteHelperText={clientDeleteEligibility.helperText}
         isApiConnected={isApiConnected}
@@ -1361,6 +1370,7 @@ function App({ appMetadata }: AppProps) {
         onResetForm={startCreating}
         onSearchQueryChange={setSearchQuery}
         onSelectClient={selectClient}
+        onSortChange={setClientSort}
         onStartEditing={startEditing}
         onSubmit={handleSubmit}
         onUpdateAddressField={updateAddressField}
@@ -1375,6 +1385,7 @@ function App({ appMetadata }: AppProps) {
         isEditorOpen={isAdminEditorOpen}
         adminMode={adminMode}
         adminSearchQuery={adminSearchQuery}
+        adminSort={adminSort}
         adminStatus={adminStatus}
         adminUsers={adminUsers}
         activeUsersCount={activeUsersCount}
@@ -1385,6 +1396,7 @@ function App({ appMetadata }: AppProps) {
         onResetForm={startAdminCreate}
         onSearchQueryChange={setAdminSearchQuery}
         onSelectUser={selectAdminUser}
+        onSortChange={setAdminSort}
         onStartEditing={startAdminEdit}
         onSubmit={handleAdminSubmit}
         onUpdateField={updateAdminField}
@@ -1403,6 +1415,7 @@ function App({ appMetadata }: AppProps) {
         isEditorOpen={isGigEditorOpen}
         gigMode={gigMode}
         gigSearchQuery={gigSearchQuery}
+        gigSort={gigSort}
         gigStatus={gigStatus}
         gigs={gigs}
         isGigLoading={isGigLoading}
@@ -1427,6 +1440,7 @@ function App({ appMetadata }: AppProps) {
         onResetForm={startGigCreate}
         onSearchQueryChange={setGigSearchQuery}
         onSelectGig={selectGig}
+        onSortChange={setGigSort}
         onToggleGigSelection={handleToggleGigSelection}
         onStartEditing={startGigEdit}
         onSubmit={handleGigSubmit}
@@ -1449,6 +1463,7 @@ function App({ appMetadata }: AppProps) {
         filteredInvoices={filteredInvoices}
         isEditorOpen={isInvoiceEditorOpen}
         invoiceSearchQuery={invoiceSearchQuery}
+        invoiceSort={invoiceSort}
         invoiceStatus={invoiceStatus}
         googleDrivePublishLink={
           invoiceStatus.startsWith('Uploaded ') ? googleDrivePublishLink : null
@@ -1474,6 +1489,7 @@ function App({ appMetadata }: AppProps) {
         onSendEmail={handleSendInvoiceEmailWithIssuePrompt}
         onSearchQueryChange={setInvoiceSearchQuery}
         onSelectInvoice={setSelectedInvoiceId}
+        onSortChange={setInvoiceSort}
         onStartEditing={startInvoiceEdit}
         sellerProfileNotice={sellerProfileNotice}
         selectedInvoice={selectedInvoice}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -14,4 +14,4 @@ export {
   SignInScreen,
   UserSettingsModal,
 } from './components'
-export type { AppNavigationItem, HeaderMetric } from './components'
+export type { AppNavigationItem, DashboardSummary } from './components'

--- a/frontend/glovelly-web/src/components/AdminSection.tsx
+++ b/frontend/glovelly-web/src/components/AdminSection.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useRef } from 'react'
+import type { CSSProperties } from 'react'
 import type { FormEvent } from 'react'
 import { formatDateTime } from '../formatters'
+import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type { AdminSort, AdminSortKey, AdminUser, AdminUserForm } from '../types'
 
 type AdminSectionProps = {
@@ -49,6 +52,11 @@ export function AdminSection({
   selectedAdminUser,
   totalAdmins,
 }: AdminSectionProps) {
+  const editorSlotRef = useRef<HTMLDivElement | null>(null)
+  const { ref: detailPanelRef, blockSize: detailPanelBlockSize } = useMeasuredBlockSize<HTMLDivElement>()
+  const workspaceStyle = detailPanelBlockSize > 0
+    ? ({ '--workspace-detail-height': `${detailPanelBlockSize}px` } as CSSProperties)
+    : undefined
   const adminSortOptions: { value: AdminSortKey; label: string }[] = [
     { value: 'displayName', label: 'User' },
     { value: 'email', label: 'Email' },
@@ -57,6 +65,16 @@ export function AdminSection({
     { value: 'enrolment', label: 'Sign-in' },
     { value: 'lastLogin', label: 'Last login' },
   ]
+
+  useEffect(() => {
+    if (!isEditorOpen || !window.matchMedia('(max-width: 1180px)').matches) {
+      return
+    }
+
+    window.setTimeout(() => {
+      editorSlotRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 80)
+  }, [isEditorOpen])
 
   return (
     <section className="section-layout admin-zone">
@@ -85,7 +103,7 @@ export function AdminSection({
         </div>
       </div>
 
-      <div className="admin-workspace">
+      <div className="admin-workspace" style={workspaceStyle}>
         <div className="panel">
           <div className="panel-heading">
             <div>
@@ -181,7 +199,7 @@ export function AdminSection({
           </div>
         </div>
 
-        <div className="panel">
+        <div ref={detailPanelRef} className="panel">
           <div className="panel-heading">
             <div>
               <p className="section-label">Access Overview</p>
@@ -193,10 +211,11 @@ export function AdminSection({
             </div>
             <div className="actions">
               <button
-                className="ghost-button"
-                onClick={onStartEditing}
+                className={`ghost-button editor-toggle ${isEditorOpen ? 'active' : ''}`}
+                onClick={isEditorOpen ? onCloseEditor : onStartEditing}
                 type="button"
                 disabled={!selectedAdminUser}
+                aria-expanded={isEditorOpen}
               >
                 Edit access
               </button>
@@ -259,7 +278,7 @@ export function AdminSection({
           )}
         </div>
 
-        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+        <div ref={editorSlotRef} className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
           <form
             aria-hidden={!isEditorOpen}
             className="editor-panel panel"

--- a/frontend/glovelly-web/src/components/AdminSection.tsx
+++ b/frontend/glovelly-web/src/components/AdminSection.tsx
@@ -97,50 +97,51 @@ export function AdminSection({
             </button>
           </div>
 
-          <label className="search-field">
-            <span>Search</span>
-            <input
-              type="search"
-              placeholder="Name, email, role..."
-              value={adminSearchQuery}
-              onChange={(event) => onSearchQueryChange(event.target.value)}
-            />
-          </label>
-
-          <div className="compact-list-toolbar" aria-label="Admin user list controls">
-            <label>
-              <span>Sort by</span>
-              <select
-                value={adminSort.key}
-                onChange={(event) =>
-                  onSortChange({ ...adminSort, key: event.target.value as AdminSortKey })
+          <div className="compact-list-controls" aria-label="Admin user list controls">
+            <div className="compact-list-main-controls">
+              <label className="search-field compact-search-field">
+                <span>Search</span>
+                <input
+                  type="search"
+                  placeholder="Name, email, role..."
+                  value={adminSearchQuery}
+                  onChange={(event) => onSearchQueryChange(event.target.value)}
+                />
+              </label>
+              <label>
+                <span>Sort by</span>
+                <select
+                  value={adminSort.key}
+                  onChange={(event) =>
+                    onSortChange({ ...adminSort, key: event.target.value as AdminSortKey })
+                  }
+                >
+                  {adminSortOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                className="compact-sort-direction"
+                type="button"
+                aria-label={
+                  adminSort.direction === 'asc'
+                    ? 'Sort ascending. Click to sort descending.'
+                    : 'Sort descending. Click to sort ascending.'
+                }
+                title={adminSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+                onClick={() =>
+                  onSortChange({
+                    ...adminSort,
+                    direction: adminSort.direction === 'asc' ? 'desc' : 'asc',
+                  })
                 }
               >
-                {adminSortOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button
-              className="compact-sort-direction"
-              type="button"
-              aria-label={
-                adminSort.direction === 'asc'
-                  ? 'Sort ascending. Click to sort descending.'
-                  : 'Sort descending. Click to sort ascending.'
-              }
-              title={adminSort.direction === 'asc' ? 'Ascending' : 'Descending'}
-              onClick={() =>
-                onSortChange({
-                  ...adminSort,
-                  direction: adminSort.direction === 'asc' ? 'desc' : 'asc',
-                })
-              }
-            >
-              {adminSort.direction === 'asc' ? '↑' : '↓'}
-            </button>
+                {adminSort.direction === 'asc' ? '↑' : '↓'}
+              </button>
+            </div>
           </div>
 
           <div className="compact-record-list admin-record-list" aria-label="People with access">

--- a/frontend/glovelly-web/src/components/AdminSection.tsx
+++ b/frontend/glovelly-web/src/components/AdminSection.tsx
@@ -1,12 +1,13 @@
 import type { FormEvent } from 'react'
 import { formatDateTime } from '../formatters'
-import type { AdminUser, AdminUserForm } from '../types'
+import type { AdminSort, AdminSortKey, AdminUser, AdminUserForm } from '../types'
 
 type AdminSectionProps = {
   adminForm: AdminUserForm
   isEditorOpen: boolean
   adminMode: 'create' | 'edit'
   adminSearchQuery: string
+  adminSort: AdminSort
   adminStatus: string
   adminUsers: AdminUser[]
   activeUsersCount: number
@@ -17,6 +18,7 @@ type AdminSectionProps = {
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
   onSelectUser: (userId: string) => void
+  onSortChange: (sort: AdminSort) => void
   onStartEditing: () => void
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
   onUpdateField: (field: keyof AdminUserForm, value: string | boolean) => void
@@ -29,6 +31,7 @@ export function AdminSection({
   isEditorOpen,
   adminMode,
   adminSearchQuery,
+  adminSort,
   adminStatus,
   adminUsers,
   activeUsersCount,
@@ -39,12 +42,22 @@ export function AdminSection({
   onResetForm,
   onSearchQueryChange,
   onSelectUser,
+  onSortChange,
   onStartEditing,
   onSubmit,
   onUpdateField,
   selectedAdminUser,
   totalAdmins,
 }: AdminSectionProps) {
+  const adminSortOptions: { value: AdminSortKey; label: string }[] = [
+    { value: 'displayName', label: 'User' },
+    { value: 'email', label: 'Email' },
+    { value: 'role', label: 'Role' },
+    { value: 'access', label: 'Access' },
+    { value: 'enrolment', label: 'Sign-in' },
+    { value: 'lastLogin', label: 'Last login' },
+  ]
+
   return (
     <section className="section-layout admin-zone">
       <div className="admin-banner panel">
@@ -94,22 +107,67 @@ export function AdminSection({
             />
           </label>
 
-          <div className="client-list">
+          <div className="compact-list-toolbar" aria-label="Admin user list controls">
+            <label>
+              <span>Sort by</span>
+              <select
+                value={adminSort.key}
+                onChange={(event) =>
+                  onSortChange({ ...adminSort, key: event.target.value as AdminSortKey })
+                }
+              >
+                {adminSortOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              className="compact-sort-direction"
+              type="button"
+              aria-label={
+                adminSort.direction === 'asc'
+                  ? 'Sort ascending. Click to sort descending.'
+                  : 'Sort descending. Click to sort ascending.'
+              }
+              title={adminSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+              onClick={() =>
+                onSortChange({
+                  ...adminSort,
+                  direction: adminSort.direction === 'asc' ? 'desc' : 'asc',
+                })
+              }
+            >
+              {adminSort.direction === 'asc' ? '↑' : '↓'}
+            </button>
+          </div>
+
+          <div className="compact-record-list admin-record-list" aria-label="People with access">
+            <div className="compact-record-header admin-record-row">
+              <span>User</span>
+              <span>Email</span>
+              <span>Role</span>
+              <span>Access</span>
+              <span>Sign-in</span>
+              <span>Last login</span>
+            </div>
             {filteredAdminUsers.map((user) => (
               <button
                 key={user.id}
-                className={`client-card ${selectedAdminUser?.id === user.id ? 'selected' : ''}`}
+                className={`compact-record-row admin-record-row ${selectedAdminUser?.id === user.id ? 'selected' : ''}`}
                 onClick={() => onSelectUser(user.id)}
                 type="button"
               >
-                <div>
+                <div className="compact-primary-cell">
                   <strong>{user.displayName || user.email}</strong>
                   <span>{user.email}</span>
                 </div>
-                <small>
-                  {user.role} · {user.isActive ? 'Active' : 'Inactive'} ·{' '}
-                  {user.isEnrolled ? 'Bound' : 'Invited'}
-                </small>
+                <span>{user.email}</span>
+                <span className="compact-status-cell">{user.role}</span>
+                <span>{user.isActive ? 'Active' : 'Inactive'}</span>
+                <span>{user.isEnrolled ? 'Bound' : 'Invited'}</span>
+                <span>{formatDateTime(user.lastLoginUtc)}</span>
               </button>
             ))}
 

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -151,9 +151,15 @@ export function AppShell({
               </div>
 
               <div className="header-actions">
-                <label className="primary-button quick-receipt-button">
-                  <span aria-hidden="true">+</span>
-                  Scan receipt
+                <label className={`primary-button quick-receipt-button ${isReturnToTopVisible ? 'mobile-scrolled' : ''}`}>
+                  <span className="quick-receipt-icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path d="M8.4 6.5 9.7 4h4.6l1.3 2.5H19a3 3 0 0 1 3 3V17a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3V9.5a3 3 0 0 1 3-3h3.4Z" />
+                      <path d="M12 16.5a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z" />
+                      <path d="M18 10h.01" />
+                    </svg>
+                  </span>
+                  <span className="quick-receipt-label">Scan receipt</span>
                   <input
                     type="file"
                     accept="application/pdf,image/jpeg,image/png,image/webp,image/heic,image/heif"

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -16,9 +16,22 @@ export type AppNavigationItem = {
   disabled?: boolean
 }
 
-export type HeaderMetric = {
-  value: number
-  label: string
+export type DashboardGigSummary = {
+  title: string
+  clientName: string
+  dateLabel: string
+  venue: string
+}
+
+export type DashboardInvoiceCandidate = DashboardGigSummary & {
+  feeLabel: string
+}
+
+export type DashboardSummary = {
+  outstandingBalanceLabel: string
+  outstandingInvoiceCount: number
+  nextGig: DashboardGigSummary | null
+  invoiceCandidate: DashboardInvoiceCandidate | null
 }
 
 type AppShellProps = {
@@ -28,10 +41,11 @@ type AppShellProps = {
   children: ReactNode
   currentSection: AppNavigationItem | undefined
   currentSectionContent: ReactNode
-  headerMetrics: HeaderMetric[]
+  dashboardSummary: DashboardSummary
   isAdmin: boolean
   isAdminLoading: boolean
   isGigLoading: boolean
+  isInvoiceLoading: boolean
   isLoading: boolean
   isProfileMenuOpen: boolean
   isQuickReceiptSaving: boolean
@@ -40,7 +54,9 @@ type AppShellProps = {
   navigationItems: AppNavigationItem[]
   pendingGigImportCount: number
   onOpenGigImports: () => void
+  onOpenNextGig: () => void
   onOpenSellerProfile: () => void
+  onGenerateDashboardInvoice: () => void
   onOpenUserSettings: () => void
   onProfileMenuToggle: () => void
   onQuickReceiptFile: (file: File) => void
@@ -59,10 +75,11 @@ export function AppShell({
   children,
   currentSection,
   currentSectionContent,
-  headerMetrics,
+  dashboardSummary,
   isAdmin,
   isAdminLoading,
   isGigLoading,
+  isInvoiceLoading,
   isLoading,
   isProfileMenuOpen,
   isQuickReceiptSaving,
@@ -71,7 +88,9 @@ export function AppShell({
   navigationItems,
   pendingGigImportCount,
   onOpenGigImports,
+  onOpenNextGig,
   onOpenSellerProfile,
+  onGenerateDashboardInvoice,
   onOpenUserSettings,
   onProfileMenuToggle,
   onQuickReceiptFile,
@@ -270,13 +289,62 @@ export function AppShell({
             </nav>
 
             <div className="content-header-aside">
-              <div className="hero-metrics">
-                {headerMetrics.map((metric) => (
-                  <article key={metric.label}>
-                    <span>{metric.value}</span>
-                    <p>{metric.label}</p>
-                  </article>
-                ))}
+              <div className="dashboard-summary" aria-label="Dashboard summary">
+                <article className="dashboard-card outstanding-card">
+                  <p className="section-label">Outstanding balance</p>
+                  <strong>{dashboardSummary.outstandingBalanceLabel}</strong>
+                  <span>
+                    {dashboardSummary.outstandingInvoiceCount === 1
+                      ? '1 invoice needs attention'
+                      : `${dashboardSummary.outstandingInvoiceCount} invoices need attention`}
+                  </span>
+                </article>
+
+                <article className="dashboard-card">
+                  <p className="section-label">Next gig</p>
+                  {dashboardSummary.nextGig ? (
+                    <>
+                      <strong>{dashboardSummary.nextGig.title}</strong>
+                      <span>
+                        {dashboardSummary.nextGig.dateLabel} · {dashboardSummary.nextGig.clientName}
+                      </span>
+                      <span>{dashboardSummary.nextGig.venue}</span>
+                      <button
+                        className="ghost-button compact-action"
+                        onClick={onOpenNextGig}
+                        type="button"
+                      >
+                        Open gig
+                      </button>
+                    </>
+                  ) : (
+                    <span>No upcoming gigs on the books.</span>
+                  )}
+                </article>
+
+                <article className="dashboard-card invoice-action-card">
+                  <p className="section-label">Invoice prompt</p>
+                  {dashboardSummary.invoiceCandidate ? (
+                    <>
+                      <strong>{dashboardSummary.invoiceCandidate.title}</strong>
+                      <span>
+                        {dashboardSummary.invoiceCandidate.dateLabel} ·{' '}
+                        {dashboardSummary.invoiceCandidate.clientName}
+                      </span>
+                      <span>{dashboardSummary.invoiceCandidate.feeLabel}</span>
+                      <button
+                        className="primary-button compact-action"
+                        disabled={isLoading || isInvoiceLoading}
+                        onClick={onGenerateDashboardInvoice}
+                        type="button"
+                      >
+                        Generate invoice
+                      </button>
+                    </>
+                  ) : (
+                    <span>No recent uninvoiced gigs ready for a draft.</span>
+                  )}
+                </article>
               </div>
             </div>
           </div>

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import type { ReactNode, RefObject } from 'react'
 import type {
   AppMetadata,
@@ -101,6 +102,7 @@ export function AppShell({
   sellerProfile,
   themePreference,
 }: AppShellProps) {
+  const [isReturnToTopVisible, setIsReturnToTopVisible] = useState(false)
   const profileDisplayName = authUser?.name?.trim() || authUser?.email || 'User'
   const profileImageUrl = authUser?.profileImageUrl?.trim() || ''
   const profileInitials = profileDisplayName
@@ -109,6 +111,29 @@ export function AppShell({
     .slice(0, 2)
     .map((part) => part[0]?.toUpperCase() ?? '')
     .join('')
+  const returnToTop = () => {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+    })
+  }
+
+  useEffect(() => {
+    const updateReturnToTopVisibility = () => {
+      setIsReturnToTopVisible(window.scrollY >= window.innerHeight / 2)
+    }
+
+    updateReturnToTopVisibility()
+    window.addEventListener('scroll', updateReturnToTopVisibility, { passive: true })
+    window.addEventListener('resize', updateReturnToTopVisibility)
+
+    return () => {
+      window.removeEventListener('scroll', updateReturnToTopVisibility)
+      window.removeEventListener('resize', updateReturnToTopVisibility)
+    }
+  }, [])
 
   return (
     <main className="app-shell">
@@ -372,6 +397,17 @@ export function AppShell({
           {formatBuildMetadata(appMetadata.commitId, appMetadata.buildTimestamp)}
         </p>
       </div>
+
+      <button
+        aria-label="Return to top"
+        aria-hidden={!isReturnToTopVisible}
+        className={`primary-button return-to-top-button ${isReturnToTopVisible ? 'visible' : ''}`}
+        onClick={returnToTop}
+        tabIndex={isReturnToTopVisible ? 0 : -1}
+        type="button"
+      >
+        Return to top
+      </button>
 
       {children}
     </main>

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -122,7 +122,8 @@ export function AppShell({
 
   useEffect(() => {
     const updateReturnToTopVisibility = () => {
-      setIsReturnToTopVisible(window.scrollY >= window.innerHeight / 2)
+      const isPhoneLayout = window.matchMedia('(max-width: 760px)').matches
+      setIsReturnToTopVisible(isPhoneLayout && window.scrollY >= window.innerHeight / 2)
     }
 
     updateReturnToTopVisibility()

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -290,7 +290,7 @@ export function AppShell({
 
             <div className="content-header-aside">
               <div className="dashboard-summary" aria-label="Dashboard summary">
-                <article className="dashboard-card outstanding-card">
+                <article className="dashboard-card outstanding-card" data-testid="dashboard-outstanding-balance">
                   <p className="section-label">Outstanding balance</p>
                   <strong>{dashboardSummary.outstandingBalanceLabel}</strong>
                   <span>
@@ -300,7 +300,7 @@ export function AppShell({
                   </span>
                 </article>
 
-                <article className="dashboard-card">
+                <article className="dashboard-card" data-testid="dashboard-next-gig">
                   <p className="section-label">Next gig</p>
                   {dashboardSummary.nextGig ? (
                     <>
@@ -311,6 +311,7 @@ export function AppShell({
                       <span>{dashboardSummary.nextGig.venue}</span>
                       <button
                         className="ghost-button compact-action"
+                        data-testid="dashboard-open-next-gig-button"
                         onClick={onOpenNextGig}
                         type="button"
                       >
@@ -322,7 +323,7 @@ export function AppShell({
                   )}
                 </article>
 
-                <article className="dashboard-card invoice-action-card">
+                <article className="dashboard-card invoice-action-card" data-testid="dashboard-invoice-prompt">
                   <p className="section-label">Invoice prompt</p>
                   {dashboardSummary.invoiceCandidate ? (
                     <>
@@ -334,6 +335,7 @@ export function AppShell({
                       <span>{dashboardSummary.invoiceCandidate.feeLabel}</span>
                       <button
                         className="primary-button compact-action"
+                        data-testid="dashboard-generate-invoice-button"
                         disabled={isLoading || isInvoiceLoading}
                         onClick={onGenerateDashboardInvoice}
                         type="button"

--- a/frontend/glovelly-web/src/components/ClientsSection.tsx
+++ b/frontend/glovelly-web/src/components/ClientsSection.tsx
@@ -85,51 +85,52 @@ export function ClientsSection({
             </button>
           </div>
 
-          <label className="search-field">
-            <span>Search</span>
-            <input
-              data-testid="client-search-input"
-              type="search"
-              placeholder="Name, email, city..."
-              value={searchQuery}
-              onChange={(event) => onSearchQueryChange(event.target.value)}
-            />
-          </label>
-
-          <div className="compact-list-toolbar" aria-label="Client list controls">
-            <label>
-              <span>Sort by</span>
-              <select
-                value={clientSort.key}
-                onChange={(event) =>
-                  onSortChange({ ...clientSort, key: event.target.value as ClientSortKey })
+          <div className="compact-list-controls" aria-label="Client list controls">
+            <div className="compact-list-main-controls">
+              <label className="search-field compact-search-field">
+                <span>Search</span>
+                <input
+                  data-testid="client-search-input"
+                  type="search"
+                  placeholder="Name, email, city..."
+                  value={searchQuery}
+                  onChange={(event) => onSearchQueryChange(event.target.value)}
+                />
+              </label>
+              <label>
+                <span>Sort by</span>
+                <select
+                  value={clientSort.key}
+                  onChange={(event) =>
+                    onSortChange({ ...clientSort, key: event.target.value as ClientSortKey })
+                  }
+                >
+                  {clientSortOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                className="compact-sort-direction"
+                type="button"
+                aria-label={
+                  clientSort.direction === 'asc'
+                    ? 'Sort ascending. Click to sort descending.'
+                    : 'Sort descending. Click to sort ascending.'
+                }
+                title={clientSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+                onClick={() =>
+                  onSortChange({
+                    ...clientSort,
+                    direction: clientSort.direction === 'asc' ? 'desc' : 'asc',
+                  })
                 }
               >
-                {clientSortOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button
-              className="compact-sort-direction"
-              type="button"
-              aria-label={
-                clientSort.direction === 'asc'
-                  ? 'Sort ascending. Click to sort descending.'
-                  : 'Sort descending. Click to sort ascending.'
-              }
-              title={clientSort.direction === 'asc' ? 'Ascending' : 'Descending'}
-              onClick={() =>
-                onSortChange({
-                  ...clientSort,
-                  direction: clientSort.direction === 'asc' ? 'desc' : 'asc',
-                })
-              }
-            >
-              {clientSort.direction === 'asc' ? '↑' : '↓'}
-            </button>
+                {clientSort.direction === 'asc' ? '↑' : '↓'}
+              </button>
+            </div>
           </div>
 
           <div className="compact-record-list client-record-list" aria-label="Clients">

--- a/frontend/glovelly-web/src/components/ClientsSection.tsx
+++ b/frontend/glovelly-web/src/components/ClientsSection.tsx
@@ -1,9 +1,10 @@
 import type { FormEvent } from 'react'
-import type { Client, ClientForm } from '../types'
+import type { Client, ClientForm, ClientSort, ClientSortKey } from '../types'
 
 type ClientsSectionProps = {
   filteredClients: Client[]
   form: ClientForm
+  clientSort: ClientSort
   canDeleteSelectedClient: boolean
   clientDeleteHelperText: string
   isApiConnected: boolean
@@ -22,6 +23,7 @@ type ClientsSectionProps = {
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
   onSelectClient: (clientId: string) => void
+  onSortChange: (sort: ClientSort) => void
   onStartEditing: () => void
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
   onUpdateAddressField: (field: keyof Client['billingAddress'], value: string) => void
@@ -34,6 +36,7 @@ type ClientsSectionProps = {
 export function ClientsSection({
   filteredClients,
   form,
+  clientSort,
   canDeleteSelectedClient,
   clientDeleteHelperText,
   isApiConnected,
@@ -52,6 +55,7 @@ export function ClientsSection({
   onResetForm,
   onSearchQueryChange,
   onSelectClient,
+  onSortChange,
   onStartEditing,
   onSubmit,
   onUpdateAddressField,
@@ -60,6 +64,13 @@ export function ClientsSection({
   selectedClient,
   status,
 }: ClientsSectionProps) {
+  const clientSortOptions: { value: ClientSortKey; label: string }[] = [
+    { value: 'name', label: 'Client' },
+    { value: 'email', label: 'Email' },
+    { value: 'city', label: 'City' },
+    { value: 'country', label: 'Country' },
+  ]
+
   return (
     <section className="section-layout">
       <div className="workspace">
@@ -85,22 +96,64 @@ export function ClientsSection({
             />
           </label>
 
-          <div className="client-list">
+          <div className="compact-list-toolbar" aria-label="Client list controls">
+            <label>
+              <span>Sort by</span>
+              <select
+                value={clientSort.key}
+                onChange={(event) =>
+                  onSortChange({ ...clientSort, key: event.target.value as ClientSortKey })
+                }
+              >
+                {clientSortOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              className="compact-sort-direction"
+              type="button"
+              aria-label={
+                clientSort.direction === 'asc'
+                  ? 'Sort ascending. Click to sort descending.'
+                  : 'Sort descending. Click to sort ascending.'
+              }
+              title={clientSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+              onClick={() =>
+                onSortChange({
+                  ...clientSort,
+                  direction: clientSort.direction === 'asc' ? 'desc' : 'asc',
+                })
+              }
+            >
+              {clientSort.direction === 'asc' ? '↑' : '↓'}
+            </button>
+          </div>
+
+          <div className="compact-record-list client-record-list" aria-label="Clients">
+            <div className="compact-record-header client-record-row">
+              <span>Client</span>
+              <span>Email</span>
+              <span>City</span>
+              <span>Country</span>
+            </div>
             {filteredClients.map((client) => (
               <button
                 key={client.id}
-                className={`client-card ${selectedClient?.id === client.id ? 'selected' : ''}`}
+                className={`compact-record-row client-record-row ${selectedClient?.id === client.id ? 'selected' : ''}`}
                 data-testid="client-card"
                 onClick={() => onSelectClient(client.id)}
                 type="button"
               >
-                <div>
+                <div className="compact-primary-cell">
                   <strong>{client.name}</strong>
                   <span>{client.email}</span>
                 </div>
-                <small>
-                  {client.billingAddress.city}, {client.billingAddress.country}
-                </small>
+                <span>{client.email}</span>
+                <span>{client.billingAddress.city || 'No city set'}</span>
+                <span>{client.billingAddress.country || 'No country set'}</span>
               </button>
             ))}
 

--- a/frontend/glovelly-web/src/components/ClientsSection.tsx
+++ b/frontend/glovelly-web/src/components/ClientsSection.tsx
@@ -1,4 +1,7 @@
+import { useEffect, useRef } from 'react'
+import type { CSSProperties } from 'react'
 import type { FormEvent } from 'react'
+import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type { Client, ClientForm, ClientSort, ClientSortKey } from '../types'
 
 type ClientsSectionProps = {
@@ -64,6 +67,11 @@ export function ClientsSection({
   selectedClient,
   status,
 }: ClientsSectionProps) {
+  const editorSlotRef = useRef<HTMLDivElement | null>(null)
+  const { ref: detailPanelRef, blockSize: detailPanelBlockSize } = useMeasuredBlockSize<HTMLDivElement>()
+  const workspaceStyle = detailPanelBlockSize > 0
+    ? ({ '--workspace-detail-height': `${detailPanelBlockSize}px` } as CSSProperties)
+    : undefined
   const clientSortOptions: { value: ClientSortKey; label: string }[] = [
     { value: 'name', label: 'Client' },
     { value: 'email', label: 'Email' },
@@ -71,9 +79,19 @@ export function ClientsSection({
     { value: 'country', label: 'Country' },
   ]
 
+  useEffect(() => {
+    if (!isEditorOpen || !window.matchMedia('(max-width: 1180px)').matches) {
+      return
+    }
+
+    window.setTimeout(() => {
+      editorSlotRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 80)
+  }, [isEditorOpen])
+
   return (
     <section className="section-layout">
-      <div className="workspace">
+      <div className="workspace" style={workspaceStyle}>
         <div className="clients-panel panel">
           <div className="panel-heading">
             <div>
@@ -175,7 +193,7 @@ export function ClientsSection({
           </div>
         </div>
 
-        <div className="detail-panel panel">
+        <div ref={detailPanelRef} className="detail-panel panel">
           <div className="panel-heading">
             <div>
               <p className="section-label">Overview</p>
@@ -191,10 +209,11 @@ export function ClientsSection({
                 Settings
               </button>
               <button
-                className="ghost-button"
-                onClick={onStartEditing}
+                className={`ghost-button editor-toggle ${isEditorOpen ? 'active' : ''}`}
+                onClick={isEditorOpen ? onCloseEditor : onStartEditing}
                 type="button"
                 disabled={!selectedClient}
+                aria-expanded={isEditorOpen}
               >
                 Edit
               </button>
@@ -276,7 +295,7 @@ export function ClientsSection({
           )}
         </div>
 
-        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+        <div ref={editorSlotRef} className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
           <form
             aria-hidden={!isEditorOpen}
             className="editor-panel panel"

--- a/frontend/glovelly-web/src/components/ExpenseStatementModal.tsx
+++ b/frontend/glovelly-web/src/components/ExpenseStatementModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { formatCurrency, formatDate } from '../formatters'
 import type {
   Gig,
@@ -44,12 +45,38 @@ export function ExpenseStatementModal({
   status,
   total,
 }: ExpenseStatementModalProps) {
+  const [isPreviewVisible, setIsPreviewVisible] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsPreviewVisible(false)
+    }
+  }, [isOpen])
+
   if (!isOpen) {
     return null
   }
 
   const selectedExpenseIdSet = new Set(expenseIds)
   const selectedExpenseCount = expenseIds.length
+  const shouldShowPreview = isPreviewVisible && Boolean(previewPdfUrl)
+  const previewButtonLabel = shouldShowPreview
+    ? 'Show expenses'
+    : previewPdfUrl
+      ? 'Show preview'
+      : 'Preview PDF'
+
+  const handlePreviewToggle = () => {
+    if (shouldShowPreview) {
+      setIsPreviewVisible(false)
+      return
+    }
+
+    setIsPreviewVisible(true)
+    if (!previewPdfUrl) {
+      onPreview()
+    }
+  }
 
   return (
     <div className="settings-overlay" onClick={onClose} role="presentation">
@@ -107,44 +134,46 @@ export function ExpenseStatementModal({
 
         <div
           className={`expense-statement-body ${
-            previewPdfUrl ? 'has-preview' : 'without-preview'
+            shouldShowPreview ? 'has-preview' : 'without-preview'
           }`}
         >
-          <div className="expense-statement-gigs">
-            {gigs.map((gig) => (
-              <section className="expense-statement-gig" key={gig.id}>
-                <div className="expense-statement-gig-header">
-                  <div>
-                    <strong>{gig.title}</strong>
-                    <span>
-                      {formatDate(gig.date)} · {gig.venue}
-                    </span>
+          {!shouldShowPreview && (
+            <div className="expense-statement-gigs">
+              {gigs.map((gig) => (
+                <section className="expense-statement-gig" key={gig.id}>
+                  <div className="expense-statement-gig-header">
+                    <div>
+                      <strong>{gig.title}</strong>
+                      <span>
+                        {formatDate(gig.date)} · {gig.venue}
+                      </span>
+                    </div>
+                    {gig.isInvoiced && <span className="expense-status-badge">Invoiced</span>}
                   </div>
-                  {gig.isInvoiced && <span className="expense-status-badge">Invoiced</span>}
-                </div>
 
-                {gig.expenses.length > 0 ? (
-                  <div className="expense-statement-expenses">
-                    {gig.expenses
-                      .slice()
-                      .sort((left, right) => left.sortOrder - right.sortOrder)
-                      .map((expense) => (
-                        <ExpenseStatementExpenseRow
-                          expense={expense}
-                          isSelected={selectedExpenseIdSet.has(expense.id)}
-                          key={expense.id}
-                          onToggleExpense={onToggleExpense}
-                        />
-                      ))}
-                  </div>
-                ) : (
-                  <p className="attachment-helper">No expenses recorded for this gig.</p>
-                )}
-              </section>
-            ))}
-          </div>
+                  {gig.expenses.length > 0 ? (
+                    <div className="expense-statement-expenses">
+                      {gig.expenses
+                        .slice()
+                        .sort((left, right) => left.sortOrder - right.sortOrder)
+                        .map((expense) => (
+                          <ExpenseStatementExpenseRow
+                            expense={expense}
+                            isSelected={selectedExpenseIdSet.has(expense.id)}
+                            key={expense.id}
+                            onToggleExpense={onToggleExpense}
+                          />
+                        ))}
+                    </div>
+                  ) : (
+                    <p className="attachment-helper">No expenses recorded for this gig.</p>
+                  )}
+                </section>
+              ))}
+            </div>
+          )}
 
-          {previewPdfUrl && (
+          {shouldShowPreview && previewPdfUrl && (
             <div className="expense-statement-preview">
               <iframe data-testid="expense-statement-preview-frame" src={previewPdfUrl} title="Expense statement PDF preview" />
             </div>
@@ -161,10 +190,11 @@ export function ExpenseStatementModal({
               className="ghost-button"
               data-testid="expense-statement-preview-button"
               disabled={isSaving || selectedExpenseCount === 0}
-              onClick={onPreview}
+              aria-pressed={shouldShowPreview}
+              onClick={handlePreviewToggle}
               type="button"
             >
-              Preview PDF
+              {previewButtonLabel}
             </button>
             <button
               className="primary-button"

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useRef } from 'react'
+import type { CSSProperties } from 'react'
 import type { FormEvent } from 'react'
 import { formatCurrency, formatDate, formatGigStatus } from '../formatters'
+import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type {
   Client,
   Gig,
@@ -128,6 +131,11 @@ export function GigsSection({
   selectedGigIds,
   selectedGigs,
 }: GigsSectionProps) {
+  const editorSlotRef = useRef<HTMLDivElement | null>(null)
+  const { ref: detailPanelRef, blockSize: detailPanelBlockSize } = useMeasuredBlockSize<HTMLDivElement>()
+  const workspaceStyle = detailPanelBlockSize > 0
+    ? ({ '--workspace-detail-height': `${detailPanelBlockSize}px` } as CSSProperties)
+    : undefined
   const selectedGigClientName =
     (selectedGig ? clientNamesById.get(selectedGig.clientId) : null) ?? 'Unknown client'
   const selectedClientId = selectedGigs[0]?.clientId ?? null
@@ -150,9 +158,19 @@ export function GigsSection({
     { value: 'completed', label: 'Completed' },
   ]
 
+  useEffect(() => {
+    if (!isEditorOpen || !window.matchMedia('(max-width: 1180px)').matches) {
+      return
+    }
+
+    window.setTimeout(() => {
+      editorSlotRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 80)
+  }, [isEditorOpen])
+
   return (
     <section className="section-layout">
-      <div className="gig-workspace">
+      <div className="gig-workspace" style={workspaceStyle}>
         <div className="panel">
           <div className="panel-heading">
             <div>
@@ -307,7 +325,7 @@ export function GigsSection({
           </div>
         </div>
 
-        <div className="panel">
+        <div ref={detailPanelRef} className="panel">
           <div className="panel-heading">
             <div>
               <p className="section-label">Gig Overview</p>
@@ -352,11 +370,12 @@ export function GigsSection({
                   : 'Expense statement'}
               </button>
               <button
-                className="ghost-button"
+                className={`ghost-button editor-toggle ${isEditorOpen ? 'active' : ''}`}
                 data-testid="gig-edit-button"
-                onClick={onStartEditing}
+                onClick={isEditorOpen ? onCloseEditor : onStartEditing}
                 type="button"
                 disabled={!selectedGig}
+                aria-expanded={isEditorOpen}
               >
                 Edit gig
               </button>
@@ -478,7 +497,7 @@ export function GigsSection({
           )}
         </div>
 
-        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+        <div ref={editorSlotRef} className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
           <form
             aria-hidden={!isEditorOpen}
             className="editor-panel panel"

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -6,6 +6,7 @@ import type {
   GigExpenseForm,
   GigExpenseReimbursementStatus,
   GigForm,
+  GigQuickFilter,
   GigSort,
   GigSortKey,
   GigStatus,
@@ -22,6 +23,7 @@ type GigsSectionProps = {
   gigForm: GigForm
   isEditorOpen: boolean
   gigMode: 'create' | 'edit'
+  gigQuickFilter: GigQuickFilter
   gigSearchQuery: string
   gigSort: GigSort
   gigStatus: string
@@ -46,6 +48,7 @@ type GigsSectionProps = {
   onDeleteExpenseAttachment: (expense: GigExpenseForm, attachmentId: string) => void
   onRemoveGigExpense: (index: number) => void
   onResetForm: () => void
+  onQuickFilterChange: (filter: GigQuickFilter) => void
   onSearchQueryChange: (value: string) => void
   onSelectGig: (gigId: string) => void
   onSortChange: (sort: GigSort) => void
@@ -83,6 +86,7 @@ export function GigsSection({
   gigForm,
   isEditorOpen,
   gigMode,
+  gigQuickFilter,
   gigSearchQuery,
   gigSort,
   gigStatus,
@@ -107,6 +111,7 @@ export function GigsSection({
   onDeleteExpenseAttachment,
   onRemoveGigExpense,
   onResetForm,
+  onQuickFilterChange,
   onSearchQueryChange,
   onSelectGig,
   onSortChange,
@@ -137,6 +142,13 @@ export function GigsSection({
     { value: 'fee', label: 'Fee' },
     { value: 'status', label: 'Status' },
   ]
+  const gigFilterOptions: { value: GigQuickFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'upcoming', label: 'Upcoming' },
+    { value: 'uninvoiced', label: 'Uninvoiced' },
+    { value: 'drafts', label: 'Drafts' },
+    { value: 'completed', label: 'Completed' },
+  ]
 
   return (
     <section className="section-layout">
@@ -149,53 +161,6 @@ export function GigsSection({
             </div>
             <button className="ghost-button" data-testid="new-gig-button" onClick={onResetForm} type="button">
               New gig
-            </button>
-          </div>
-
-          <label className="search-field">
-            <span>Search</span>
-              <input
-                data-testid="gig-search-input"
-                type="search"
-              placeholder="Client, title, venue..."
-              value={gigSearchQuery}
-              onChange={(event) => onSearchQueryChange(event.target.value)}
-            />
-          </label>
-
-          <div className="compact-list-toolbar" aria-label="Gig list controls">
-            <label>
-              <span>Sort by</span>
-              <select
-                value={gigSort.key}
-                onChange={(event) =>
-                  onSortChange({ ...gigSort, key: event.target.value as GigSortKey })
-                }
-              >
-                {gigSortOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button
-              className="compact-sort-direction"
-              type="button"
-              aria-label={
-                gigSort.direction === 'asc'
-                  ? 'Sort ascending. Click to sort descending.'
-                  : 'Sort descending. Click to sort ascending.'
-              }
-              title={gigSort.direction === 'asc' ? 'Ascending' : 'Descending'}
-              onClick={() =>
-                onSortChange({
-                  ...gigSort,
-                  direction: gigSort.direction === 'asc' ? 'desc' : 'asc',
-                })
-              }
-            >
-              {gigSort.direction === 'asc' ? '↑' : '↓'}
             </button>
           </div>
 
@@ -212,6 +177,66 @@ export function GigsSection({
               <span>{completedGigCount}</span>
               <p>completed</p>
             </article>
+          </div>
+
+          <div className="compact-list-controls" aria-label="Gig list controls">
+            <div className="compact-list-main-controls">
+              <label className="search-field compact-search-field">
+                <span>Search</span>
+                <input
+                  data-testid="gig-search-input"
+                  type="search"
+                  placeholder="Client, title, venue..."
+                  value={gigSearchQuery}
+                  onChange={(event) => onSearchQueryChange(event.target.value)}
+                />
+              </label>
+              <label>
+                <span>Sort by</span>
+                <select
+                  value={gigSort.key}
+                  onChange={(event) =>
+                    onSortChange({ ...gigSort, key: event.target.value as GigSortKey })
+                  }
+                >
+                  {gigSortOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                className="compact-sort-direction"
+                type="button"
+                aria-label={
+                  gigSort.direction === 'asc'
+                    ? 'Sort ascending. Click to sort descending.'
+                    : 'Sort descending. Click to sort ascending.'
+                }
+                title={gigSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+                onClick={() =>
+                  onSortChange({
+                    ...gigSort,
+                    direction: gigSort.direction === 'asc' ? 'desc' : 'asc',
+                  })
+                }
+              >
+                {gigSort.direction === 'asc' ? '↑' : '↓'}
+              </button>
+            </div>
+            <div className="compact-filter-chips" aria-label="Gig filters">
+              {gigFilterOptions.map((option) => (
+                <button
+                  key={option.value}
+                  className={`compact-filter-chip ${gigQuickFilter === option.value ? 'selected' : ''}`}
+                  type="button"
+                  onClick={() => onQuickFilterChange(option.value)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
           </div>
 
           <div className="compact-record-list gig-record-list" aria-label="Gigs">

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -163,7 +163,16 @@ export function GigsSection({
             </article>
           </div>
 
-          <div className="client-list">
+          <div className="compact-record-list gig-record-list" aria-label="Gigs">
+            <div className="compact-record-header gig-record-row">
+              <span title="Select gigs" aria-label="Select gigs" />
+              <span>Gig</span>
+              <span>Client</span>
+              <span>Date</span>
+              <span>Venue</span>
+              <span>Fee</span>
+              <span>Status</span>
+            </div>
             {filteredGigs.map((gig) => {
               const clientName = clientNamesById.get(gig.clientId) ?? 'Unknown client'
               const isDifferentSelectedClient =
@@ -171,43 +180,44 @@ export function GigsSection({
                 selectedClientId !== gig.clientId &&
                 !selectedGigIds.includes(gig.id)
               const isSelectionDisabled = isDifferentSelectedClient
+              const selectionLabel = gig.isInvoiced
+                ? 'Invoiced gig'
+                : isDifferentSelectedClient
+                  ? 'Different client'
+                  : 'Select gig'
 
               return (
                 <button
                   key={gig.id}
-                  className={`client-card ${selectedGig?.id === gig.id ? 'selected' : ''}`}
+                  className={`compact-record-row gig-record-row ${selectedGig?.id === gig.id ? 'selected' : ''}`}
                   data-testid="gig-card"
                   onClick={() => onSelectGig(gig.id)}
                   type="button"
                 >
                   <label
-                    className="gig-select-toggle"
+                    className="compact-select-toggle gig-select-toggle"
                     onClick={(event) => event.stopPropagation()}
+                    title={selectionLabel}
                   >
                     <input
                       type="checkbox"
+                      aria-label={selectionLabel}
                       checked={selectedGigIds.includes(gig.id)}
                       disabled={isSelectionDisabled}
                       onChange={() => onToggleGigSelection(gig.id)}
                     />
-                    <span>
-                      {gig.isInvoiced
-                        ? 'Invoiced'
-                        : isDifferentSelectedClient
-                          ? 'Different client'
-                          : 'Select'}
-                    </span>
                   </label>
-                  <div>
+                  <div className="compact-primary-cell">
                     <strong>{gig.title}</strong>
                     <span>{clientName}</span>
                   </div>
-                  <small className="gig-card-meta">
-                    {formatDate(gig.date)} · {gig.venue}
-                  </small>
-                  <small className="gig-card-meta">
-                    {formatCurrency(gig.fee)} · {formatGigStatus(gig.status)}
-                  </small>
+                  <span>{clientName}</span>
+                  <span>{formatDate(gig.date)}</span>
+                  <span>{gig.venue || 'No venue set'}</span>
+                  <span>{formatCurrency(gig.fee)}</span>
+                  <span className="compact-status-cell">
+                    {formatGigStatus(gig.status)}
+                  </span>
                 </button>
               )
             })}

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -129,6 +129,7 @@ export function GigsSection({
   const hasCrossClientSelection = new Set(selectedGigs.map((gig) => gig.clientId)).size > 1
   const hasInvoicedSelection = selectedGigs.some((gig) => gig.isInvoiced)
   const gigSortOptions: { value: GigSortKey; label: string }[] = [
+    { value: 'priority', label: 'Priority' },
     { value: 'date', label: 'Date' },
     { value: 'title', label: 'Gig' },
     { value: 'client', label: 'Client' },

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -6,6 +6,8 @@ import type {
   GigExpenseForm,
   GigExpenseReimbursementStatus,
   GigForm,
+  GigSort,
+  GigSortKey,
   GigStatus,
   SellerProfile,
 } from '../types'
@@ -21,6 +23,7 @@ type GigsSectionProps = {
   isEditorOpen: boolean
   gigMode: 'create' | 'edit'
   gigSearchQuery: string
+  gigSort: GigSort
   gigStatus: string
   gigs: Gig[]
   isGigLoading: boolean
@@ -45,6 +48,7 @@ type GigsSectionProps = {
   onResetForm: () => void
   onSearchQueryChange: (value: string) => void
   onSelectGig: (gigId: string) => void
+  onSortChange: (sort: GigSort) => void
   onToggleGigSelection: (gigId: string) => void
   onStartEditing: () => void
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
@@ -80,6 +84,7 @@ export function GigsSection({
   isEditorOpen,
   gigMode,
   gigSearchQuery,
+  gigSort,
   gigStatus,
   gigs,
   isGigLoading,
@@ -104,6 +109,7 @@ export function GigsSection({
   onResetForm,
   onSearchQueryChange,
   onSelectGig,
+  onSortChange,
   onToggleGigSelection,
   onStartEditing,
   onSubmit,
@@ -122,6 +128,14 @@ export function GigsSection({
   const selectedClientId = selectedGigs[0]?.clientId ?? null
   const hasCrossClientSelection = new Set(selectedGigs.map((gig) => gig.clientId)).size > 1
   const hasInvoicedSelection = selectedGigs.some((gig) => gig.isInvoiced)
+  const gigSortOptions: { value: GigSortKey; label: string }[] = [
+    { value: 'date', label: 'Date' },
+    { value: 'title', label: 'Gig' },
+    { value: 'client', label: 'Client' },
+    { value: 'venue', label: 'Venue' },
+    { value: 'fee', label: 'Fee' },
+    { value: 'status', label: 'Status' },
+  ]
 
   return (
     <section className="section-layout">
@@ -147,6 +161,42 @@ export function GigsSection({
               onChange={(event) => onSearchQueryChange(event.target.value)}
             />
           </label>
+
+          <div className="compact-list-toolbar" aria-label="Gig list controls">
+            <label>
+              <span>Sort by</span>
+              <select
+                value={gigSort.key}
+                onChange={(event) =>
+                  onSortChange({ ...gigSort, key: event.target.value as GigSortKey })
+                }
+              >
+                {gigSortOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              className="compact-sort-direction"
+              type="button"
+              aria-label={
+                gigSort.direction === 'asc'
+                  ? 'Sort ascending. Click to sort descending.'
+                  : 'Sort descending. Click to sort ascending.'
+              }
+              title={gigSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+              onClick={() =>
+                onSortChange({
+                  ...gigSort,
+                  direction: gigSort.direction === 'asc' ? 'desc' : 'asc',
+                })
+              }
+            >
+              {gigSort.direction === 'asc' ? '↑' : '↓'}
+            </button>
+          </div>
 
           <div className="gig-summary-grid">
             <article>

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -500,7 +500,7 @@ export function GigsSection({
         <div ref={editorSlotRef} className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
           <form
             aria-hidden={!isEditorOpen}
-            className="editor-panel panel"
+            className="editor-panel panel gig-editor-panel"
             data-testid="gig-form"
             onSubmit={onSubmit}
           >

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -320,7 +320,7 @@ export function GigsSection({
                 </article>
                 <article>
                   <p className="detail-label">Status</p>
-                  <strong>{formatGigStatus(selectedGig.status)}</strong>
+                  <strong data-testid="selected-gig-status">{formatGigStatus(selectedGig.status)}</strong>
                 </article>
                 <article>
                   <p className="detail-label">Date</p>
@@ -473,6 +473,7 @@ export function GigsSection({
               <label>
                 <span>Status</span>
                 <select
+                  data-testid="gig-status-select"
                   value={gigForm.status}
                   onChange={(event) =>
                     onUpdateGigField('status', event.target.value as GigStatus)

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -85,6 +85,7 @@ export function InvoicesSection({
     (selectedInvoice ? clientNamesById.get(selectedInvoice.clientId) : null) ??
     'Unknown client'
   const invoiceSortOptions: { value: InvoiceSortKey; label: string }[] = [
+    { value: 'priority', label: 'Priority' },
     { value: 'invoiceDate', label: 'Date' },
     { value: 'dueDate', label: 'Due date' },
     { value: 'invoiceNumber', label: 'Invoice' },

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -4,7 +4,7 @@ import {
   formatDateTime,
   getAllowedInvoiceStatusTransitions,
 } from '../formatters'
-import type { Invoice, InvoiceStatus } from '../types'
+import type { Invoice, InvoiceSort, InvoiceSortKey, InvoiceStatus } from '../types'
 
 type InvoicesSectionProps = {
   adjustmentAmount: string
@@ -15,6 +15,7 @@ type InvoicesSectionProps = {
   googleDrivePublishLink: { href: string; fileName: string | null } | null
   isEditorOpen: boolean
   invoiceSearchQuery: string
+  invoiceSort: InvoiceSort
   invoiceStatus: string
   invoices: Invoice[]
   issuedInvoiceCount: number
@@ -37,6 +38,7 @@ type InvoicesSectionProps = {
   onSendEmail: (invoice: Invoice) => Promise<Invoice | null>
   onSearchQueryChange: (value: string) => void
   onSelectInvoice: (invoiceId: string) => void
+  onSortChange: (sort: InvoiceSort) => void
   onStartEditing: () => void
   sellerProfileNotice: string
   selectedInvoice: Invoice | null
@@ -51,6 +53,7 @@ export function InvoicesSection({
   googleDrivePublishLink,
   isEditorOpen,
   invoiceSearchQuery,
+  invoiceSort,
   invoiceStatus,
   invoices,
   issuedInvoiceCount,
@@ -73,6 +76,7 @@ export function InvoicesSection({
   onSendEmail,
   onSearchQueryChange,
   onSelectInvoice,
+  onSortChange,
   onStartEditing,
   sellerProfileNotice,
   selectedInvoice,
@@ -80,6 +84,14 @@ export function InvoicesSection({
   const selectedInvoiceClientName =
     (selectedInvoice ? clientNamesById.get(selectedInvoice.clientId) : null) ??
     'Unknown client'
+  const invoiceSortOptions: { value: InvoiceSortKey; label: string }[] = [
+    { value: 'invoiceDate', label: 'Date' },
+    { value: 'dueDate', label: 'Due date' },
+    { value: 'invoiceNumber', label: 'Invoice' },
+    { value: 'client', label: 'Client' },
+    { value: 'status', label: 'Status' },
+    { value: 'total', label: 'Total' },
+  ]
 
   return (
     <section className="section-layout">
@@ -119,6 +131,42 @@ export function InvoicesSection({
               onChange={(event) => onSearchQueryChange(event.target.value)}
             />
           </label>
+
+          <div className="compact-list-toolbar" aria-label="Invoice list controls">
+            <label>
+              <span>Sort by</span>
+              <select
+                value={invoiceSort.key}
+                onChange={(event) =>
+                  onSortChange({ ...invoiceSort, key: event.target.value as InvoiceSortKey })
+                }
+              >
+                {invoiceSortOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              className="compact-sort-direction"
+              type="button"
+              aria-label={
+                invoiceSort.direction === 'asc'
+                  ? 'Sort ascending. Click to sort descending.'
+                  : 'Sort descending. Click to sort ascending.'
+              }
+              title={invoiceSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+              onClick={() =>
+                onSortChange({
+                  ...invoiceSort,
+                  direction: invoiceSort.direction === 'asc' ? 'desc' : 'asc',
+                })
+              }
+            >
+              {invoiceSort.direction === 'asc' ? '↑' : '↓'}
+            </button>
+          </div>
 
           <div className="gig-summary-grid">
             <article>

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -135,26 +135,37 @@ export function InvoicesSection({
             </article>
           </div>
 
-          <div className="client-list">
+          <div className="compact-record-list invoice-record-list" aria-label="Invoices">
+            <div className="compact-record-header invoice-record-row">
+              <span>Invoice</span>
+              <span>Client</span>
+              <span>Date</span>
+              <span>Due</span>
+              <span>Status</span>
+              <span>Total</span>
+            </div>
             {filteredInvoices.map((invoice) => {
               const clientName = clientNamesById.get(invoice.clientId) ?? 'Unknown client'
 
               return (
                 <button
                   key={invoice.id}
-                  className={`client-card ${selectedInvoice?.id === invoice.id ? 'selected' : ''}`}
+                  className={`compact-record-row invoice-record-row ${selectedInvoice?.id === invoice.id ? 'selected' : ''}`}
                   data-testid="invoice-card"
                   onClick={() => onSelectInvoice(invoice.id)}
                   type="button"
                 >
-                  <div>
+                  <div className="compact-primary-cell">
                     <strong>{invoice.invoiceNumber}</strong>
                     <span>{clientName}</span>
                   </div>
-                  <small className="gig-card-meta">
-                    {formatDate(invoice.invoiceDate)} · {invoice.status}
-                  </small>
-                  <small className="gig-card-meta">{formatCurrency(invoice.total)}</small>
+                  <span>{clientName}</span>
+                  <span>{formatDate(invoice.invoiceDate)}</span>
+                  <span>{formatDate(invoice.dueDate)}</span>
+                  <span className="compact-status-cell">{invoice.status}</span>
+                  <span className="compact-money-cell">
+                    {formatCurrency(invoice.total)}
+                  </span>
                 </button>
               )
             })}

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -4,7 +4,13 @@ import {
   formatDateTime,
   getAllowedInvoiceStatusTransitions,
 } from '../formatters'
-import type { Invoice, InvoiceSort, InvoiceSortKey, InvoiceStatus } from '../types'
+import type {
+  Invoice,
+  InvoiceQuickFilter,
+  InvoiceSort,
+  InvoiceSortKey,
+  InvoiceStatus,
+} from '../types'
 
 type InvoicesSectionProps = {
   adjustmentAmount: string
@@ -14,6 +20,7 @@ type InvoicesSectionProps = {
   filteredInvoices: Invoice[]
   googleDrivePublishLink: { href: string; fileName: string | null } | null
   isEditorOpen: boolean
+  invoiceQuickFilter: InvoiceQuickFilter
   invoiceSearchQuery: string
   invoiceSort: InvoiceSort
   invoiceStatus: string
@@ -36,6 +43,7 @@ type InvoicesSectionProps = {
   onPublishGoogleDrive: (invoice: Invoice) => Promise<Invoice | null>
   onReissue: (invoice: Invoice) => Promise<Invoice | null>
   onSendEmail: (invoice: Invoice) => Promise<Invoice | null>
+  onQuickFilterChange: (filter: InvoiceQuickFilter) => void
   onSearchQueryChange: (value: string) => void
   onSelectInvoice: (invoiceId: string) => void
   onSortChange: (sort: InvoiceSort) => void
@@ -52,6 +60,7 @@ export function InvoicesSection({
   filteredInvoices,
   googleDrivePublishLink,
   isEditorOpen,
+  invoiceQuickFilter,
   invoiceSearchQuery,
   invoiceSort,
   invoiceStatus,
@@ -74,6 +83,7 @@ export function InvoicesSection({
   onPublishGoogleDrive,
   onReissue,
   onSendEmail,
+  onQuickFilterChange,
   onSearchQueryChange,
   onSelectInvoice,
   onSortChange,
@@ -92,6 +102,13 @@ export function InvoicesSection({
     { value: 'client', label: 'Client' },
     { value: 'status', label: 'Status' },
     { value: 'total', label: 'Total' },
+  ]
+  const invoiceFilterOptions: { value: InvoiceQuickFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'outstanding', label: 'Outstanding' },
+    { value: 'drafts', label: 'Drafts' },
+    { value: 'overdue', label: 'Overdue' },
+    { value: 'paid', label: 'Paid' },
   ]
 
   return (
@@ -122,53 +139,6 @@ export function InvoicesSection({
             </span>
           </div>
 
-          <label className="search-field">
-            <span>Search</span>
-            <input
-              data-testid="invoice-search-input"
-              type="search"
-              placeholder="Invoice number, client or description..."
-              value={invoiceSearchQuery}
-              onChange={(event) => onSearchQueryChange(event.target.value)}
-            />
-          </label>
-
-          <div className="compact-list-toolbar" aria-label="Invoice list controls">
-            <label>
-              <span>Sort by</span>
-              <select
-                value={invoiceSort.key}
-                onChange={(event) =>
-                  onSortChange({ ...invoiceSort, key: event.target.value as InvoiceSortKey })
-                }
-              >
-                {invoiceSortOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button
-              className="compact-sort-direction"
-              type="button"
-              aria-label={
-                invoiceSort.direction === 'asc'
-                  ? 'Sort ascending. Click to sort descending.'
-                  : 'Sort descending. Click to sort ascending.'
-              }
-              title={invoiceSort.direction === 'asc' ? 'Ascending' : 'Descending'}
-              onClick={() =>
-                onSortChange({
-                  ...invoiceSort,
-                  direction: invoiceSort.direction === 'asc' ? 'desc' : 'asc',
-                })
-              }
-            >
-              {invoiceSort.direction === 'asc' ? '↑' : '↓'}
-            </button>
-          </div>
-
           <div className="gig-summary-grid">
             <article>
               <span>{invoices.length}</span>
@@ -182,6 +152,66 @@ export function InvoicesSection({
               <span>{issuedInvoiceCount}</span>
               <p>issued</p>
             </article>
+          </div>
+
+          <div className="compact-list-controls" aria-label="Invoice list controls">
+            <div className="compact-list-main-controls">
+              <label className="search-field compact-search-field">
+                <span>Search</span>
+                <input
+                  data-testid="invoice-search-input"
+                  type="search"
+                  placeholder="Invoice number, client or description..."
+                  value={invoiceSearchQuery}
+                  onChange={(event) => onSearchQueryChange(event.target.value)}
+                />
+              </label>
+              <label>
+                <span>Sort by</span>
+                <select
+                  value={invoiceSort.key}
+                  onChange={(event) =>
+                    onSortChange({ ...invoiceSort, key: event.target.value as InvoiceSortKey })
+                  }
+                >
+                  {invoiceSortOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                className="compact-sort-direction"
+                type="button"
+                aria-label={
+                  invoiceSort.direction === 'asc'
+                    ? 'Sort ascending. Click to sort descending.'
+                    : 'Sort descending. Click to sort ascending.'
+                }
+                title={invoiceSort.direction === 'asc' ? 'Ascending' : 'Descending'}
+                onClick={() =>
+                  onSortChange({
+                    ...invoiceSort,
+                    direction: invoiceSort.direction === 'asc' ? 'desc' : 'asc',
+                  })
+                }
+              >
+                {invoiceSort.direction === 'asc' ? '↑' : '↓'}
+              </button>
+            </div>
+            <div className="compact-filter-chips" aria-label="Invoice filters">
+              {invoiceFilterOptions.map((option) => (
+                <button
+                  key={option.value}
+                  className={`compact-filter-chip ${invoiceQuickFilter === option.value ? 'selected' : ''}`}
+                  type="button"
+                  onClick={() => onQuickFilterChange(option.value)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
           </div>
 
           <div className="compact-record-list invoice-record-list" aria-label="Invoices">

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useRef } from 'react'
+import type { CSSProperties } from 'react'
 import {
   formatCurrency,
   formatDate,
   formatDateTime,
   getAllowedInvoiceStatusTransitions,
 } from '../formatters'
+import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type {
   Invoice,
   InvoiceQuickFilter,
@@ -91,6 +94,11 @@ export function InvoicesSection({
   sellerProfileNotice,
   selectedInvoice,
 }: InvoicesSectionProps) {
+  const editorSlotRef = useRef<HTMLDivElement | null>(null)
+  const { ref: detailPanelRef, blockSize: detailPanelBlockSize } = useMeasuredBlockSize<HTMLDivElement>()
+  const workspaceStyle = detailPanelBlockSize > 0
+    ? ({ '--workspace-detail-height': `${detailPanelBlockSize}px` } as CSSProperties)
+    : undefined
   const selectedInvoiceClientName =
     (selectedInvoice ? clientNamesById.get(selectedInvoice.clientId) : null) ??
     'Unknown client'
@@ -111,9 +119,19 @@ export function InvoicesSection({
     { value: 'paid', label: 'Paid' },
   ]
 
+  useEffect(() => {
+    if (!isEditorOpen || !window.matchMedia('(max-width: 1180px)').matches) {
+      return
+    }
+
+    window.setTimeout(() => {
+      editorSlotRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 80)
+  }, [isEditorOpen])
+
   return (
     <section className="section-layout">
-      <div className="gig-workspace">
+      <div className="gig-workspace" style={workspaceStyle}>
         <div className="panel">
           <div className="panel-heading">
             <div>
@@ -258,7 +276,7 @@ export function InvoicesSection({
           </div>
         </div>
 
-        <div className="panel">
+        <div ref={detailPanelRef} className="panel">
           <div className="panel-heading">
             <div>
               <p className="section-label">Invoice Overview</p>
@@ -266,11 +284,12 @@ export function InvoicesSection({
             </div>
             <div className="actions">
               <button
-                className="ghost-button"
+                className={`ghost-button editor-toggle ${isEditorOpen ? 'active' : ''}`}
                 data-testid="invoice-line-items-button"
-                onClick={onStartEditing}
+                onClick={isEditorOpen ? onCloseEditor : onStartEditing}
                 type="button"
                 disabled={!selectedInvoice}
+                aria-expanded={isEditorOpen}
               >
                 Line items
               </button>
@@ -459,7 +478,7 @@ export function InvoicesSection({
           )}
         </div>
 
-        <div className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
+        <div ref={editorSlotRef} className={`editor-slot ${isEditorOpen ? 'open' : ''}`}>
           <div aria-hidden={!isEditorOpen} className="panel editor-panel">
             <div className="panel-heading">
               <div>

--- a/frontend/glovelly-web/src/components/index.ts
+++ b/frontend/glovelly-web/src/components/index.ts
@@ -1,5 +1,5 @@
 export { AppShell } from './AppShell'
-export type { AppNavigationItem, HeaderMetric } from './AppShell'
+export type { AppNavigationItem, DashboardSummary } from './AppShell'
 export { AdminSection } from './AdminSection'
 export { ClientSettingsModal } from './ClientSettingsModal'
 export { ClientsSection } from './ClientsSection'

--- a/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
@@ -9,7 +9,7 @@ import {
   throwIfSessionExpired,
 } from '../api'
 import { defaultAdminStatus, emptyAdminForm } from '../forms'
-import type { AdminUser, AdminUserForm } from '../types'
+import type { AdminSort, AdminUser, AdminUserForm } from '../types'
 
 type UseAdminWorkspaceOptions = {
   onSessionExpired: (message: string) => void
@@ -37,6 +37,10 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
   const [adminUsers, setAdminUsers] = useState<AdminUser[]>([])
   const [selectedAdminUserId, setSelectedAdminUserId] = useState<string>('')
   const [adminSearchQuery, setAdminSearchQuery] = useState('')
+  const [adminSort, setAdminSort] = useState<AdminSort>({
+    key: 'displayName',
+    direction: 'asc',
+  })
   const [isAdminEditorOpen, setIsAdminEditorOpen] = useState(false)
   const [adminMode, setAdminMode] = useState<'create' | 'edit'>('create')
   const [adminForm, setAdminForm] = useState<AdminUserForm>(emptyAdminForm)
@@ -48,6 +52,7 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
     setAdminUsers([])
     setSelectedAdminUserId('')
     setAdminSearchQuery('')
+    setAdminSort({ key: 'displayName', direction: 'asc' })
     setIsAdminEditorOpen(false)
     setAdminMode('create')
     setAdminForm(emptyAdminForm())
@@ -83,17 +88,52 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
   )
   const filteredAdminUsers = useMemo(() => {
     const query = deferredAdminSearchQuery.trim().toLowerCase()
+    const sortDirection = adminSort.direction === 'asc' ? 1 : -1
+    const compareText = (left: string, right: string) => left.localeCompare(right)
+    const compareBoolean = (left: boolean, right: boolean) => Number(left) - Number(right)
+    const getDisplayName = (user: AdminUser) => user.displayName || user.email
+    const compareByKey = (left: AdminUser, right: AdminUser) => {
+      switch (adminSort.key) {
+        case 'access':
+          return compareBoolean(left.isActive, right.isActive)
+        case 'email':
+          return compareText(left.email, right.email)
+        case 'enrolment':
+          return compareBoolean(left.isEnrolled, right.isEnrolled)
+        case 'lastLogin':
+          return compareText(left.lastLoginUtc ?? '', right.lastLoginUtc ?? '')
+        case 'role':
+          return compareText(left.role, right.role)
+        case 'displayName':
+        default:
+          return compareText(getDisplayName(left), getDisplayName(right))
+      }
+    }
+    const sortedAdminUsers = [...adminUsers].sort((left, right) => {
+      const primaryComparison = compareByKey(left, right)
+      if (primaryComparison !== 0) {
+        return primaryComparison * sortDirection
+      }
+
+      const nameComparison = getDisplayName(left).localeCompare(getDisplayName(right))
+      if (nameComparison !== 0) {
+        return nameComparison
+      }
+
+      return left.id.localeCompare(right.id)
+    })
+
     if (!query) {
-      return adminUsers
+      return sortedAdminUsers
     }
 
-    return adminUsers.filter((user) =>
+    return sortedAdminUsers.filter((user) =>
       [user.email, user.displayName ?? '', user.role, user.googleSubject ?? '']
         .join(' ')
         .toLowerCase()
         .includes(query)
     )
-  }, [adminUsers, deferredAdminSearchQuery])
+  }, [adminSort, adminUsers, deferredAdminSearchQuery])
 
   const selectedAdminUser =
     adminUsersById.get(selectedAdminUserId) ?? filteredAdminUsers[0] ?? null
@@ -339,6 +379,7 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
     adminForm,
     adminMode,
     adminSearchQuery,
+    adminSort,
     adminStatus,
     adminUsers,
     closeAdminEditor,
@@ -353,6 +394,7 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
     selectedAdminUser,
     selectAdminUser,
     setAdminSearchQuery,
+    setAdminSort,
     setSelectedAdminUserId,
     startAdminCreate,
     startAdminEdit,

--- a/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
@@ -209,6 +209,13 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
   }
 
   const closeAdminEditor = () => {
+    if (
+      hasUnsavedAdminEditorChanges() &&
+      !window.confirm('Discard unsaved access changes and close the editor?')
+    ) {
+      return
+    }
+
     setIsAdminEditorOpen(false)
     setAdminMode('create')
     setAdminForm(emptyAdminForm())

--- a/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
@@ -214,6 +214,13 @@ export function useClientsWorkspace({
   }
 
   const closeClientEditor = () => {
+    if (
+      hasUnsavedClientEditorChanges() &&
+      !window.confirm('Discard unsaved client changes and close the editor?')
+    ) {
+      return
+    }
+
     setIsClientEditorOpen(false)
     setMode('create')
     setForm(emptyForm())

--- a/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
@@ -8,7 +8,7 @@ import {
   jsonRequestInit,
 } from '../api'
 import { emptyClientSettingsForm, emptyForm } from '../forms'
-import type { Address, Client, ClientForm, ClientSettingsForm } from '../types'
+import type { Address, Client, ClientForm, ClientSettingsForm, ClientSort } from '../types'
 
 type UseClientsWorkspaceOptions = {
   isApiConnected: boolean
@@ -59,6 +59,7 @@ export function useClientsWorkspace({
   const [clients, setClients] = useState<Client[]>([])
   const [selectedClientId, setSelectedClientId] = useState<string>('')
   const [searchQuery, setSearchQuery] = useState('')
+  const [clientSort, setClientSort] = useState<ClientSort>({ key: 'name', direction: 'asc' })
   const [isClientEditorOpen, setIsClientEditorOpen] = useState(false)
   const [mode, setMode] = useState<'create' | 'edit'>('create')
   const [form, setForm] = useState<ClientForm>(emptyForm)
@@ -81,11 +82,40 @@ export function useClientsWorkspace({
 
   const filteredClients = useMemo(() => {
     const query = deferredSearchQuery.trim().toLowerCase()
+    const sortDirection = clientSort.direction === 'asc' ? 1 : -1
+    const compareText = (left: string, right: string) => left.localeCompare(right)
+    const compareByKey = (left: Client, right: Client) => {
+      switch (clientSort.key) {
+        case 'city':
+          return compareText(left.billingAddress.city, right.billingAddress.city)
+        case 'country':
+          return compareText(left.billingAddress.country, right.billingAddress.country)
+        case 'email':
+          return compareText(left.email, right.email)
+        case 'name':
+        default:
+          return compareText(left.name, right.name)
+      }
+    }
+    const sortedClients = [...clients].sort((left, right) => {
+      const primaryComparison = compareByKey(left, right)
+      if (primaryComparison !== 0) {
+        return primaryComparison * sortDirection
+      }
+
+      const nameComparison = left.name.localeCompare(right.name)
+      if (nameComparison !== 0) {
+        return nameComparison
+      }
+
+      return left.id.localeCompare(right.id)
+    })
+
     if (!query) {
-      return clients
+      return sortedClients
     }
 
-    return clients.filter((client) =>
+    return sortedClients.filter((client) =>
       [
         client.name,
         client.email,
@@ -96,7 +126,7 @@ export function useClientsWorkspace({
         .toLowerCase()
         .includes(query)
     )
-  }, [clients, deferredSearchQuery])
+  }, [clientSort, clients, deferredSearchQuery])
 
   const selectedClient = clientsById.get(selectedClientId) ?? filteredClients[0] ?? null
 
@@ -122,6 +152,7 @@ export function useClientsWorkspace({
     setClients([])
     setSelectedClientId('')
     setSearchQuery('')
+    setClientSort({ key: 'name', direction: 'asc' })
     setIsClientEditorOpen(false)
     setMode('create')
     setForm(emptyForm())
@@ -479,6 +510,7 @@ export function useClientsWorkspace({
     clientNamesById,
     clientSettingsForm,
     clientSettingsStatus,
+    clientSort,
     clients,
     closeClientEditor,
     closeClientSettings,
@@ -497,6 +529,7 @@ export function useClientsWorkspace({
     selectedClient,
     selectClient,
     setSelectedClientId,
+    setClientSort,
     setSearchQuery,
     startCreating,
     startEditing,

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -25,6 +25,7 @@ import type {
   GigExpenseForm,
   GigExpenseReimbursementStatus,
   GigForm,
+  GigQuickFilter,
   GigSort,
   Invoice,
 } from '../types'
@@ -60,6 +61,7 @@ export function useGigsWorkspace({
   const [selectedGigId, setSelectedGigId] = useState<string>('')
   const [selectedGigIds, setSelectedGigIds] = useState<string[]>([])
   const [gigSearchQuery, setGigSearchQuery] = useState('')
+  const [gigQuickFilter, setGigQuickFilter] = useState<GigQuickFilter>('all')
   const [gigSort, setGigSort] = useState<GigSort>({ key: 'priority', direction: 'asc' })
   const [isGigEditorOpen, setIsGigEditorOpen] = useState(false)
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
@@ -153,12 +155,27 @@ export function useGigsWorkspace({
 
       return left.id.localeCompare(right.id)
     })
+    const quickFilteredGigs = sortedGigs.filter((gig) => {
+      switch (gigQuickFilter) {
+        case 'completed':
+          return gig.status === 'Completed'
+        case 'drafts':
+          return gig.status === 'Draft'
+        case 'uninvoiced':
+          return !gig.isInvoiced && gig.status !== 'Cancelled'
+        case 'upcoming':
+          return gig.status !== 'Cancelled' && gig.date >= today
+        case 'all':
+        default:
+          return true
+      }
+    })
 
     if (!query) {
-      return sortedGigs
+      return quickFilteredGigs
     }
 
-    return sortedGigs.filter((gig) => {
+    return quickFilteredGigs.filter((gig) => {
       const clientName = clientNamesById.get(gig.clientId) ?? ''
 
       return [gig.title, gig.venue, gig.date, gig.status, clientName]
@@ -166,7 +183,7 @@ export function useGigsWorkspace({
         .toLowerCase()
         .includes(query)
     })
-  }, [clientNamesById, deferredGigSearchQuery, gigSort, gigs])
+  }, [clientNamesById, deferredGigSearchQuery, gigQuickFilter, gigSort, gigs])
 
   const selectedGig = gigsById.get(selectedGigId) ?? filteredGigs[0] ?? null
 
@@ -250,6 +267,7 @@ export function useGigsWorkspace({
     setSelectedGigId('')
     setSelectedGigIds([])
     setGigSearchQuery('')
+    setGigQuickFilter('all')
     setGigSort({ key: 'priority', direction: 'asc' })
     setIsGigEditorOpen(false)
     setGigMode('create')
@@ -1116,6 +1134,7 @@ export function useGigsWorkspace({
     gigExpenseDescription,
     gigForm,
     gigMode,
+    gigQuickFilter,
     gigSearchQuery,
     gigSort,
     gigStatus,
@@ -1144,6 +1163,7 @@ export function useGigsWorkspace({
     setGigExpenseAmount,
     setGigExpenseDescription,
     setGigs,
+    setGigQuickFilter,
     setGigSearchQuery,
     setGigSort,
     setGigStatus,

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -25,6 +25,7 @@ import type {
   GigExpenseForm,
   GigExpenseReimbursementStatus,
   GigForm,
+  GigSort,
   Invoice,
 } from '../types'
 import { useExpenseStatementWorkspace } from './useExpenseStatementWorkspace'
@@ -59,6 +60,7 @@ export function useGigsWorkspace({
   const [selectedGigId, setSelectedGigId] = useState<string>('')
   const [selectedGigIds, setSelectedGigIds] = useState<string[]>([])
   const [gigSearchQuery, setGigSearchQuery] = useState('')
+  const [gigSort, setGigSort] = useState<GigSort>({ key: 'date', direction: 'desc' })
   const [isGigEditorOpen, setIsGigEditorOpen] = useState(false)
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
   const [gigForm, setGigForm] = useState<GigForm>(emptyGigForm)
@@ -73,13 +75,44 @@ export function useGigsWorkspace({
 
   const filteredGigs = useMemo(() => {
     const query = deferredGigSearchQuery.trim().toLowerCase()
+    const sortDirection = gigSort.direction === 'asc' ? 1 : -1
+    const compareText = (left: string, right: string) => left.localeCompare(right)
+    const compareNumber = (left: number, right: number) => left - right
+    const getClientName = (gig: Gig) => clientNamesById.get(gig.clientId) ?? ''
+    const compareByKey = (left: Gig, right: Gig) => {
+      switch (gigSort.key) {
+        case 'client':
+          return compareText(getClientName(left), getClientName(right))
+        case 'fee':
+          return compareNumber(left.fee, right.fee)
+        case 'status':
+          return compareText(left.status, right.status)
+        case 'title':
+          return compareText(left.title, right.title)
+        case 'venue':
+          return compareText(left.venue, right.venue)
+        case 'date':
+        default:
+          return compareText(left.date, right.date)
+      }
+    }
     const sortedGigs = [...gigs].sort((left, right) => {
-      const dateComparison = right.date.localeCompare(left.date)
+      const primaryComparison = compareByKey(left, right)
+      if (primaryComparison !== 0) {
+        return primaryComparison * sortDirection
+      }
+
+      const dateComparison = left.date.localeCompare(right.date)
       if (dateComparison !== 0) {
         return dateComparison
       }
 
-      return left.title.localeCompare(right.title)
+      const titleComparison = left.title.localeCompare(right.title)
+      if (titleComparison !== 0) {
+        return titleComparison
+      }
+
+      return left.id.localeCompare(right.id)
     })
 
     if (!query) {
@@ -94,7 +127,7 @@ export function useGigsWorkspace({
         .toLowerCase()
         .includes(query)
     })
-  }, [clientNamesById, deferredGigSearchQuery, gigs])
+  }, [clientNamesById, deferredGigSearchQuery, gigSort, gigs])
 
   const selectedGig = gigsById.get(selectedGigId) ?? filteredGigs[0] ?? null
 
@@ -178,6 +211,7 @@ export function useGigsWorkspace({
     setSelectedGigId('')
     setSelectedGigIds([])
     setGigSearchQuery('')
+    setGigSort({ key: 'date', direction: 'desc' })
     setIsGigEditorOpen(false)
     setGigMode('create')
     setGigForm(emptyGigForm())
@@ -1044,6 +1078,7 @@ export function useGigsWorkspace({
     gigForm,
     gigMode,
     gigSearchQuery,
+    gigSort,
     gigStatus,
     gigs,
     gigsById,
@@ -1071,6 +1106,7 @@ export function useGigsWorkspace({
     setGigExpenseDescription,
     setGigs,
     setGigSearchQuery,
+    setGigSort,
     setGigStatus,
     setIncludeStatementReceiptAppendix,
     setIncludeStatementReceiptAttachments,

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -430,6 +430,13 @@ export function useGigsWorkspace({
   }
 
   const closeGigEditor = () => {
+    if (
+      hasUnsavedGigEditorChanges() &&
+      !window.confirm('Discard unsaved gig changes and close the editor?')
+    ) {
+      return
+    }
+
     setIsGigEditorOpen(false)
     setGigMode('create')
     setGigForm(toCreateGigForm(clients))

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -60,7 +60,7 @@ export function useGigsWorkspace({
   const [selectedGigId, setSelectedGigId] = useState<string>('')
   const [selectedGigIds, setSelectedGigIds] = useState<string[]>([])
   const [gigSearchQuery, setGigSearchQuery] = useState('')
-  const [gigSort, setGigSort] = useState<GigSort>({ key: 'date', direction: 'desc' })
+  const [gigSort, setGigSort] = useState<GigSort>({ key: 'priority', direction: 'asc' })
   const [isGigEditorOpen, setIsGigEditorOpen] = useState(false)
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
   const [gigForm, setGigForm] = useState<GigForm>(emptyGigForm)
@@ -75,10 +75,47 @@ export function useGigsWorkspace({
 
   const filteredGigs = useMemo(() => {
     const query = deferredGigSearchQuery.trim().toLowerCase()
+    const today = new Date().toISOString().slice(0, 10)
     const sortDirection = gigSort.direction === 'asc' ? 1 : -1
     const compareText = (left: string, right: string) => left.localeCompare(right)
     const compareNumber = (left: number, right: number) => left - right
     const getClientName = (gig: Gig) => clientNamesById.get(gig.clientId) ?? ''
+    const getPriorityBucket = (gig: Gig) => {
+      if (gig.status === 'Cancelled') {
+        return 5
+      }
+
+      if (gig.status === 'Confirmed' && gig.date >= today) {
+        return 0
+      }
+
+      if (gig.status === 'Completed' && !gig.isInvoiced && gig.date <= today) {
+        return 1
+      }
+
+      if (gig.status === 'Confirmed' && !gig.isInvoiced && gig.date < today) {
+        return 2
+      }
+
+      if (gig.status === 'Draft') {
+        return 3
+      }
+
+      return 4
+    }
+    const comparePriority = (left: Gig, right: Gig) => {
+      const bucketComparison = getPriorityBucket(left) - getPriorityBucket(right)
+      if (bucketComparison !== 0) {
+        return bucketComparison
+      }
+
+      const bucket = getPriorityBucket(left)
+      if (bucket === 0) {
+        return compareText(left.date, right.date)
+      }
+
+      return compareText(right.date, left.date)
+    }
     const compareByKey = (left: Gig, right: Gig) => {
       switch (gigSort.key) {
         case 'client':
@@ -91,6 +128,8 @@ export function useGigsWorkspace({
           return compareText(left.title, right.title)
         case 'venue':
           return compareText(left.venue, right.venue)
+        case 'priority':
+          return comparePriority(left, right)
         case 'date':
         default:
           return compareText(left.date, right.date)
@@ -211,7 +250,7 @@ export function useGigsWorkspace({
     setSelectedGigId('')
     setSelectedGigIds([])
     setGigSearchQuery('')
-    setGigSort({ key: 'date', direction: 'desc' })
+    setGigSort({ key: 'priority', direction: 'asc' })
     setIsGigEditorOpen(false)
     setGigMode('create')
     setGigForm(emptyGigForm())

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -193,6 +193,13 @@ export function useInvoicesWorkspace({
   }
 
   const closeInvoiceEditor = () => {
+    if (
+      (adjustmentAmount.trim().length > 0 || adjustmentReason.trim().length > 0) &&
+      !window.confirm('Discard unsaved invoice adjustment and close line items?')
+    ) {
+      return
+    }
+
     setIsInvoiceEditorOpen(false)
     setAdjustmentAmount('')
     setAdjustmentReason('')

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -9,7 +9,7 @@ import {
 } from '../api'
 import { defaultInvoiceStatus } from '../forms'
 import { formatCurrency, formatDateTime } from '../formatters'
-import type { Invoice, InvoiceStatus } from '../types'
+import type { Invoice, InvoiceSort, InvoiceStatus } from '../types'
 
 type GoogleDrivePublishLink = {
   href: string
@@ -36,6 +36,10 @@ export function useInvoicesWorkspace({
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('')
   const [isInvoiceEditorOpen, setIsInvoiceEditorOpen] = useState(false)
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
+  const [invoiceSort, setInvoiceSort] = useState<InvoiceSort>({
+    key: 'invoiceDate',
+    direction: 'desc',
+  })
   const [invoiceStatus, setInvoiceStatus] = useState(defaultInvoiceStatus)
   const [googleDrivePublishLink, setGoogleDrivePublishLink] =
     useState<GoogleDrivePublishLink | null>(null)
@@ -51,13 +55,44 @@ export function useInvoicesWorkspace({
 
   const filteredInvoices = useMemo(() => {
     const query = deferredInvoiceSearchQuery.trim().toLowerCase()
+    const sortDirection = invoiceSort.direction === 'asc' ? 1 : -1
+    const compareText = (left: string, right: string) => left.localeCompare(right)
+    const compareNumber = (left: number, right: number) => left - right
+    const getClientName = (invoice: Invoice) => clientNamesById.get(invoice.clientId) ?? ''
+    const compareByKey = (left: Invoice, right: Invoice) => {
+      switch (invoiceSort.key) {
+        case 'client':
+          return compareText(getClientName(left), getClientName(right))
+        case 'dueDate':
+          return compareText(left.dueDate, right.dueDate)
+        case 'invoiceNumber':
+          return compareText(left.invoiceNumber, right.invoiceNumber)
+        case 'status':
+          return compareText(left.status, right.status)
+        case 'total':
+          return compareNumber(left.total, right.total)
+        case 'invoiceDate':
+        default:
+          return compareText(left.invoiceDate, right.invoiceDate)
+      }
+    }
     const sortedInvoices = [...invoices].sort((left, right) => {
-      const dateComparison = right.invoiceDate.localeCompare(left.invoiceDate)
+      const primaryComparison = compareByKey(left, right)
+      if (primaryComparison !== 0) {
+        return primaryComparison * sortDirection
+      }
+
+      const dateComparison = left.invoiceDate.localeCompare(right.invoiceDate)
       if (dateComparison !== 0) {
         return dateComparison
       }
 
-      return left.invoiceNumber.localeCompare(right.invoiceNumber)
+      const numberComparison = left.invoiceNumber.localeCompare(right.invoiceNumber)
+      if (numberComparison !== 0) {
+        return numberComparison
+      }
+
+      return left.id.localeCompare(right.id)
     })
 
     if (!query) {
@@ -77,7 +112,7 @@ export function useInvoicesWorkspace({
         .toLowerCase()
         .includes(query)
     })
-  }, [clientNamesById, deferredInvoiceSearchQuery, invoices])
+  }, [clientNamesById, deferredInvoiceSearchQuery, invoiceSort, invoices])
 
   const selectedInvoice =
     invoicesById.get(selectedInvoiceId) ?? filteredInvoices[0] ?? null
@@ -92,6 +127,7 @@ export function useInvoicesWorkspace({
     setSelectedInvoiceId('')
     setIsInvoiceEditorOpen(false)
     setInvoiceSearchQuery('')
+    setInvoiceSort({ key: 'invoiceDate', direction: 'desc' })
     setInvoiceStatus(defaultInvoiceStatus)
     setGoogleDrivePublishLink(null)
     setIsInvoiceLoading(false)
@@ -453,6 +489,7 @@ export function useInvoicesWorkspace({
     handleSendInvoiceEmail,
     invoices,
     invoiceSearchQuery,
+    invoiceSort,
     invoiceStatus,
     isInvoiceEditorOpen,
     issuedInvoiceCount: invoices.filter((invoice) => invoice.status === 'Issued').length,
@@ -467,6 +504,7 @@ export function useInvoicesWorkspace({
     setIsInvoiceLoading,
     setSelectedInvoiceId,
     setInvoiceSearchQuery,
+    setInvoiceSort,
     startInvoiceEdit,
   }
 }

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -37,8 +37,8 @@ export function useInvoicesWorkspace({
   const [isInvoiceEditorOpen, setIsInvoiceEditorOpen] = useState(false)
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
   const [invoiceSort, setInvoiceSort] = useState<InvoiceSort>({
-    key: 'invoiceDate',
-    direction: 'desc',
+    key: 'priority',
+    direction: 'asc',
   })
   const [invoiceStatus, setInvoiceStatus] = useState(defaultInvoiceStatus)
   const [googleDrivePublishLink, setGoogleDrivePublishLink] =
@@ -59,6 +59,35 @@ export function useInvoicesWorkspace({
     const compareText = (left: string, right: string) => left.localeCompare(right)
     const compareNumber = (left: number, right: number) => left - right
     const getClientName = (invoice: Invoice) => clientNamesById.get(invoice.clientId) ?? ''
+    const getPriorityBucket = (invoice: Invoice) => {
+      switch (invoice.status) {
+        case 'Overdue':
+          return 0
+        case 'Issued':
+          return 1
+        case 'Draft':
+          return 2
+        case 'Paid':
+          return 4
+        case 'Cancelled':
+          return 5
+        default:
+          return 3
+      }
+    }
+    const comparePriority = (left: Invoice, right: Invoice) => {
+      const bucketComparison = getPriorityBucket(left) - getPriorityBucket(right)
+      if (bucketComparison !== 0) {
+        return bucketComparison
+      }
+
+      const bucket = getPriorityBucket(left)
+      if (bucket === 0 || bucket === 1) {
+        return compareText(left.dueDate, right.dueDate)
+      }
+
+      return compareText(right.invoiceDate, left.invoiceDate)
+    }
     const compareByKey = (left: Invoice, right: Invoice) => {
       switch (invoiceSort.key) {
         case 'client':
@@ -71,6 +100,8 @@ export function useInvoicesWorkspace({
           return compareText(left.status, right.status)
         case 'total':
           return compareNumber(left.total, right.total)
+        case 'priority':
+          return comparePriority(left, right)
         case 'invoiceDate':
         default:
           return compareText(left.invoiceDate, right.invoiceDate)
@@ -127,7 +158,7 @@ export function useInvoicesWorkspace({
     setSelectedInvoiceId('')
     setIsInvoiceEditorOpen(false)
     setInvoiceSearchQuery('')
-    setInvoiceSort({ key: 'invoiceDate', direction: 'desc' })
+    setInvoiceSort({ key: 'priority', direction: 'asc' })
     setInvoiceStatus(defaultInvoiceStatus)
     setGoogleDrivePublishLink(null)
     setIsInvoiceLoading(false)

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -9,7 +9,7 @@ import {
 } from '../api'
 import { defaultInvoiceStatus } from '../forms'
 import { formatCurrency, formatDateTime } from '../formatters'
-import type { Invoice, InvoiceSort, InvoiceStatus } from '../types'
+import type { Invoice, InvoiceQuickFilter, InvoiceSort, InvoiceStatus } from '../types'
 
 type GoogleDrivePublishLink = {
   href: string
@@ -36,6 +36,8 @@ export function useInvoicesWorkspace({
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string>('')
   const [isInvoiceEditorOpen, setIsInvoiceEditorOpen] = useState(false)
   const [invoiceSearchQuery, setInvoiceSearchQuery] = useState('')
+  const [invoiceQuickFilter, setInvoiceQuickFilter] =
+    useState<InvoiceQuickFilter>('all')
   const [invoiceSort, setInvoiceSort] = useState<InvoiceSort>({
     key: 'priority',
     direction: 'asc',
@@ -125,12 +127,27 @@ export function useInvoicesWorkspace({
 
       return left.id.localeCompare(right.id)
     })
+    const quickFilteredInvoices = sortedInvoices.filter((invoice) => {
+      switch (invoiceQuickFilter) {
+        case 'drafts':
+          return invoice.status === 'Draft'
+        case 'outstanding':
+          return invoice.status !== 'Paid' && invoice.status !== 'Cancelled'
+        case 'overdue':
+          return invoice.status === 'Overdue'
+        case 'paid':
+          return invoice.status === 'Paid'
+        case 'all':
+        default:
+          return true
+      }
+    })
 
     if (!query) {
-      return sortedInvoices
+      return quickFilteredInvoices
     }
 
-    return sortedInvoices.filter((invoice) => {
+    return quickFilteredInvoices.filter((invoice) => {
       const clientName = clientNamesById.get(invoice.clientId) ?? ''
 
       return [
@@ -143,7 +160,7 @@ export function useInvoicesWorkspace({
         .toLowerCase()
         .includes(query)
     })
-  }, [clientNamesById, deferredInvoiceSearchQuery, invoiceSort, invoices])
+  }, [clientNamesById, deferredInvoiceSearchQuery, invoiceQuickFilter, invoiceSort, invoices])
 
   const selectedInvoice =
     invoicesById.get(selectedInvoiceId) ?? filteredInvoices[0] ?? null
@@ -158,6 +175,7 @@ export function useInvoicesWorkspace({
     setSelectedInvoiceId('')
     setIsInvoiceEditorOpen(false)
     setInvoiceSearchQuery('')
+    setInvoiceQuickFilter('all')
     setInvoiceSort({ key: 'priority', direction: 'asc' })
     setInvoiceStatus(defaultInvoiceStatus)
     setGoogleDrivePublishLink(null)
@@ -519,6 +537,7 @@ export function useInvoicesWorkspace({
     handlePublishInvoiceGoogleDrive,
     handleSendInvoiceEmail,
     invoices,
+    invoiceQuickFilter,
     invoiceSearchQuery,
     invoiceSort,
     invoiceStatus,
@@ -533,6 +552,7 @@ export function useInvoicesWorkspace({
     setInvoices,
     setInvoiceStatus,
     setIsInvoiceLoading,
+    setInvoiceQuickFilter,
     setSelectedInvoiceId,
     setInvoiceSearchQuery,
     setInvoiceSort,

--- a/frontend/glovelly-web/src/hooks/useMeasuredBlockSize.ts
+++ b/frontend/glovelly-web/src/hooks/useMeasuredBlockSize.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function useMeasuredBlockSize<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null)
+  const [blockSize, setBlockSize] = useState(0)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) {
+      return
+    }
+
+    const updateBlockSize = () => {
+      setBlockSize(Math.ceil(element.getBoundingClientRect().height))
+    }
+
+    updateBlockSize()
+
+    const observer = new ResizeObserver(updateBlockSize)
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, blockSize }
+}

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -249,6 +249,7 @@ export type GigSort = {
   key: GigSortKey
   direction: SortDirection
 }
+export type GigQuickFilter = 'all' | 'upcoming' | 'uninvoiced' | 'drafts' | 'completed'
 
 export type GigImportDraftConfidence = 'Low' | 'Medium' | 'High'
 export type GigImportDraftStatus = 'Pending' | 'Accepted' | 'Rejected' | 'Committed'
@@ -393,6 +394,7 @@ export type InvoiceSort = {
   key: InvoiceSortKey
   direction: SortDirection
 }
+export type InvoiceQuickFilter = 'all' | 'outstanding' | 'drafts' | 'overdue' | 'paid'
 
 export type GigForm = {
   clientId: string

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -244,7 +244,7 @@ export type Gig = {
   expenses: GigExpense[]
 }
 
-export type GigSortKey = 'date' | 'title' | 'client' | 'venue' | 'fee' | 'status'
+export type GigSortKey = 'priority' | 'date' | 'title' | 'client' | 'venue' | 'fee' | 'status'
 export type GigSort = {
   key: GigSortKey
   direction: SortDirection
@@ -382,6 +382,7 @@ export type Invoice = {
 }
 
 export type InvoiceSortKey =
+  | 'priority'
   | 'invoiceDate'
   | 'dueDate'
   | 'invoiceNumber'

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -25,6 +25,13 @@ export type ClientForm = {
   billingAddress: Address
 }
 
+export type SortDirection = 'asc' | 'desc'
+export type ClientSortKey = 'name' | 'email' | 'city' | 'country'
+export type ClientSort = {
+  key: ClientSortKey
+  direction: SortDirection
+}
+
 export type AuthUser = {
   userId: string
   role: string
@@ -72,6 +79,18 @@ export type AdminUserForm = {
   googleSubject: string
   role: 'Admin' | 'User'
   isActive: boolean
+}
+
+export type AdminSortKey =
+  | 'displayName'
+  | 'email'
+  | 'role'
+  | 'access'
+  | 'enrolment'
+  | 'lastLogin'
+export type AdminSort = {
+  key: AdminSortKey
+  direction: SortDirection
 }
 
 export type UserSettingsForm = {
@@ -225,6 +244,12 @@ export type Gig = {
   expenses: GigExpense[]
 }
 
+export type GigSortKey = 'date' | 'title' | 'client' | 'venue' | 'fee' | 'status'
+export type GigSort = {
+  key: GigSortKey
+  direction: SortDirection
+}
+
 export type GigImportDraftConfidence = 'Low' | 'Medium' | 'High'
 export type GigImportDraftStatus = 'Pending' | 'Accepted' | 'Rejected' | 'Committed'
 export type GigImportBatchStatus = 'Draft' | 'Committed' | 'Abandoned'
@@ -354,6 +379,18 @@ export type Invoice = {
   pdfGeneratedAt: string | null
   total: number
   lines: InvoiceLine[]
+}
+
+export type InvoiceSortKey =
+  | 'invoiceDate'
+  | 'dueDate'
+  | 'invoiceNumber'
+  | 'client'
+  | 'status'
+  | 'total'
+export type InvoiceSort = {
+  key: InvoiceSortKey
+  direction: SortDirection
 }
 
 export type GigForm = {

--- a/tests/Glovelly.Uat.Tests/DashboardSummaryTests.cs
+++ b/tests/Glovelly.Uat.Tests/DashboardSummaryTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public sealed class DashboardSummaryTests : InvoiceUatTestBase
+{
+    [Fact]
+    public Task DashboardHighlightsNextGigOutstandingBalanceAndInvoicePrompt() => RunWithDiagnosticsAsync(
+        nameof(DashboardHighlightsNextGigOutstandingBalanceAndInvoicePrompt),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Dashboard Client";
+            var gigTitle = $"000 {runId} Dashboard Gig";
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(
+                clientName,
+                gigTitle,
+                DateTime.UtcNow.ToString("yyyy-MM-dd"),
+                fee: "187.00",
+                status: "Completed");
+
+            await Assertions.Expect(Page.GetByTestId("dashboard-next-gig").Locator("strong")).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+            await Assertions.Expect(Page.GetByTestId("dashboard-invoice-prompt").Locator("strong")).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+
+            var dashboardNextGigTitle = (await Page.GetByTestId("dashboard-next-gig").Locator("strong").InnerTextAsync()).Trim();
+            var dashboardInvoicePromptTitle = (await Page.GetByTestId("dashboard-invoice-prompt").Locator("strong").InnerTextAsync()).Trim();
+
+            await Page.GetByTestId("dashboard-open-next-gig-button").ClickAsync();
+            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = dashboardNextGigTitle })).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+            await Assertions.Expect(Page.GetByTestId("selected-gig-status")).ToBeVisibleAsync();
+
+            await Page.GetByTestId("dashboard-generate-invoice-button").ClickAsync();
+            await WaitForInvoicePreviewAsync();
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Close" }).ClickAsync();
+
+            var expectedOutstandingBalance = await FormatCurrentOutstandingBalanceAsync();
+            await Assertions.Expect(Page.GetByTestId("dashboard-outstanding-balance")).ToContainTextAsync(
+                expectedOutstandingBalance,
+                new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+            await Assertions.Expect(Page.GetByTestId("dashboard-invoice-prompt")).Not.ToContainTextAsync(
+                dashboardInvoicePromptTitle,
+                new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+
+            await OpenGigAsync(dashboardInvoicePromptTitle);
+            await ExpectContainsAsync(Page.GetByTestId("generate-invoice-button"), "Already invoiced");
+            await Page.GetByTestId("gig-open-linked-invoice-button").WaitForAsync(new LocatorWaitForOptions
+            {
+                State = WaitForSelectorState.Visible,
+                Timeout = 30_000,
+            });
+        });
+
+    private async Task<string> FormatCurrentOutstandingBalanceAsync()
+    {
+        return await Page.EvaluateAsync<string>(
+            """
+            async () => {
+              const response = await fetch('/invoices', { credentials: 'include' });
+              if (!response.ok) {
+                throw new Error(`Unable to load invoices: ${response.status}`);
+              }
+
+              const invoices = await response.json();
+              const total = invoices
+                .filter((invoice) => invoice.status !== 'Paid' && invoice.status !== 'Cancelled')
+                .reduce((sum, invoice) => sum + invoice.total, 0);
+
+              return new Intl.NumberFormat(undefined, {
+                style: 'currency',
+                currency: 'GBP',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              }).format(total);
+            }
+            """);
+    }
+}

--- a/tests/Glovelly.Uat.Tests/InvoiceAggregationWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceAggregationWorkflowTests.cs
@@ -30,7 +30,7 @@ public sealed class InvoiceAggregationWorkflowTests : InvoiceUatTestBase
 
             var otherClientCheckbox = GigCard(otherGigTitle).Locator("input[type=checkbox]");
             await Assertions.Expect(otherClientCheckbox).ToBeDisabledAsync();
-            await Assertions.Expect(GigCard(otherGigTitle)).ToContainTextAsync("Different client");
+            await Assertions.Expect(otherClientCheckbox).ToHaveAttributeAsync("aria-label", "Different client");
 
             await Page.GetByTestId("generate-invoice-button").ClickAsync();
             await WaitForInvoicePreviewAsync();

--- a/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
@@ -47,7 +47,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
             await AssertInvoiceLineCountAsync(adjustmentReason, 1);
 
             await OpenGigAsync(gigTitle);
-            await Page.GetByTestId("gig-edit-button").ClickAsync();
+            await EnsureGigEditorOpenAsync();
             await SetExpenseReimbursementAsync(0, "Reimbursed");
 
             await OpenLinkedInvoiceFromGigAsync();
@@ -58,7 +58,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
             await AssertInvoiceLineTypeCountAsync("PerformanceFee", 1);
 
             await OpenGigAsync(gigTitle);
-            await Page.GetByTestId("gig-edit-button").ClickAsync();
+            await EnsureGigEditorOpenAsync();
             await SetExpenseReimbursementAsync(0, "Unreimbursed");
 
             await OpenLinkedInvoiceFromGigAsync();
@@ -67,7 +67,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
             await AssertInvoiceLineCountAsync(adjustmentReason, 1);
 
             await OpenGigAsync(gigTitle);
-            await Page.GetByTestId("gig-edit-button").ClickAsync();
+            await EnsureGigEditorOpenAsync();
             await Page.GetByTestId("gig-driving-checkbox").UncheckAsync();
             await SaveGigAndAcceptLinkedRedraftAsync();
 
@@ -78,7 +78,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
             await AssertInvoiceLineTypeCountAsync("PerformanceFee", 1);
 
             await OpenGigAsync(gigTitle);
-            await Page.GetByTestId("gig-edit-button").ClickAsync();
+            await EnsureGigEditorOpenAsync();
             await Page.GetByTestId("gig-driving-checkbox").CheckAsync();
             await Assertions.Expect(Page.GetByTestId("gig-travel-miles-input")).ToHaveValueAsync("18");
             await Assertions.Expect(Page.GetByTestId("gig-passenger-count-input")).ToHaveValueAsync("1");
@@ -136,7 +136,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                     DateTime.UtcNow.AddDays(51).ToString("yyyy-MM-dd"),
                     venue: "Bristol Beacon, Bristol");
                 await OpenGigAsync(estimatedGigTitle);
-                await Page.GetByTestId("gig-edit-button").ClickAsync();
+                await EnsureGigEditorOpenAsync();
                 await Page.GetByTestId("gig-driving-checkbox").CheckAsync();
                 await Page.GetByTestId("gig-estimate-mileage-button").ClickAsync();
                 await Assertions.Expect(Page.GetByTestId("gig-travel-miles-input")).Not.ToHaveValueAsync(string.Empty, new LocatorAssertionsToHaveValueOptions
@@ -157,7 +157,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                     DateTime.UtcNow.AddDays(52).ToString("yyyy-MM-dd"),
                     venue: "The Moon");
                 await OpenGigAsync(fallbackGigTitle);
-                await Page.GetByTestId("gig-edit-button").ClickAsync();
+                await EnsureGigEditorOpenAsync();
                 await Page.GetByTestId("gig-driving-checkbox").CheckAsync();
                 await Page.GetByTestId("gig-estimate-mileage-button").ClickAsync();
                 await ExpectGigStatusContainsAnyAsync("unable", "route", "estimate", "address not found");
@@ -176,7 +176,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                     DateTime.UtcNow.AddDays(53).ToString("yyyy-MM-dd"),
                     venue: "Bristol Beacon, Bristol");
                 await OpenGigAsync(originRequiredGigTitle);
-                await Page.GetByTestId("gig-edit-button").ClickAsync();
+                await EnsureGigEditorOpenAsync();
                 await Page.GetByTestId("gig-driving-checkbox").CheckAsync();
                 await Page.GetByTestId("gig-travel-miles-input").FillAsync("12");
                 await Page.GetByTestId("gig-estimate-mileage-button").ClickAsync();

--- a/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
@@ -48,7 +48,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
 
             await OpenGigAsync(gigTitle);
             await EnsureGigEditorOpenAsync();
-            await SetExpenseReimbursementAsync(0, "Reimbursed");
+            await SetExpenseReimbursementAsync(reimbursedExpense, "Reimbursed");
 
             await OpenLinkedInvoiceFromGigAsync();
             await OpenInvoiceLinesAsync();
@@ -59,7 +59,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
 
             await OpenGigAsync(gigTitle);
             await EnsureGigEditorOpenAsync();
-            await SetExpenseReimbursementAsync(0, "Unreimbursed");
+            await SetExpenseReimbursementAsync(reimbursedExpense, "Unreimbursed");
 
             await OpenLinkedInvoiceFromGigAsync();
             await OpenInvoiceLinesAsync();
@@ -229,13 +229,13 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
         Assert.Fail($"Expected gig status to contain one of [{string.Join(", ", expectedFragments)}], but was '{lastStatus}'.");
     }
 
-    private async Task SetExpenseReimbursementAsync(int expenseIndex, string status)
+    private async Task SetExpenseReimbursementAsync(string expenseDescription, string status)
     {
         Page.Dialog += AcceptReimbursementDialogs;
         try
         {
-            await ExpenseRowAt(expenseIndex)
-                .GetByTestId("gig-expense-reimbursement-select")
+            var expenseRow = await ExpenseRowForDescriptionAsync(expenseDescription);
+            await expenseRow.GetByTestId("gig-expense-reimbursement-select")
                 .SelectOptionAsync(new[] { status });
             await ExpectContainsAsync(Page.GetByTestId("gig-status"), "regenerated");
         }
@@ -254,6 +254,29 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                 _ => dialog.DismissAsync(),
             };
         }
+    }
+
+    private async Task<ILocator> ExpenseRowForDescriptionAsync(string expenseDescription)
+    {
+        var rows = Page.GetByTestId("gig-expense-item");
+        await Assertions.Expect(rows.First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions
+        {
+            Timeout = 30_000,
+        });
+
+        var rowCount = await rows.CountAsync();
+        for (var index = 0; index < rowCount; index++)
+        {
+            var row = rows.Nth(index);
+            var descriptionInput = row.Locator("input").First;
+            if (await descriptionInput.InputValueAsync() == expenseDescription)
+            {
+                return row;
+            }
+        }
+
+        Assert.Fail($"Expected to find gig expense row with description '{expenseDescription}'.");
+        throw new InvalidOperationException($"Expected to find gig expense row with description '{expenseDescription}'.");
     }
 
     private async Task SaveGigAndAcceptLinkedRedraftAsync()

--- a/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
@@ -235,8 +235,20 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
         try
         {
             var expenseRow = await ExpenseRowForDescriptionAsync(expenseDescription);
-            await expenseRow.GetByTestId("gig-expense-reimbursement-select")
-                .SelectOptionAsync(new[] { status });
+            var redraftResponse = await Page.RunAndWaitForResponseAsync(
+                async () => await expenseRow.GetByTestId("gig-expense-reimbursement-select")
+                    .SelectOptionAsync(new[] { status }),
+                response =>
+                {
+                    var path = new Uri(response.Url).AbsolutePath;
+
+                    return response.Request.Method == "POST" &&
+                        path.StartsWith("/invoices/", StringComparison.Ordinal) &&
+                        path.EndsWith("/redraft", StringComparison.Ordinal);
+                },
+                new PageRunAndWaitForResponseOptions { Timeout = 30_000 });
+
+            Assert.True(redraftResponse.Ok, $"Expected invoice redraft to succeed, got HTTP {redraftResponse.Status} for {redraftResponse.Url}.");
             await ExpectContainsAsync(Page.GetByTestId("gig-status"), "regenerated");
         }
         finally

--- a/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
@@ -235,20 +235,11 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
         try
         {
             var expenseRow = await ExpenseRowForDescriptionAsync(expenseDescription);
-            var redraftResponse = await Page.RunAndWaitForResponseAsync(
+            var redraftResponse = await RunAndWaitForInvoiceRedraftAsync(
                 async () => await expenseRow.GetByTestId("gig-expense-reimbursement-select")
-                    .SelectOptionAsync(new[] { status }),
-                response =>
-                {
-                    var path = new Uri(response.Url).AbsolutePath;
+                    .SelectOptionAsync(new[] { status }));
 
-                    return response.Request.Method == "POST" &&
-                        path.StartsWith("/invoices/", StringComparison.Ordinal) &&
-                        path.EndsWith("/redraft", StringComparison.Ordinal);
-                },
-                new PageRunAndWaitForResponseOptions { Timeout = 30_000 });
-
-            Assert.True(redraftResponse.Ok, $"Expected invoice redraft to succeed, got HTTP {redraftResponse.Status} for {redraftResponse.Url}.");
+            AssertRedraftSucceeded(redraftResponse);
             await ExpectContainsAsync(Page.GetByTestId("gig-status"), "regenerated");
         }
         finally
@@ -296,7 +287,10 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
         Page.Dialog += AcceptLinkedRedraftDialog;
         try
         {
-            await Page.GetByTestId("gig-save-close-button").ClickAsync();
+            var redraftResponse = await RunAndWaitForInvoiceRedraftAsync(
+                async () => await Page.GetByTestId("gig-save-close-button").ClickAsync());
+
+            AssertRedraftSucceeded(redraftResponse);
             await ExpectContainsAsync(Page.GetByTestId("gig-status"), "regenerated");
         }
         finally
@@ -312,6 +306,24 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                 _ => dialog.DismissAsync(),
             };
         }
+    }
+
+    private Task<IResponse> RunAndWaitForInvoiceRedraftAsync(Func<Task> action) =>
+        Page.RunAndWaitForResponseAsync(
+            action,
+            response =>
+            {
+                var path = new Uri(response.Url).AbsolutePath;
+
+                return response.Request.Method == "POST" &&
+                    path.StartsWith("/invoices/", StringComparison.Ordinal) &&
+                    path.EndsWith("/redraft", StringComparison.Ordinal);
+            },
+            new PageRunAndWaitForResponseOptions { Timeout = 30_000 });
+
+    private static void AssertRedraftSucceeded(IResponse redraftResponse)
+    {
+        Assert.True(redraftResponse.Ok, $"Expected invoice redraft to succeed, got HTTP {redraftResponse.Status} for {redraftResponse.Url}.");
     }
 
     private async Task SaveUserMileageSettingsViaUiAsync(string mileageRate, string passengerMileageRate, string travelOriginPostcode)

--- a/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
@@ -198,6 +198,21 @@ public abstract class InvoiceUatTestBase : UatTestBase
         await GigCard(gigTitle).ClickAsync();
     }
 
+    protected async Task EnsureGigEditorOpenAsync()
+    {
+        var editButton = Page.GetByTestId("gig-edit-button");
+        if (await editButton.GetAttributeAsync("aria-expanded") != "true")
+        {
+            await editButton.ClickAsync();
+        }
+
+        await Page.GetByTestId("gig-form").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = 30_000,
+        });
+    }
+
     protected async Task OpenLinkedInvoiceFromGigAsync()
     {
         await Page.GetByTestId("gig-open-linked-invoice-button").ClickAsync();

--- a/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
@@ -34,6 +34,7 @@ public abstract class InvoiceUatTestBase : UatTestBase
         string gigDate,
         string fee = "125.00",
         string venue = "UAT Invoice Hall",
+        string status = "Confirmed",
         bool wasDriving = false,
         string travelMiles = "0",
         string passengerCount = "0",
@@ -52,6 +53,7 @@ public abstract class InvoiceUatTestBase : UatTestBase
         await Page.GetByTestId("gig-title-input").FillAsync(gigTitle);
         await Page.GetByTestId("gig-venue-input").FillAsync(venue);
         await Page.GetByTestId("gig-fee-input").FillAsync(fee);
+        await Page.GetByTestId("gig-status-select").SelectOptionAsync(status);
 
         if (wasDriving)
         {


### PR DESCRIPTION
## Summary
- Replace top-level metrics with actionable dashboard cards and add dashboard UAT coverage
- Add compact sortable/filterable workspace lists for gigs, invoices, clients, and admin users
- Refine desktop panel sizing so overview panes define workspace height while lists/editors scroll internally
- Expand development seed data for richer UI testing

## Verification
- npm --prefix frontend/glovelly-web run lint
- npm --prefix frontend/glovelly-web run build
- dotnet test glovelly.sln -m:1 --filter FullyQualifiedName~DevelopmentSeedDataTests