### PR TITLE
Send enrolment emails to users

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,7 @@ jobs:
             Email__Mode=Resend
             Email__AccessRequests__FromDisplayName=Glovelly
             Email__Invoices__FromDisplayName=Glovelly
+            Email__UserInvitations__FromDisplayName=Glovelly
             ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
             Mcp__OAuth__Issuer=${{ vars.DEPLOYMENT_URL }}
             Mcp__OAuth__Resource=${{ vars.DEPLOYMENT_URL }}/mcp
@@ -215,6 +216,7 @@ jobs:
             Email__Resend__ApiKey=glovelly-resend-api-key:latest
             Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest
             Email__Invoices__FromAddress=glovelly-invoices-from-address:latest
+            Email__UserInvitations__FromAddress=glovelly-access-requests-from-address:latest
             Mileage__GoogleRoutes__ApiKey=glovelly-routes-api-key:latest
             Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest
             Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest
@@ -331,6 +333,7 @@ jobs:
             Email__Mode=Resend
             Email__AccessRequests__FromDisplayName=Glovelly
             Email__Invoices__FromDisplayName=Glovelly
+            Email__UserInvitations__FromDisplayName=Glovelly
             ExpenseAttachments__BucketName=${{ vars.GCP_BUCKET_NAME }}
             Mcp__OAuth__Issuer=${{ vars.DEPLOYMENT_URL }}
             Mcp__OAuth__Resource=${{ vars.DEPLOYMENT_URL }}/mcp
@@ -343,6 +346,7 @@ jobs:
             Email__Resend__ApiKey=glovelly-resend-api-key:latest
             Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest
             Email__Invoices__FromAddress=glovelly-invoices-from-address:latest
+            Email__UserInvitations__FromAddress=glovelly-access-requests-from-address:latest
             Mileage__GoogleRoutes__ApiKey=glovelly-routes-api-key:latest
             Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest
             Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest

--- a/.glovelly.dev.local.example
+++ b/.glovelly.dev.local.example
@@ -6,6 +6,7 @@ export Email__AccessRequests__FromAddress="access@example.com"
 export Email__AccessRequests__FromDisplayName="Glovelly Access"
 export Email__Invoices__FromAddress="invoices@example.com"
 export Email__Invoices__FromDisplayName="Glovelly Invoices"
+export Email__UserInvitations__FromAddress="onboarding@example.net"
 export Mcp__DevelopmentAuth__AllowAnonymous="false"
 # Optional: configure an OAuth client for staging/local MCP OAuth testing.
 # export Mcp__OAuth__Issuer="https://your-public-glovelly-host.example"

--- a/backend/Glovelly.Api.Tests/AdminEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AdminEndpointsTests.cs
@@ -9,11 +9,70 @@ namespace Glovelly.Api.Tests;
 public sealed class AdminEndpointsTests : IClassFixture<GlovellyApiFactory>
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly GlovellyApiFactory _factory;
     private readonly HttpClient _client;
 
     public AdminEndpointsTests(GlovellyApiFactory factory)
     {
+        _factory = factory;
         _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task CreateUser_DoesNotSendInvitationEmailByDefault()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/admin/users", new
+        {
+            email = "new-user@glovelly.local",
+            displayName = "New User",
+            googleSubject = (string?)null,
+            mileageRate = (decimal?)null,
+            passengerMileageRate = (decimal?)null,
+            role = "User",
+            isActive = true,
+        }, TestContext.Current.CancellationToken);
+
+        createResponse.EnsureSuccessStatusCode();
+
+        Assert.Empty(_factory.Emails.SentEmails);
+    }
+
+    [Fact]
+    public async Task SendInvitationEmail_WhenUserActive_SendsInvite()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/admin/users", new
+        {
+            email = "invited-user@glovelly.local",
+            displayName = "Invited User",
+            googleSubject = (string?)null,
+            mileageRate = (decimal?)null,
+            passengerMileageRate = (decimal?)null,
+            role = "User",
+            isActive = true,
+        }, TestContext.Current.CancellationToken);
+        createResponse.EnsureSuccessStatusCode();
+        var createdUser = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        var userId = createdUser.GetProperty("id").GetGuid();
+
+        var inviteResponse = await _client.PostAsync($"/admin/users/{userId}/invitation-email", null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, inviteResponse.StatusCode);
+        var email = Assert.Single(_factory.Emails.SentEmails);
+        var recipient = Assert.Single(email.To);
+        Assert.Equal("invited-user@glovelly.local", recipient.Address);
+        Assert.Equal("Invited User", recipient.DisplayName);
+        Assert.Equal("You have been invited to Glovelly", email.Subject);
+        Assert.Contains("Sign in with Google using this email address", email.PlainTextBody);
+        Assert.Contains("/auth/login", email.PlainTextBody);
+    }
+
+    [Fact]
+    public async Task SendInvitationEmail_WhenUserMissing_ReturnsNotFound()
+    {
+        var inviteResponse = await _client.PostAsync($"/admin/users/{Guid.NewGuid()}/invitation-email", null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, inviteResponse.StatusCode);
+        Assert.Empty(_factory.Emails.SentEmails);
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -79,6 +79,8 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
                 settings.AccessRequests.FromDisplayName = "Glovelly Access";
                 settings.Invoices.FromAddress = "invoices@glovelly.test";
                 settings.Invoices.FromDisplayName = "Glovelly Invoices";
+                settings.UserInvitations.FromAddress = "invitations@glovelly.test";
+                settings.UserInvitations.FromDisplayName = "Glovelly Invitations";
             });
 
             services.AddDbContext<AppDbContext>(options =>

--- a/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AccessEndpoints.cs
@@ -5,7 +5,6 @@ using Glovelly.Api.Services;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
-using System.Net;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
@@ -184,55 +183,43 @@ internal static class AccessEndpoints
 
     private static string BuildHtmlBody(AccessRequestEmailRequest requester, string environmentLabel)
     {
-        var encodedEmail = WebUtility.HtmlEncode(requester.Email);
-        var encodedDisplayName = WebUtility.HtmlEncode(requester.DisplayName ?? "Not provided");
-        var encodedEnvironment = WebUtility.HtmlEncode(environmentLabel);
-        var encodedTimestamp = WebUtility.HtmlEncode(
+        var encodedEmail = EmailHtmlRenderer.Encode(requester.Email);
+        var encodedDisplayName = EmailHtmlRenderer.Encode(requester.DisplayName ?? "Not provided");
+        var encodedEnvironment = EmailHtmlRenderer.Encode(environmentLabel);
+        var encodedTimestamp = EmailHtmlRenderer.Encode(
             requester.RequestedAtUtc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"));
-        var encodedSubject = WebUtility.HtmlEncode(requester.Subject ?? "Not provided");
+        var encodedSubject = EmailHtmlRenderer.Encode(requester.Subject ?? "Not provided");
 
-        return $$"""
-            <!DOCTYPE html>
-            <html lang="en">
-            <body style="margin:0;padding:24px;background:#f5efe7;font-family:'Avenir Next','Segoe UI',sans-serif;color:#21313c;">
-                <div style="max-width:640px;margin:0 auto;background:#fffdf9;border:1px solid #e5d8ca;border-radius:24px;overflow:hidden;box-shadow:0 18px 45px rgba(39,31,24,0.08);">
-                    <div style="padding:24px 28px;background:linear-gradient(135deg,#17324d,#255a7a);color:#ffffff;">
-                        <div style="font-size:12px;letter-spacing:0.18em;text-transform:uppercase;opacity:0.82;">Glovelly</div>
-                        <h1 style="margin:12px 0 0;font-size:28px;line-height:1.05;font-family:Georgia,serif;">Access Request</h1>
-                        <p style="margin:12px 0 0;font-size:15px;line-height:1.6;color:rgba(255,255,255,0.88);">
-                            A user has successfully authenticated and is asking to be enrolled in Glovelly.
-                        </p>
-                    </div>
-                    <div style="padding:28px;">
-                        <div style="display:inline-block;padding:8px 12px;border-radius:999px;background:#efe4d7;color:#8c4920;font-size:12px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;">
-                            {{encodedEnvironment}}
-                        </div>
-                        <table style="width:100%;margin-top:20px;border-collapse:collapse;">
-                            <tr>
-                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;font-weight:700;width:180px;">User email</td>
-                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;">{{encodedEmail}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;font-weight:700;">Display name</td>
-                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;">{{encodedDisplayName}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;font-weight:700;">Timestamp</td>
-                                <td style="padding:12px 0;border-bottom:1px solid #efe3d6;">{{encodedTimestamp}}</td>
-                            </tr>
-                            <tr>
-                                <td style="padding:12px 0;font-weight:700;">Identity subject</td>
-                                <td style="padding:12px 0;">{{encodedSubject}}</td>
-                            </tr>
-                        </table>
-                        <p style="margin:24px 0 0;font-size:14px;line-height:1.7;color:#52606b;">
-                            Review this user in the target environment and grant access if appropriate.
-                        </p>
-                    </div>
-                </div>
-            </body>
-            </html>
-            """;
+        return EmailHtmlRenderer.RenderDocument(
+            "Access Request",
+            "A user has successfully authenticated and is asking to be enrolled in Glovelly.",
+            $$"""
+                  <div class="info-note">
+                    <p class="section-label">Environment</p>
+                    <p>{{encodedEnvironment}}</p>
+                  </div>
+                  <table class="details">
+                    <tr>
+                      <th>User email</th>
+                      <td>{{encodedEmail}}</td>
+                    </tr>
+                    <tr>
+                      <th>Display name</th>
+                      <td>{{encodedDisplayName}}</td>
+                    </tr>
+                    <tr>
+                      <th>Timestamp</th>
+                      <td>{{encodedTimestamp}}</td>
+                    </tr>
+                    <tr>
+                      <th>Identity subject</th>
+                      <td>{{encodedSubject}}</td>
+                    </tr>
+                  </table>
+                  <div class="message-copy">
+                    <p>Review this user in the target environment and grant access if appropriate.</p>
+                  </div>
+            """);
     }
 
     private static string ResolveEnvironmentLabel(StartupSettings settings)

--- a/backend/Glovelly.Api/Endpoints/AdminEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AdminEndpoints.cs
@@ -4,7 +4,6 @@ using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using System.Net;
 using System.Security.Claims;
 
 namespace Glovelly.Api.Endpoints;
@@ -304,39 +303,24 @@ public static class AdminEndpoints
 
     private static string BuildInvitationHtmlBody(User user, string loginUrl)
     {
-        var encodedDisplayName = WebUtility.HtmlEncode(
-            string.IsNullOrWhiteSpace(user.DisplayName) ? user.Email : user.DisplayName);
-        var encodedEmail = WebUtility.HtmlEncode(user.Email);
-        var encodedLoginUrl = WebUtility.HtmlEncode(loginUrl);
+        var displayName = string.IsNullOrWhiteSpace(user.DisplayName) ? user.Email : user.DisplayName;
+        var encodedDisplayName = EmailHtmlRenderer.Encode(displayName);
+        var encodedEmail = EmailHtmlRenderer.Encode(user.Email);
+        var encodedLoginUrl = EmailHtmlRenderer.Encode(loginUrl);
 
-        return $$"""
-            <!DOCTYPE html>
-            <html lang="en">
-            <body style="margin:0;padding:24px;background:#f5efe7;font-family:'Avenir Next','Segoe UI',sans-serif;color:#21313c;">
-                <div style="max-width:640px;margin:0 auto;background:#fffdf9;border:1px solid #e5d8ca;border-radius:24px;overflow:hidden;box-shadow:0 18px 45px rgba(39,31,24,0.08);">
-                    <div style="padding:24px 28px;background:linear-gradient(135deg,#17324d,#255a7a);color:#ffffff;">
-                        <div style="font-size:12px;letter-spacing:0.18em;text-transform:uppercase;opacity:0.82;">Glovelly</div>
-                        <h1 style="margin:12px 0 0;font-size:28px;line-height:1.05;font-family:Georgia,serif;">You're invited</h1>
-                        <p style="margin:12px 0 0;font-size:15px;line-height:1.6;color:rgba(255,255,255,0.88);">
-                            Your Glovelly account is ready for you to sign in.
-                        </p>
-                    </div>
-                    <div style="padding:28px;">
-                        <p style="margin:0 0 16px;font-size:15px;line-height:1.7;">Hi {{encodedDisplayName}},</p>
-                        <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#52606b;">
-                            You have been invited to use Glovelly. Sign in with Google using <strong>{{encodedEmail}}</strong>.
-                        </p>
-                        <p style="margin:28px 0;">
-                            <a href="{{encodedLoginUrl}}" style="display:inline-block;padding:12px 18px;border-radius:999px;background:#17324d;color:#ffffff;text-decoration:none;font-weight:700;">Open Glovelly</a>
-                        </p>
-                        <p style="margin:0;font-size:13px;line-height:1.7;color:#6b7280;">
-                            If you were not expecting this invitation, you can ignore this email.
-                        </p>
-                    </div>
-                </div>
-            </body>
-            </html>
-            """;
+        return EmailHtmlRenderer.RenderDocument(
+            "You're invited",
+            "Your Glovelly account is ready for you to sign in.",
+            $$"""
+                  <div class="message-copy">
+                    <p>Hi {{encodedDisplayName}},</p>
+                    <p>You have been invited to use Glovelly. Sign in with Google using <strong>{{encodedEmail}}</strong>.</p>
+                    <p><a class="button" href="{{encodedLoginUrl}}">Open Glovelly</a></p>
+                  </div>
+                  <div class="info-note">
+                    <p>If you were not expecting this invitation, you can ignore this email.</p>
+                  </div>
+            """);
     }
 
     private sealed record AdminUserRequest(

--- a/backend/Glovelly.Api/Endpoints/AdminEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AdminEndpoints.cs
@@ -1,7 +1,10 @@
 using Glovelly.Api.Auth;
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
+using Glovelly.Api.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using System.Net;
 using System.Security.Claims;
 
 namespace Glovelly.Api.Endpoints;
@@ -52,6 +55,61 @@ public static class AdminEndpoints
             await db.SaveChangesAsync();
 
             return Results.Created($"/admin/users/{user.Id}", user);
+        });
+
+        users.MapPost("/{id:guid}/invitation-email", async (
+            Guid id,
+            AppDbContext db,
+            IEmailSender emailSender,
+            IOptions<EmailSettings> emailSettingsAccessor,
+            HttpContext httpContext,
+            ILoggerFactory loggerFactory,
+            CancellationToken cancellationToken) =>
+        {
+            var user = await db.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(value => value.Id == id, cancellationToken);
+            if (user is null)
+            {
+                return Results.NotFound();
+            }
+
+            if (!user.IsActive)
+            {
+                return EndpointSupport.ValidationProblem("isActive", "Only active users can be invited to sign in.");
+            }
+
+            var loginUrl = BuildLoginUrl(httpContext);
+            var logger = loggerFactory.CreateLogger("Glovelly.UserInvitations");
+
+            try
+            {
+                await emailSender.SendAsync(
+                    new EmailMessage(
+                        To: [new EmailAddress(user.Email, user.DisplayName)],
+                        Subject: "You have been invited to Glovelly",
+                        PlainTextBody: BuildInvitationPlainTextBody(user, loginUrl),
+                        From: EmailSenderSupport.ResolveConfiguredFromAddress(
+                            emailSettingsAccessor.Value,
+                            EmailUseCase.UserInvitations),
+                        HtmlBody: BuildInvitationHtmlBody(user, loginUrl)),
+                    cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(
+                    exception,
+                    "Failed to dispatch user invitation email for user {UserId}.",
+                    user.Id);
+                return Results.Problem(
+                    title: "Unable to send invitation email",
+                    detail: "The user was saved, but the invitation email could not be sent right now.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+
+            logger.LogInformation("User invitation email sent for user {UserId}.", user.Id);
+
+            return Results.NoContent();
         });
 
         users.MapPut("/{id:guid}", async (
@@ -207,6 +265,78 @@ public static class AdminEndpoints
             request.PassengerMileageRate,
             role,
             request.IsActive);
+    }
+
+    private static string BuildLoginUrl(HttpContext httpContext)
+    {
+        var request = httpContext.Request;
+        var baseUri = new UriBuilder(request.Scheme, request.Host.Host)
+        {
+            Path = request.PathBase.Add("/auth/login").Value,
+        };
+
+        if (request.Host.Port.HasValue)
+        {
+            baseUri.Port = request.Host.Port.Value;
+        }
+
+        return baseUri.Uri.ToString();
+    }
+
+    private static string BuildInvitationPlainTextBody(User user, string loginUrl)
+    {
+        var displayName = string.IsNullOrWhiteSpace(user.DisplayName) ? user.Email : user.DisplayName;
+
+        return string.Join(Environment.NewLine, [
+            $"Hi {displayName},",
+            string.Empty,
+            "You have been invited to use Glovelly.",
+            string.Empty,
+            "Sign in with Google using this email address:",
+            user.Email,
+            string.Empty,
+            "Open Glovelly:",
+            loginUrl,
+            string.Empty,
+            "If you were not expecting this invitation, you can ignore this email.",
+        ]);
+    }
+
+    private static string BuildInvitationHtmlBody(User user, string loginUrl)
+    {
+        var encodedDisplayName = WebUtility.HtmlEncode(
+            string.IsNullOrWhiteSpace(user.DisplayName) ? user.Email : user.DisplayName);
+        var encodedEmail = WebUtility.HtmlEncode(user.Email);
+        var encodedLoginUrl = WebUtility.HtmlEncode(loginUrl);
+
+        return $$"""
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="margin:0;padding:24px;background:#f5efe7;font-family:'Avenir Next','Segoe UI',sans-serif;color:#21313c;">
+                <div style="max-width:640px;margin:0 auto;background:#fffdf9;border:1px solid #e5d8ca;border-radius:24px;overflow:hidden;box-shadow:0 18px 45px rgba(39,31,24,0.08);">
+                    <div style="padding:24px 28px;background:linear-gradient(135deg,#17324d,#255a7a);color:#ffffff;">
+                        <div style="font-size:12px;letter-spacing:0.18em;text-transform:uppercase;opacity:0.82;">Glovelly</div>
+                        <h1 style="margin:12px 0 0;font-size:28px;line-height:1.05;font-family:Georgia,serif;">You're invited</h1>
+                        <p style="margin:12px 0 0;font-size:15px;line-height:1.6;color:rgba(255,255,255,0.88);">
+                            Your Glovelly account is ready for you to sign in.
+                        </p>
+                    </div>
+                    <div style="padding:28px;">
+                        <p style="margin:0 0 16px;font-size:15px;line-height:1.7;">Hi {{encodedDisplayName}},</p>
+                        <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#52606b;">
+                            You have been invited to use Glovelly. Sign in with Google using <strong>{{encodedEmail}}</strong>.
+                        </p>
+                        <p style="margin:28px 0;">
+                            <a href="{{encodedLoginUrl}}" style="display:inline-block;padding:12px 18px;border-radius:999px;background:#17324d;color:#ffffff;text-decoration:none;font-weight:700;">Open Glovelly</a>
+                        </p>
+                        <p style="margin:0;font-size:13px;line-height:1.7;color:#6b7280;">
+                            If you were not expecting this invitation, you can ignore this email.
+                        </p>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """;
     }
 
     private sealed record AdminUserRequest(

--- a/backend/Glovelly.Api/Services/EmailHtmlRenderer.cs
+++ b/backend/Glovelly.Api/Services/EmailHtmlRenderer.cs
@@ -1,0 +1,81 @@
+using System.Net;
+
+namespace Glovelly.Api.Services;
+
+internal static class EmailHtmlRenderer
+{
+    public static string RenderDocument(
+        string title,
+        string intro,
+        string contentHtml,
+        string eyebrow = "Glovelly")
+    {
+        var encodedEyebrow = Encode(eyebrow);
+        var encodedTitle = Encode(title);
+        var encodedIntro = Encode(intro);
+
+        return $$"""
+            <!doctype html>
+            <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1">
+              <style>
+                body { margin: 0; padding: 0; background: #f5efe7; color: #21313c; font-family: 'Avenir Next', 'Segoe UI', Arial, sans-serif; }
+                .wrap { max-width: 640px; margin: 0 auto; padding: 32px 20px; }
+                .card { background: #fffdf9; border: 1px solid #e5d8ca; border-radius: 24px; box-shadow: 0 18px 45px rgba(39, 31, 24, 0.08); }
+                .hero { padding: 24px 28px; background: #17324d; color: #ffffff; border-radius: 24px 24px 0 0; }
+                .eyebrow { font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; opacity: 0.82; }
+                .hero h1 { margin: 12px 0 0; font-family: Georgia, serif; font-size: 28px; line-height: 1.05; }
+                .hero p { margin: 12px 0 0; color: rgba(255, 255, 255, 0.88); font-size: 15px; line-height: 1.6; }
+                .message-main { padding: 28px; }
+                .message-copy p { margin: 0 0 16px; line-height: 1.6; }
+                .attachment-note, .additional-message, .info-note { margin-top: 24px; padding: 16px; background: #fbf8f2; border-radius: 12px; }
+                .section-label { margin: 0 0 8px; color: #6c5f50; font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+                .details { width: 100%; border-collapse: collapse; margin-top: 8px; }
+                .details th { width: 160px; padding: 10px 12px 10px 0; border-bottom: 1px solid #eee6dc; color: #6c5f50; font-size: 12px; letter-spacing: 0.04em; text-align: left; text-transform: uppercase; vertical-align: top; }
+                .details td { padding: 10px 0; border-bottom: 1px solid #eee6dc; vertical-align: top; }
+                .button { display: inline-block; padding: 12px 18px; border-radius: 999px; background: #17324d; color: #ffffff !important; font-weight: 700; text-decoration: none; }
+                .footer { margin-top: 18px; color: #746b61; font-size: 12px; text-align: center; }
+                .footer a { color: #746b61; font-weight: 700; }
+              </style>
+            </head>
+            <body>
+              <div class="wrap">
+                <div class="card">
+                  <div class="hero">
+                    <div class="eyebrow">{{encodedEyebrow}}</div>
+                    <h1>{{encodedTitle}}</h1>
+                    <p>{{encodedIntro}}</p>
+                  </div>
+                  <div class="message-main">
+                    {{contentHtml}}
+                  </div>
+                </div>
+                <div class="footer">Sent with <a href="https://glovelly.net">Glovelly</a></div>
+              </div>
+            </body>
+            </html>
+            """;
+    }
+
+    public static string PlainTextToHtml(string text)
+    {
+        var normalized = text.ReplaceLineEndings("\n").Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return string.Empty;
+        }
+
+        var paragraphs = normalized.Split("\n\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return string.Join(
+            Environment.NewLine,
+            paragraphs.Select(paragraph =>
+                $"<p>{Encode(paragraph).Replace("\n", "<br>", StringComparison.Ordinal)}</p>"));
+    }
+
+    public static string Encode(string? value)
+    {
+        return WebUtility.HtmlEncode(value ?? string.Empty);
+    }
+}

--- a/backend/Glovelly.Api/Services/EmailSenderSupport.cs
+++ b/backend/Glovelly.Api/Services/EmailSenderSupport.cs
@@ -4,6 +4,7 @@ internal enum EmailUseCase
 {
     AccessRequests,
     Invoices,
+    UserInvitations,
 }
 
 internal static class EmailSenderSupport
@@ -67,6 +68,7 @@ internal static class EmailSenderSupport
         {
             EmailUseCase.AccessRequests => settings.AccessRequests,
             EmailUseCase.Invoices => settings.Invoices,
+            EmailUseCase.UserInvitations => settings.UserInvitations,
             _ => throw new ArgumentOutOfRangeException(nameof(useCase)),
         };
     }

--- a/backend/Glovelly.Api/Services/EmailSettings.cs
+++ b/backend/Glovelly.Api/Services/EmailSettings.cs
@@ -6,6 +6,7 @@ public sealed class EmailSettings
     public long MaxTotalAttachmentBytes { get; set; } = 25 * 1024 * 1024;
     public EmailSenderIdentitySettings AccessRequests { get; set; } = new();
     public EmailSenderIdentitySettings Invoices { get; set; } = new();
+    public EmailSenderIdentitySettings UserInvitations { get; set; } = new();
     public ResendEmailSettings Resend { get; set; } = new();
 }
 

--- a/backend/Glovelly.Api/Services/InvoiceEmailTemplateRenderer.cs
+++ b/backend/Glovelly.Api/Services/InvoiceEmailTemplateRenderer.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using Glovelly.Api.Models;
@@ -128,69 +127,33 @@ public static partial class InvoiceEmailTemplateRenderer
         string? additionalMessage,
         bool includeReceipts)
     {
-        var bodyHtml = PlainTextToHtml(resolvedBody);
+        var bodyHtml = EmailHtmlRenderer.PlainTextToHtml(resolvedBody);
         var additionalMessageHtml = string.IsNullOrWhiteSpace(additionalMessage)
             ? string.Empty
             : $"""
                 <div class="additional-message">
                   <p class="section-label">Additional message</p>
-                  {PlainTextToHtml(additionalMessage.Trim())}
+                  {EmailHtmlRenderer.PlainTextToHtml(additionalMessage.Trim())}
                 </div>
                 """;
         var receiptNote = includeReceipts
             ? "<p>Expense receipts are attached in a separate ZIP file.</p>"
             : string.Empty;
 
-        return $$"""
-            <!doctype html>
-            <html lang="en">
-            <head>
-              <meta charset="utf-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1">
-              <style>
-                body { margin: 0; padding: 0; background: #f6f3ee; color: #202020; font-family: Arial, sans-serif; }
-                .wrap { max-width: 640px; margin: 0 auto; padding: 32px 20px; }
-                .card { background: #ffffff; border: 1px solid #e5ded2; border-radius: 16px; padding: 28px; }
-                .content p { margin: 0 0 16px; line-height: 1.55; }
-                .attachment-note, .additional-message { margin-top: 24px; padding: 16px; background: #fbf8f2; border-radius: 12px; }
-                .section-label { margin: 0 0 8px; color: #6c5f50; font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
-                .footer { margin-top: 18px; color: #746b61; font-size: 12px; text-align: center; }
-                .footer a { color: #746b61; font-weight: 700; }
-              </style>
-            </head>
-            <body>
-              <div class="wrap">
-                <div class="card">
-                  <div class="content">
+        return EmailHtmlRenderer.RenderDocument(
+            $"Invoice {invoice.InvoiceNumber}",
+            "Your invoice is attached as a PDF.",
+            $$"""
+                  <div class="message-copy">
                     {{bodyHtml}}
                   </div>
                   <div class="attachment-note">
                     <p class="section-label">Attachment</p>
-                    <p>Invoice {{WebUtility.HtmlEncode(invoice.InvoiceNumber)}} is attached as a PDF.</p>
+                    <p>Invoice {{EmailHtmlRenderer.Encode(invoice.InvoiceNumber)}} is attached as a PDF.</p>
                     {{receiptNote}}
                   </div>
                   {{additionalMessageHtml}}
-                </div>
-                <div class="footer">Sent with <a href="https://glovelly.net">Glovelly</a></div>
-              </div>
-            </body>
-            </html>
-            """;
-    }
-
-    private static string PlainTextToHtml(string text)
-    {
-        var normalized = text.ReplaceLineEndings("\n").Trim();
-        if (string.IsNullOrWhiteSpace(normalized))
-        {
-            return string.Empty;
-        }
-
-        var paragraphs = normalized.Split("\n\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return string.Join(
-            Environment.NewLine,
-            paragraphs.Select(paragraph =>
-                $"<p>{WebUtility.HtmlEncode(paragraph).Replace("\n", "<br>", StringComparison.Ordinal)}</p>"));
+            """);
     }
 
     private static string ResolveTokens(

--- a/docs/uat/enrolment.md
+++ b/docs/uat/enrolment.md
@@ -66,14 +66,19 @@ Saved defaults are reused in later client, gig, or invoice workflows where expec
 ### Steps
 
 1. Open Admin as an administrator.
-2. Create or edit a user record.
-3. Toggle active state or role.
-4. Save.
-5. Confirm the user list updates.
+2. Create a user record and leave `Email this user an invitation to sign in` checked.
+3. Save.
+4. Confirm the user list updates and the status confirms the invitation was sent.
+5. Create another user record and clear `Email this user an invitation to sign in`.
+6. Save.
+7. Confirm the user list updates without an invitation-sent status.
+8. Edit a user record.
+9. Toggle active state or role.
+10. Save.
 
 ### Expected Results
 
-Admin changes persist and non-admin users cannot access admin workflows.
+Admin changes persist and non-admin users cannot access admin workflows. New users can be invited by email during enrolment, and admins can choose not to send the invitation when needed.
 
 ## Inactive User Deletion
 

--- a/frontend/glovelly-web/src/components/AdminSection.tsx
+++ b/frontend/glovelly-web/src/components/AdminSection.tsx
@@ -344,6 +344,19 @@ export function AdminSection({
                 />
                 <span>Account is active and allowed to sign in</span>
               </label>
+
+              {adminMode === 'create' ? (
+                <label className="checkbox-field full-width">
+                  <input
+                    type="checkbox"
+                    checked={adminForm.sendInvitationEmail}
+                    onChange={(event) =>
+                      onUpdateField('sendInvitationEmail', event.target.checked)
+                    }
+                  />
+                  <span>Email this user an invitation to sign in</span>
+                </label>
+              ) : null}
             </div>
 
             <div className="form-actions">

--- a/frontend/glovelly-web/src/forms.ts
+++ b/frontend/glovelly-web/src/forms.ts
@@ -26,6 +26,7 @@ export const emptyAdminForm = (): AdminUserForm => ({
   googleSubject: '',
   role: 'User',
   isActive: true,
+  sendInvitationEmail: true,
 })
 
 export const emptyUserSettingsForm = (): UserSettingsForm => ({

--- a/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
@@ -30,6 +30,7 @@ function toEditableAdminForm(user: AdminUser): AdminUserForm {
     googleSubject: user.googleSubject ?? '',
     role: user.role === 'Admin' ? 'Admin' : 'User',
     isActive: user.isActive,
+    sendInvitationEmail: false,
   }
 }
 
@@ -247,6 +248,7 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
       googleSubject: adminForm.googleSubject.trim(),
       role: adminForm.role,
       isActive: adminForm.isActive,
+      sendInvitationEmail: adminForm.sendInvitationEmail,
     }
 
     if (!payload.email) {
@@ -306,9 +308,43 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
         googleSubject: savedUser.googleSubject ?? '',
         role: savedUser.role === 'Admin' ? 'Admin' : 'User',
         isActive: savedUser.isActive,
+        sendInvitationEmail: false,
       })
-      setAdminStatus(isEdit ? 'User updated.' : 'User added.')
       setIsAdminEditorOpen(!closeAfterSave)
+
+      if (!isEdit && payload.sendInvitationEmail) {
+        try {
+          const invitationResponse = await fetchWithSession(
+            buildApiUrl(`/admin/users/${savedUser.id}/invitation-email`),
+            { method: 'POST' }
+          )
+
+          if (
+            handleSessionExpired(
+              invitationResponse,
+              onSessionExpired,
+              'Your session expired. Sign in again to keep managing access.'
+            )
+          ) {
+            return
+          }
+
+          if (!invitationResponse.ok) {
+            throw new Error(
+              await getResponseErrorMessage(
+                invitationResponse,
+                'Unable to send invitation email.'
+              )
+            )
+          }
+
+          setAdminStatus('User added and invitation sent.')
+        } catch {
+          setAdminStatus('User added, but the invitation email could not be sent.')
+        }
+      } else {
+        setAdminStatus(isEdit ? 'User updated.' : 'User added.')
+      }
     } catch (error) {
       setAdminStatus(
         error instanceof Error ? error.message : 'Unable to save right now.'

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -80,6 +80,7 @@ export type AdminUserForm = {
   googleSubject: string
   role: 'Admin' | 'User'
   isActive: boolean
+  sendInvitationEmail: boolean
 }
 
 export type AdminSortKey =


### PR DESCRIPTION
## Summary
- add an admin invitation-email endpoint for enrolled users
- add a checked-by-default invitation checkbox to the admin create-user flow
- configure invitation sender settings for tests, local examples, and Cloud Run
- update enrolment UAT docs

## Tests
- dotnet test glovelly.sln -m:1 --filter FullyQualifiedName~AdminEndpointsTests
- dotnet test glovelly.sln -m:1
- npm --prefix frontend/glovelly-web run lint
- npm --prefix frontend/glovelly-web run build

Closes #126