### PR TITLE
Add wake gate for scheduled worker tasks

### DIFF
--- a/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
@@ -476,6 +476,63 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
     }
 
     [Fact]
+    public async Task CalendarIntegrationService_InvalidateSyncHashes_ClearsHashesWithoutClearingProviderIdentity()
+    {
+        var calendarClient = new FakeGoogleCalendarApiClient();
+        using var factory = CreateFactory(calendarClient);
+        _ = factory.CreateClient();
+        var connectionId = await SeedCalendarConnectionAsync(factory);
+        var currentGigId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+        var deletedGigId = Guid.Parse("66666666-6666-6666-6666-666666666666");
+
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var dbContext = seedScope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var deletedState = CreateSyncState(
+                deletedGigId,
+                "deleted-hash",
+                "deleted-event-id");
+            deletedState.DeletedAtUtc = DateTimeOffset.UtcNow;
+            dbContext.GoogleCalendarIntegrationSettings.Add(new GoogleCalendarIntegrationSettings
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                GoogleConnectionId = connectionId,
+                IsEnabled = true,
+                GoogleCalendarId = "calendar-id",
+                CalendarName = "Glovelly Gigs",
+                CreatedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            dbContext.GigCalendarSyncStates.Add(CreateSyncState(
+                currentGigId,
+                "current-hash",
+                "current-event-id"));
+            dbContext.GigCalendarSyncStates.Add(deletedState);
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var scope = factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IGoogleCalendarIntegrationService>();
+        await service.InvalidateSyncHashesAsync(TestAuthContext.UserId, TestContext.Current.CancellationToken);
+
+        var assertionDbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var currentState = await assertionDbContext.GigCalendarSyncStates.SingleAsync(
+            state => state.GigId == currentGigId,
+            TestContext.Current.CancellationToken);
+        var assertionDeletedState = await assertionDbContext.GigCalendarSyncStates.SingleAsync(
+            state => state.GigId == deletedGigId,
+            TestContext.Current.CancellationToken);
+        Assert.Null(currentState.LastSyncHash);
+        Assert.Equal("calendar-id", currentState.ProviderCalendarId);
+        Assert.Equal("current-event-id", currentState.ProviderEventId);
+        Assert.Null(assertionDeletedState.LastSyncHash);
+        Assert.Equal("calendar-id", assertionDeletedState.ProviderCalendarId);
+        Assert.Equal("deleted-event-id", assertionDeletedState.ProviderEventId);
+        Assert.NotNull(assertionDeletedState.DeletedAtUtc);
+    }
+
+    [Fact]
     public async Task SyncProcessor_CreatesEventAndStoresSyncState()
     {
         var calendarClient = new FakeGoogleCalendarApiClient();

--- a/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
@@ -328,6 +328,122 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
     }
 
     [Fact]
+    public async Task CalendarSyncWorkQueue_MarksCalendarPropagationTaskStale()
+    {
+        _ = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        var queue = scope.ServiceProvider.GetRequiredService<ICalendarSyncWorkQueue>();
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+
+        await queue.EnqueueGigAsync(
+            TestAuthContext.UserId,
+            Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            CalendarSyncWorkItemReason.GigUpdated,
+            TestContext.Current.CancellationToken);
+
+        var envelope = await stateStore.ReadAsync<GoogleCalendarPropagationTaskState>(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(envelope);
+        Assert.True(envelope.State.HasPendingCalendarChanges);
+        Assert.Equal(CalendarSyncWorkItemReason.GigUpdated.ToString(), envelope.State.LastMarkedStaleReason);
+    }
+
+    [Fact]
+    public async Task CalendarPropagationTask_WhenRecentSuccessfulStateIsNotStale_Skips()
+    {
+        _ = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        var task = scope.ServiceProvider.GetRequiredService<GoogleCalendarPropagationScheduledTask>();
+        var now = DateTimeOffset.UtcNow;
+        await stateStore.WriteAsync(new ScheduledTaskStateEnvelope<GoogleCalendarPropagationTaskState>
+        {
+            TaskName = ScheduledTaskNames.GoogleCalendarPropagation,
+            LastDecisionUtc = now,
+            LastSuccessfulRunUtc = now,
+            State = new GoogleCalendarPropagationTaskState
+            {
+                HasPendingCalendarChanges = false,
+                LastSuccessfulPropagationUtc = now
+            }
+        }, TestContext.Current.CancellationToken);
+
+        var decision = await task.ShouldRunAsync(
+            new ScheduledTaskContext(now),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(decision.ShouldRun);
+    }
+
+    [Fact]
+    public async Task CalendarPropagationTask_WhenStale_RunsAndClearsStaleAfterFullDrain()
+    {
+        var processor = new FakeGoogleCalendarSyncProcessor();
+        using var factory = CreateFactory(processor);
+        _ = factory.CreateClient();
+        using var scope = factory.Services.CreateScope();
+        var signal = scope.ServiceProvider.GetRequiredService<IScheduledTaskSignal>();
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        var task = scope.ServiceProvider.GetRequiredService<GoogleCalendarPropagationScheduledTask>();
+        var now = DateTimeOffset.UtcNow;
+
+        await signal.MarkStaleAsync(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            "GigUpdated",
+            TestContext.Current.CancellationToken);
+
+        var decision = await task.ShouldRunAsync(
+            new ScheduledTaskContext(now),
+            TestContext.Current.CancellationToken);
+        var result = await task.ExecuteAsync(
+            new CalendarSyncDrainOptions(MaxItems: 5),
+            new ScheduledTaskContext(now),
+            TestContext.Current.CancellationToken);
+
+        var envelope = await stateStore.ReadAsync<GoogleCalendarPropagationTaskState>(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            TestContext.Current.CancellationToken);
+        Assert.True(decision.ShouldRun);
+        Assert.True(result.CanConcludeQueueIsFullyDrained);
+        Assert.NotNull(envelope);
+        Assert.False(envelope.State.HasPendingCalendarChanges);
+        Assert.Equal(now, envelope.State.LastSuccessfulPropagationUtc);
+    }
+
+    [Fact]
+    public async Task CalendarPropagationTask_WhenDrainHitsMaxItems_LeavesStale()
+    {
+        var processor = new FakeGoogleCalendarSyncProcessor();
+        using var factory = CreateFactory(processor);
+        _ = factory.CreateClient();
+        await SeedWorkItemAsync(factory, CalendarSyncWorkItemReason.ConnectionChanged);
+        await SeedWorkItemAsync(factory, CalendarSyncWorkItemReason.GigUpdated, Guid.NewGuid());
+        using var scope = factory.Services.CreateScope();
+        var signal = scope.ServiceProvider.GetRequiredService<IScheduledTaskSignal>();
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        var task = scope.ServiceProvider.GetRequiredService<GoogleCalendarPropagationScheduledTask>();
+
+        await signal.MarkStaleAsync(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            "GigUpdated",
+            TestContext.Current.CancellationToken);
+
+        var result = await task.ExecuteAsync(
+            new CalendarSyncDrainOptions(MaxItems: 1),
+            new ScheduledTaskContext(DateTimeOffset.UtcNow),
+            TestContext.Current.CancellationToken);
+
+        var envelope = await stateStore.ReadAsync<GoogleCalendarPropagationTaskState>(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(CalendarSyncDrainCompletionReason.MaxItemsReached, result.CompletionReason);
+        Assert.NotNull(envelope);
+        Assert.True(envelope.State.HasPendingCalendarChanges);
+    }
+
+    [Fact]
     public async Task SyncProcessor_CreatesEventAndStoresSyncState()
     {
         var calendarClient = new FakeGoogleCalendarApiClient();
@@ -592,7 +708,7 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
         var drainer = scope.ServiceProvider.GetRequiredService<ICalendarSyncQueueDrainer>();
         var result = await drainer.DrainAsync(new CalendarSyncDrainOptions(MaxItems: 1), TestContext.Current.CancellationToken);
 
-        Assert.Equal(new CalendarSyncDrainResult(1, 1, 0, 0, 0, 0), result);
+        Assert.Equal(new CalendarSyncDrainResult(1, 1, 0, 0, 0, 0, CalendarSyncDrainCompletionReason.MaxItemsReached), result);
 
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         Assert.Equal(1, await dbContext.CalendarSyncWorkItems.CountAsync(item => item.Status == CalendarSyncWorkItemStatus.Succeeded, TestContext.Current.CancellationToken));

--- a/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
@@ -334,6 +334,14 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
         using var scope = _factory.Services.CreateScope();
         var queue = scope.ServiceProvider.GetRequiredService<ICalendarSyncWorkQueue>();
         var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        await stateStore.WriteAsync(new ScheduledTaskStateEnvelope<GoogleCalendarPropagationTaskState>
+        {
+            TaskName = ScheduledTaskNames.GoogleCalendarPropagation,
+            State = new GoogleCalendarPropagationTaskState
+            {
+                HasPendingCalendarChanges = false
+            }
+        }, TestContext.Current.CancellationToken);
 
         await queue.EnqueueGigAsync(
             TestAuthContext.UserId,
@@ -348,6 +356,30 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
         Assert.NotNull(envelope);
         Assert.True(envelope.State.HasPendingCalendarChanges);
         Assert.Equal(CalendarSyncWorkItemReason.GigUpdated.ToString(), envelope.State.LastMarkedStaleReason);
+    }
+
+    [Fact]
+    public async Task ScheduledTaskSignal_WhenCalendarPropagationIsAlreadyStale_DoesNotRewriteState()
+    {
+        var stateStore = new CountingScheduledTaskStateStore();
+        var signal = new ScheduledTaskSignal(stateStore, TimeProvider.System);
+
+        await signal.MarkStaleAsync(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            "GigUpdated",
+            TestContext.Current.CancellationToken);
+        await signal.MarkStaleAsync(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            "CalendarRecreated",
+            TestContext.Current.CancellationToken);
+
+        var envelope = await stateStore.ReadAsync<GoogleCalendarPropagationTaskState>(
+            ScheduledTaskNames.GoogleCalendarPropagation,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(1, stateStore.WriteCount);
+        Assert.NotNull(envelope);
+        Assert.True(envelope.State.HasPendingCalendarChanges);
+        Assert.Equal("GigUpdated", envelope.State.LastMarkedStaleReason);
     }
 
     [Fact]
@@ -1065,6 +1097,31 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
             {
                 throw ExceptionToThrow;
             }
+        }
+    }
+
+    private sealed class CountingScheduledTaskStateStore : IScheduledTaskStateStore
+    {
+        private object? _envelope;
+
+        public int WriteCount { get; private set; }
+
+        public Task<ScheduledTaskStateEnvelope<TState>?> ReadAsync<TState>(
+            string taskName,
+            CancellationToken cancellationToken = default)
+            where TState : class, new()
+        {
+            return Task.FromResult(_envelope as ScheduledTaskStateEnvelope<TState>);
+        }
+
+        public Task WriteAsync<TState>(
+            ScheduledTaskStateEnvelope<TState> envelope,
+            CancellationToken cancellationToken = default)
+            where TState : class, new()
+        {
+            WriteCount += 1;
+            _envelope = envelope;
+            return Task.CompletedTask;
         }
     }
 }

--- a/backend/Glovelly.Api/Endpoints/GoogleCalendarIntegrationEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GoogleCalendarIntegrationEndpoints.cs
@@ -142,6 +142,7 @@ internal static class GoogleCalendarIntegrationEndpoints
                 tokenResponse.TokenResponse,
                 cancellationToken);
             _ = await calendarIntegrationService.EnsureCalendarAsync(currentUserId.Value, cancellationToken);
+            await calendarIntegrationService.InvalidateSyncHashesAsync(currentUserId.Value, cancellationToken);
             await workQueue.EnqueueFullSyncAsync(
                 currentUserId.Value,
                 CalendarSyncWorkItemReason.ConnectionChanged,

--- a/backend/Glovelly.Api/Services/CalendarSyncDrainResult.cs
+++ b/backend/Glovelly.Api/Services/CalendarSyncDrainResult.cs
@@ -6,4 +6,18 @@ public sealed record CalendarSyncDrainResult(
     int Retried,
     int Failed,
     int Skipped,
-    int Recovered);
+    int Recovered,
+    CalendarSyncDrainCompletionReason CompletionReason = CalendarSyncDrainCompletionReason.QueueFullyDrained)
+{
+    public bool CanConcludeQueueIsFullyDrained =>
+        CompletionReason == CalendarSyncDrainCompletionReason.QueueFullyDrained &&
+        Retried == 0 &&
+        Failed == 0;
+}
+
+public enum CalendarSyncDrainCompletionReason
+{
+    QueueFullyDrained,
+    MaxItemsReached,
+    MaxDurationReached
+}

--- a/backend/Glovelly.Api/Services/CalendarSyncQueueDrainer.cs
+++ b/backend/Glovelly.Api/Services/CalendarSyncQueueDrainer.cs
@@ -30,10 +30,22 @@ public sealed class CalendarSyncQueueDrainer(
         var succeeded = 0;
         var retried = 0;
         var failed = 0;
+        var completionReason = CalendarSyncDrainCompletionReason.QueueFullyDrained;
 
-        while (processed < maxItems &&
-               (!stopAt.HasValue || DateTimeOffset.UtcNow < stopAt.Value))
+        while (true)
         {
+            if (processed >= maxItems)
+            {
+                completionReason = CalendarSyncDrainCompletionReason.MaxItemsReached;
+                break;
+            }
+
+            if (stopAt.HasValue && DateTimeOffset.UtcNow >= stopAt.Value)
+            {
+                completionReason = CalendarSyncDrainCompletionReason.MaxDurationReached;
+                break;
+            }
+
             var outcome = await ProcessNextAsync(ownerId, cancellationToken);
             if (outcome == CalendarSyncDrainItemOutcome.None)
             {
@@ -55,7 +67,7 @@ public sealed class CalendarSyncQueueDrainer(
             }
         }
 
-        return new CalendarSyncDrainResult(processed, succeeded, retried, failed, Skipped: 0, recovered);
+        return new CalendarSyncDrainResult(processed, succeeded, retried, failed, Skipped: 0, recovered, completionReason);
     }
 
     private async Task<int> RecoverStaleProcessingItemsAsync(

--- a/backend/Glovelly.Api/Services/CalendarSyncWorkQueue.cs
+++ b/backend/Glovelly.Api/Services/CalendarSyncWorkQueue.cs
@@ -4,7 +4,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Glovelly.Api.Services;
 
-public sealed class CalendarSyncWorkQueue(AppDbContext dbContext) : ICalendarSyncWorkQueue
+public sealed class CalendarSyncWorkQueue(
+    AppDbContext dbContext,
+    IScheduledTaskSignal scheduledTaskSignal,
+    ILogger<CalendarSyncWorkQueue> logger) : ICalendarSyncWorkQueue
 {
     public async Task EnqueueGigAsync(
         Guid userId,
@@ -51,6 +54,7 @@ public sealed class CalendarSyncWorkQueue(AppDbContext dbContext) : ICalendarSyn
 
             existingWorkItem.UpdatedAtUtc = now;
             await dbContext.SaveChangesAsync(cancellationToken);
+            await TryMarkCalendarPropagationStaleAsync(reason, cancellationToken);
             return;
         }
 
@@ -69,5 +73,26 @@ public sealed class CalendarSyncWorkQueue(AppDbContext dbContext) : ICalendarSyn
         });
 
         await dbContext.SaveChangesAsync(cancellationToken);
+        await TryMarkCalendarPropagationStaleAsync(reason, cancellationToken);
+    }
+
+    private async Task TryMarkCalendarPropagationStaleAsync(
+        CalendarSyncWorkItemReason reason,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await scheduledTaskSignal.MarkStaleAsync(
+                ScheduledTaskNames.GoogleCalendarPropagation,
+                reason.ToString(),
+                cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                exception,
+                "Failed to mark scheduled task {TaskName} stale after queuing calendar sync work. Calendar sync work remains queued in Postgres.",
+                ScheduledTaskNames.GoogleCalendarPropagation);
+        }
     }
 }

--- a/backend/Glovelly.Api/Services/GcsBlobStore.cs
+++ b/backend/Glovelly.Api/Services/GcsBlobStore.cs
@@ -46,7 +46,7 @@ public sealed class GcsBlobStore(
         {
             await storageClient.DeleteObjectAsync(_bucketName, key, cancellationToken: cancellationToken);
         }
-        catch (GoogleApiException exception) when (exception.Error?.Code == StatusCodes.Status404NotFound)
+        catch (GoogleApiException exception) when (GoogleApiExceptionSupport.IsNotFound(exception))
         {
         }
     }

--- a/backend/Glovelly.Api/Services/GoogleApiExceptionSupport.cs
+++ b/backend/Glovelly.Api/Services/GoogleApiExceptionSupport.cs
@@ -1,0 +1,13 @@
+using Google;
+using System.Net;
+
+namespace Glovelly.Api.Services;
+
+internal static class GoogleApiExceptionSupport
+{
+    public static bool IsNotFound(GoogleApiException exception)
+    {
+        return exception.HttpStatusCode == HttpStatusCode.NotFound ||
+            exception.Error?.Code == StatusCodes.Status404NotFound;
+    }
+}

--- a/backend/Glovelly.Api/Services/GoogleCalendarIntegrationService.cs
+++ b/backend/Glovelly.Api/Services/GoogleCalendarIntegrationService.cs
@@ -72,4 +72,28 @@ public sealed class GoogleCalendarIntegrationService(
 
         return settings;
     }
+
+    public async Task InvalidateSyncHashesAsync(
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var syncStates = await dbContext.GigCalendarSyncStates
+            .Where(state =>
+                state.UserId == userId &&
+                state.Provider == CalendarProvider.GoogleCalendar &&
+                state.LastSyncHash != null)
+            .ToListAsync(cancellationToken);
+
+        foreach (var state in syncStates)
+        {
+            state.LastSyncHash = null;
+            state.UpdatedAtUtc = now;
+        }
+
+        if (syncStates.Count > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
 }

--- a/backend/Glovelly.Api/Services/GoogleCalendarPropagationScheduledTask.cs
+++ b/backend/Glovelly.Api/Services/GoogleCalendarPropagationScheduledTask.cs
@@ -1,0 +1,120 @@
+namespace Glovelly.Api.Services;
+
+public sealed class GoogleCalendarPropagationScheduledTask(
+    IScheduledTaskStateStore stateStore,
+    IServiceScopeFactory serviceScopeFactory,
+    ILogger<GoogleCalendarPropagationScheduledTask> logger) : IScheduledTask<CalendarSyncDrainOptions, CalendarSyncDrainResult>
+{
+    private static readonly TimeSpan SafetyInterval = TimeSpan.FromHours(24);
+
+    public string Name => ScheduledTaskNames.GoogleCalendarPropagation;
+
+    public async Task<ExecutionDecision> ShouldRunAsync(
+        ScheduledTaskContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // This wake gate deliberately reads only task state storage. Do not resolve EF-backed services here.
+        ScheduledTaskStateEnvelope<GoogleCalendarPropagationTaskState>? envelope;
+        try
+        {
+            envelope = await stateStore.ReadAsync<GoogleCalendarPropagationTaskState>(Name, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                exception,
+                "Scheduled task {TaskName} wake-gate state could not be read; running so Postgres remains the source of truth.",
+                Name);
+            return ExecutionDecision.Run("Task state could not be read.");
+        }
+
+        if (envelope is null)
+        {
+            return ExecutionDecision.Run("Task state is missing.");
+        }
+
+        var state = envelope.State;
+        if (state.HasPendingCalendarChanges)
+        {
+            return ExecutionDecision.Run($"Task is stale from {state.LastMarkedStaleReason ?? "unknown reason"}.");
+        }
+
+        if (state.LastSuccessfulPropagationUtc is null)
+        {
+            return ExecutionDecision.Run("Task has no recorded successful propagation.");
+        }
+
+        if (context.NowUtc - state.LastSuccessfulPropagationUtc.Value >= SafetyInterval)
+        {
+            return ExecutionDecision.Run("Safety interval elapsed since last successful propagation.");
+        }
+
+        return ExecutionDecision.Skip("No pending calendar changes and safety interval has not elapsed.");
+    }
+
+    public async Task<CalendarSyncDrainResult> ExecuteAsync(
+        CalendarSyncDrainOptions options,
+        ScheduledTaskContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = serviceScopeFactory.CreateScope();
+        var drainer = scope.ServiceProvider.GetRequiredService<ICalendarSyncQueueDrainer>();
+        var result = await drainer.DrainAsync(options, cancellationToken);
+
+        if (result.CanConcludeQueueIsFullyDrained)
+        {
+            try
+            {
+                await MarkSuccessfulFullyDrainedRunAsync(context.NowUtc, cancellationToken);
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                logger.LogWarning(
+                    exception,
+                    "Scheduled task {TaskName} fully drained but stale state could not be cleared. The next execution will check Postgres again.",
+                    Name);
+            }
+        }
+        else
+        {
+            logger.LogInformation(
+                "Scheduled task {TaskName} left stale because calendar sync drain completed with {CompletionReason}. Retried: {Retried}; Failed: {Failed}.",
+                Name,
+                result.CompletionReason,
+                result.Retried,
+                result.Failed);
+        }
+
+        return result;
+    }
+
+    private async Task MarkSuccessfulFullyDrainedRunAsync(
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var envelope = await stateStore.ReadAsync<GoogleCalendarPropagationTaskState>(Name, cancellationToken)
+            ?? new ScheduledTaskStateEnvelope<GoogleCalendarPropagationTaskState>
+            {
+                TaskName = Name
+            };
+
+        envelope.TaskName = Name;
+        envelope.LastDecisionUtc = now;
+        envelope.LastSuccessfulRunUtc = now;
+        envelope.State.HasPendingCalendarChanges = false;
+        envelope.State.LastSuccessfulPropagationUtc = now;
+
+        await stateStore.WriteAsync(envelope, cancellationToken);
+    }
+}
+
+public sealed class GoogleCalendarPropagationTaskState
+{
+    public bool HasPendingCalendarChanges { get; set; }
+
+    public DateTimeOffset? LastMarkedStaleUtc { get; set; }
+
+    public string? LastMarkedStaleReason { get; set; }
+
+    public DateTimeOffset? LastSuccessfulPropagationUtc { get; set; }
+}

--- a/backend/Glovelly.Api/Services/GoogleCalendarSyncProcessor.cs
+++ b/backend/Glovelly.Api/Services/GoogleCalendarSyncProcessor.cs
@@ -15,27 +15,43 @@ public sealed class GoogleCalendarSyncProcessor(
 {
     public async Task ProcessAsync(CalendarSyncWorkItem workItem, CancellationToken cancellationToken)
     {
+        logger.LogInformation(
+            "Processing Google Calendar sync work item {WorkItemId}. User: {UserId}; Gig: {GigId}; Reason: {Reason}.",
+            workItem.Id,
+            workItem.UserId,
+            workItem.GigId,
+            workItem.Reason);
+
         if (workItem.GigId is null)
         {
-            await ProcessFullSyncAsync(workItem.UserId, workItem.Reason, cancellationToken);
+            await ProcessFullSyncAsync(workItem, cancellationToken);
             return;
         }
 
-        await ProcessGigSyncAsync(workItem.UserId, workItem.GigId.Value, cancellationToken);
+        await ProcessGigSyncAsync(workItem, cancellationToken);
     }
 
     private async Task ProcessFullSyncAsync(
-        Guid userId,
-        CalendarSyncWorkItemReason reason,
+        CalendarSyncWorkItem workItem,
         CancellationToken cancellationToken)
     {
+        var userId = workItem.UserId;
         var settings = await GetEnabledSettingsAsync(userId, cancellationToken);
         if (settings is null)
         {
+            logger.LogInformation(
+                "Google Calendar full sync work item {WorkItemId} skipped because enabled calendar settings were not found for user {UserId}.",
+                workItem.Id,
+                userId);
             return;
         }
 
-        _ = await calendarIntegrationService.EnsureCalendarAsync(userId, cancellationToken);
+        settings = await calendarIntegrationService.EnsureCalendarAsync(userId, cancellationToken);
+        logger.LogInformation(
+            "Google Calendar full sync work item {WorkItemId} using calendar {CalendarId} for user {UserId}.",
+            workItem.Id,
+            settings.GoogleCalendarId,
+            userId);
 
         var gigIds = await dbContext.Gigs
             .AsNoTracking()
@@ -47,21 +63,34 @@ public sealed class GoogleCalendarSyncProcessor(
             .Where(state => state.UserId == userId && state.Provider == CalendarProvider.GoogleCalendar && state.GigId != null)
             .Select(state => state.GigId!.Value)
             .ToListAsync(cancellationToken);
+        var enqueuedGigIds = gigIds.Concat(stateGigIds).Distinct().ToList();
+        logger.LogInformation(
+            "Google Calendar full sync work item {WorkItemId} queued {GigCount} gig sync items. User: {UserId}; Reason: {Reason}.",
+            workItem.Id,
+            enqueuedGigIds.Count,
+            userId,
+            workItem.Reason);
 
-        foreach (var gigId in gigIds.Concat(stateGigIds).Distinct())
+        foreach (var gigId in enqueuedGigIds)
         {
-            await workQueue.EnqueueGigAsync(userId, gigId, reason, cancellationToken);
+            await workQueue.EnqueueGigAsync(userId, gigId, workItem.Reason, cancellationToken);
         }
     }
 
     private async Task ProcessGigSyncAsync(
-        Guid userId,
-        Guid gigId,
+        CalendarSyncWorkItem workItem,
         CancellationToken cancellationToken)
     {
+        var userId = workItem.UserId;
+        var gigId = workItem.GigId!.Value;
         var settings = await GetEnabledSettingsAsync(userId, cancellationToken);
         if (settings is null)
         {
+            logger.LogInformation(
+                "Google Calendar gig sync work item {WorkItemId} skipped because enabled calendar settings were not found. User: {UserId}; Gig: {GigId}.",
+                workItem.Id,
+                userId,
+                gigId);
             return;
         }
 
@@ -82,6 +111,14 @@ public sealed class GoogleCalendarSyncProcessor(
 
         if (gig is null)
         {
+            logger.LogInformation(
+                "Google Calendar gig sync work item {WorkItemId} found no local gig. User: {UserId}; Gig: {GigId}; HasSyncState: {HasSyncState}; ProviderCalendar: {ProviderCalendarId}; ProviderEvent: {ProviderEventId}.",
+                workItem.Id,
+                userId,
+                gigId,
+                syncState is not null,
+                syncState?.ProviderCalendarId,
+                syncState?.ProviderEventId);
             if (syncState is not null)
             {
                 await DeleteProviderEventAsync(userId, settings, syncState, cancellationToken);
@@ -96,6 +133,19 @@ public sealed class GoogleCalendarSyncProcessor(
         }
 
         var plan = syncPlanner.Plan(gig, gig.Client, settings, syncState);
+        logger.LogInformation(
+            "Google Calendar gig sync work item {WorkItemId} planned {Operation}. User: {UserId}; Gig: {GigId}; Status: {Status}; Calendar: {CalendarId}; HasSyncState: {HasSyncState}; ProviderCalendar: {ProviderCalendarId}; ProviderEvent: {ProviderEventId}; HasLastSyncHash: {HasLastSyncHash}; PayloadHashChanged: {PayloadHashChanged}.",
+            workItem.Id,
+            plan.Operation,
+            userId,
+            gigId,
+            gig.Status,
+            settings.GoogleCalendarId,
+            syncState is not null,
+            syncState?.ProviderCalendarId,
+            syncState?.ProviderEventId,
+            !string.IsNullOrWhiteSpace(syncState?.LastSyncHash),
+            plan.PayloadHash is not null && !string.Equals(syncState?.LastSyncHash, plan.PayloadHash, StringComparison.Ordinal));
         switch (plan.Operation)
         {
             case CalendarSyncOperation.None:
@@ -175,6 +225,12 @@ public sealed class GoogleCalendarSyncProcessor(
         var payloadHash = plan.PayloadHash ?? throw new InvalidOperationException("Calendar create hash is missing.");
         var eventId = GoogleCalendarApiClient.BuildDeterministicEventId(gigId);
         var accessToken = await GetAccessTokenAsync(userId, cancellationToken);
+        logger.LogInformation(
+            "Creating Google Calendar event {EventId} in calendar {CalendarId}. User: {UserId}; Gig: {GigId}.",
+            eventId,
+            settings.GoogleCalendarId,
+            userId,
+            gigId);
         var createdEvent = await CreateEventWithCalendarRecoveryAsync(
             userId,
             settings,
@@ -214,6 +270,12 @@ public sealed class GoogleCalendarSyncProcessor(
             ? GoogleCalendarApiClient.BuildDeterministicEventId(gigId)
             : syncState.ProviderEventId;
         var accessToken = await GetAccessTokenAsync(userId, cancellationToken);
+        logger.LogInformation(
+            "Updating Google Calendar event {EventId} in calendar {CalendarId}. User: {UserId}; Gig: {GigId}.",
+            eventId,
+            settings.GoogleCalendarId,
+            userId,
+            gigId);
         var updatedEvent = await UpdateEventWithCalendarRecoveryAsync(
             userId,
             settings,
@@ -237,6 +299,12 @@ public sealed class GoogleCalendarSyncProcessor(
             !string.IsNullOrWhiteSpace(syncState.ProviderCalendarId))
         {
             var accessToken = await GetAccessTokenAsync(userId, cancellationToken);
+            logger.LogInformation(
+                "Deleting Google Calendar event {EventId} from calendar {CalendarId}. User: {UserId}; Gig: {GigId}.",
+                syncState.ProviderEventId,
+                syncState.ProviderCalendarId,
+                userId,
+                syncState.GigId);
             await calendarApiClient.DeleteEventAsync(
                 accessToken,
                 syncState.ProviderCalendarId,
@@ -294,8 +362,19 @@ public sealed class GoogleCalendarSyncProcessor(
         }
         catch (GoogleCalendarApiException exception) when (exception.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
+            logger.LogWarning(
+                exception,
+                "Google Calendar event create returned 404 for event {EventId} in calendar {CalendarId}; recreating calendar. User: {UserId}.",
+                eventId,
+                settings.GoogleCalendarId,
+                userId);
             await RecreateMissingCalendarAsync(userId, settings, cancellationToken);
             accessToken = await GetAccessTokenAsync(userId, cancellationToken);
+            logger.LogInformation(
+                "Retrying Google Calendar event create for event {EventId} in replacement calendar {CalendarId}. User: {UserId}.",
+                eventId,
+                settings.GoogleCalendarId,
+                userId);
             return await calendarApiClient.CreateEventAsync(
                 accessToken,
                 settings.GoogleCalendarId!,
@@ -324,6 +403,12 @@ public sealed class GoogleCalendarSyncProcessor(
         }
         catch (GoogleCalendarApiException exception) when (exception.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
+            logger.LogWarning(
+                exception,
+                "Google Calendar event update returned 404 for event {EventId} in calendar {CalendarId}; trying create before calendar recreation. User: {UserId}.",
+                eventId,
+                settings.GoogleCalendarId,
+                userId);
             try
             {
                 return await calendarApiClient.CreateEventAsync(
@@ -335,8 +420,19 @@ public sealed class GoogleCalendarSyncProcessor(
             }
             catch (GoogleCalendarApiException createException) when (createException.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
+                logger.LogWarning(
+                    createException,
+                    "Google Calendar event create-after-update returned 404 for event {EventId} in calendar {CalendarId}; recreating calendar. User: {UserId}.",
+                    eventId,
+                    settings.GoogleCalendarId,
+                    userId);
                 await RecreateMissingCalendarAsync(userId, settings, cancellationToken);
                 accessToken = await GetAccessTokenAsync(userId, cancellationToken);
+                logger.LogInformation(
+                    "Retrying Google Calendar event create for event {EventId} in replacement calendar {CalendarId}. User: {UserId}.",
+                    eventId,
+                    settings.GoogleCalendarId,
+                    userId);
                 return await calendarApiClient.CreateEventAsync(
                     accessToken,
                     settings.GoogleCalendarId!,

--- a/backend/Glovelly.Api/Services/IGoogleCalendarIntegrationService.cs
+++ b/backend/Glovelly.Api/Services/IGoogleCalendarIntegrationService.cs
@@ -7,4 +7,8 @@ public interface IGoogleCalendarIntegrationService
     Task<GoogleCalendarIntegrationSettings> EnsureCalendarAsync(
         Guid userId,
         CancellationToken cancellationToken);
+
+    Task InvalidateSyncHashesAsync(
+        Guid userId,
+        CancellationToken cancellationToken);
 }

--- a/backend/Glovelly.Api/Services/ScheduledTaskContracts.cs
+++ b/backend/Glovelly.Api/Services/ScheduledTaskContracts.cs
@@ -1,0 +1,31 @@
+namespace Glovelly.Api.Services;
+
+public interface IScheduledTask<in TOptions, TResult>
+{
+    string Name { get; }
+
+    // Wake gates must avoid resolving AppDbContext or other Postgres-backed services.
+    // They are cheap hints that decide whether execution is worth opening the source of truth.
+    Task<ExecutionDecision> ShouldRunAsync(
+        ScheduledTaskContext context,
+        CancellationToken cancellationToken = default);
+
+    Task<TResult> ExecuteAsync(
+        TOptions options,
+        ScheduledTaskContext context,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ScheduledTaskContext(DateTimeOffset NowUtc);
+
+public sealed record ExecutionDecision(bool ShouldRun, string Reason)
+{
+    public static ExecutionDecision Run(string reason) => new(true, reason);
+
+    public static ExecutionDecision Skip(string reason) => new(false, reason);
+}
+
+public static class ScheduledTaskNames
+{
+    public const string GoogleCalendarPropagation = "google-calendar-propagation";
+}

--- a/backend/Glovelly.Api/Services/ScheduledTaskSignal.cs
+++ b/backend/Glovelly.Api/Services/ScheduledTaskSignal.cs
@@ -29,6 +29,11 @@ public sealed class ScheduledTaskSignal(
                 TaskName = taskName
             };
 
+        if (envelope.State.HasPendingCalendarChanges)
+        {
+            return;
+        }
+
         envelope.TaskName = taskName;
         envelope.State.HasPendingCalendarChanges = true;
         envelope.State.LastMarkedStaleUtc = now;

--- a/backend/Glovelly.Api/Services/ScheduledTaskSignal.cs
+++ b/backend/Glovelly.Api/Services/ScheduledTaskSignal.cs
@@ -1,0 +1,39 @@
+namespace Glovelly.Api.Services;
+
+public interface IScheduledTaskSignal
+{
+    Task MarkStaleAsync(
+        string taskName,
+        string reason,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class ScheduledTaskSignal(
+    IScheduledTaskStateStore stateStore,
+    TimeProvider timeProvider) : IScheduledTaskSignal
+{
+    public async Task MarkStaleAsync(
+        string taskName,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        if (taskName != ScheduledTaskNames.GoogleCalendarPropagation)
+        {
+            throw new InvalidOperationException($"Scheduled task '{taskName}' does not support stale signalling.");
+        }
+
+        var now = timeProvider.GetUtcNow();
+        var envelope = await stateStore.ReadAsync<GoogleCalendarPropagationTaskState>(taskName, cancellationToken)
+            ?? new ScheduledTaskStateEnvelope<GoogleCalendarPropagationTaskState>
+            {
+                TaskName = taskName
+            };
+
+        envelope.TaskName = taskName;
+        envelope.State.HasPendingCalendarChanges = true;
+        envelope.State.LastMarkedStaleUtc = now;
+        envelope.State.LastMarkedStaleReason = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim();
+
+        await stateStore.WriteAsync(envelope, cancellationToken);
+    }
+}

--- a/backend/Glovelly.Api/Services/ScheduledTaskStateStore.cs
+++ b/backend/Glovelly.Api/Services/ScheduledTaskStateStore.cs
@@ -40,7 +40,7 @@ public sealed class BlobScheduledTaskStateStore(IBlobStore blobStore) : ISchedul
         {
             return null;
         }
-        catch (GoogleApiException exception) when (exception.Error?.Code == StatusCodes.Status404NotFound)
+        catch (GoogleApiException exception) when (GoogleApiExceptionSupport.IsNotFound(exception))
         {
             return null;
         }

--- a/backend/Glovelly.Api/Services/ScheduledTaskStateStore.cs
+++ b/backend/Glovelly.Api/Services/ScheduledTaskStateStore.cs
@@ -1,0 +1,82 @@
+using Google;
+using System.Text.Json;
+
+namespace Glovelly.Api.Services;
+
+public interface IScheduledTaskStateStore
+{
+    Task<ScheduledTaskStateEnvelope<TState>?> ReadAsync<TState>(
+        string taskName,
+        CancellationToken cancellationToken = default)
+        where TState : class, new();
+
+    Task WriteAsync<TState>(
+        ScheduledTaskStateEnvelope<TState> envelope,
+        CancellationToken cancellationToken = default)
+        where TState : class, new();
+}
+
+public sealed class BlobScheduledTaskStateStore(IBlobStore blobStore) : IScheduledTaskStateStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public async Task<ScheduledTaskStateEnvelope<TState>?> ReadAsync<TState>(
+        string taskName,
+        CancellationToken cancellationToken = default)
+        where TState : class, new()
+    {
+        try
+        {
+            await using var content = (await blobStore.OpenReadAsync(BuildKey(taskName), cancellationToken)).Content;
+            return await JsonSerializer.DeserializeAsync<ScheduledTaskStateEnvelope<TState>>(
+                content,
+                JsonOptions,
+                cancellationToken);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (GoogleApiException exception) when (exception.Error?.Code == StatusCodes.Status404NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task WriteAsync<TState>(
+        ScheduledTaskStateEnvelope<TState> envelope,
+        CancellationToken cancellationToken = default)
+        where TState : class, new()
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        await using var content = new MemoryStream();
+        await JsonSerializer.SerializeAsync(content, envelope, JsonOptions, cancellationToken);
+        content.Position = 0;
+        await blobStore.SaveAsync(
+            new BlobWriteRequest(BuildKey(envelope.TaskName), content, "application/json", content.Length),
+            cancellationToken);
+    }
+
+    private static string BuildKey(string taskName)
+    {
+        return $"worker/scheduled-tasks/{taskName}.json";
+    }
+}
+
+public sealed class ScheduledTaskStateEnvelope<TState>
+    where TState : class, new()
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public string TaskName { get; set; } = string.Empty;
+
+    public DateTimeOffset? LastDecisionUtc { get; set; }
+
+    public DateTimeOffset? LastSuccessfulRunUtc { get; set; }
+
+    public TState State { get; set; } = new();
+}

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -29,6 +29,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICalendarSyncWorkQueue, CalendarSyncWorkQueue>();
         services.AddScoped<IGoogleCalendarSyncProcessor, GoogleCalendarSyncProcessor>();
         services.AddScoped<ICalendarSyncQueueDrainer, CalendarSyncQueueDrainer>();
+        services.AddSingleton<IScheduledTaskStateStore, BlobScheduledTaskStateStore>();
+        services.AddSingleton<IScheduledTaskSignal, ScheduledTaskSignal>();
+        services.AddSingleton<GoogleCalendarPropagationScheduledTask>();
         services.AddOptions<GoogleRoutesMileageSettings>()
             .BindConfiguration(GoogleRoutesMileageSettings.SectionName);
         services.AddHttpClient<GoogleRoutesMileageEstimationService>();

--- a/backend/Glovelly.Worker/Program.cs
+++ b/backend/Glovelly.Worker/Program.cs
@@ -69,21 +69,38 @@ static async Task<int> RunCalendarSyncDrainAsync(
     IServiceProvider services,
     CancellationToken cancellationToken)
 {
-    using var scope = services.CreateScope();
-    var logger = scope.ServiceProvider
+    var logger = services
         .GetRequiredService<ILoggerFactory>()
         .CreateLogger("Glovelly.Worker.CalendarSync");
-    var drainer = scope.ServiceProvider.GetRequiredService<ICalendarSyncQueueDrainer>();
+    var timeProvider = services.GetRequiredService<TimeProvider>();
+    var scheduledTask = services.GetRequiredService<GoogleCalendarPropagationScheduledTask>();
+    var context = new ScheduledTaskContext(timeProvider.GetUtcNow());
+    var decision = await scheduledTask.ShouldRunAsync(context, cancellationToken);
 
-    var result = await drainer.DrainAsync(options, cancellationToken);
+    if (!decision.ShouldRun)
+    {
+        logger.LogInformation(
+            "Scheduled task {TaskName} skipped: {Reason}",
+            scheduledTask.Name,
+            decision.Reason);
+        return 0;
+    }
+
     logger.LogInformation(
-        "Calendar sync drain complete: {Processed} processed, {Succeeded} succeeded, {Retried} retried, {Failed} failed, {Skipped} skipped, {Recovered} recovered.",
+        "Scheduled task {TaskName} running: {Reason}",
+        scheduledTask.Name,
+        decision.Reason);
+
+    var result = await scheduledTask.ExecuteAsync(options, context, cancellationToken);
+    logger.LogInformation(
+        "Calendar sync drain complete: {Processed} processed, {Succeeded} succeeded, {Retried} retried, {Failed} failed, {Skipped} skipped, {Recovered} recovered, completion reason {CompletionReason}.",
         result.Processed,
         result.Succeeded,
         result.Retried,
         result.Failed,
         result.Skipped,
-        result.Recovered);
+        result.Recovered,
+        result.CompletionReason);
 
     return 0;
 }

--- a/docs/engineering/decisions/0005-cloud-run-jobs-for-background-workers.md
+++ b/docs/engineering/decisions/0005-cloud-run-jobs-for-background-workers.md
@@ -31,6 +31,10 @@ Trigger the Calendar sync job with Cloud Scheduler on a fixed cadence.
 
 Use the same runtime configuration model as the web app: Secret Manager bindings, deployment environment variables, runtime service account, EF Core models, and application services.
 
+Scheduled worker commands use task-level wake gates before opening Postgres-backed services. The Calendar sync wake gate reads small task-state JSON from the existing GCS bucket under `worker/scheduled-tasks/` and skips the drain command when the task is not stale and the safety interval has not elapsed. Wake gates must not resolve `AppDbContext` or other EF-backed services; the cheap state file is only an execution hint, while Postgres remains the source of truth.
+
+The Calendar sync stale flag is cleared only after a drain run can conclusively say the queue is fully drained. If a run stops because of max items, max duration, retry, failure, cancellation, or an exception, the stale flag remains set so the next scheduled execution will check Postgres again. Failures to update the stale flag are logged as warnings and do not fail user-visible gig mutations because the database queue remains authoritative and the safety interval self-heals lost wake hints.
+
 ## Consequences
 
 Background execution is decoupled from the web request lifecycle and does not depend on a warm Cloud Run service instance.


### PR DESCRIPTION
## Summary
- add scheduled task wake-gate/state abstractions backed by the existing blob/GCS store
- gate calendar sync drain before resolving Postgres-backed services and log skip/run decisions
- mark calendar propagation stale from queued calendar work and clear stale only after a conclusive full drain
- document the wake-gate/source-of-truth rules in the worker ADR

## Tests
- dotnet test glovelly.sln -m:1

Closes #181