### PR TITLE
Fix flaky invoice line items UAT helper

### DIFF
--- a/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
@@ -116,8 +116,17 @@ public abstract class InvoiceUatTestBase : UatTestBase
 
     protected async Task OpenInvoiceLinesAsync()
     {
-        await Page.GetByTestId("invoice-line-items-button").ClickAsync();
-        await Page.GetByTestId("invoice-line-item").First.WaitForAsync(new LocatorWaitForOptions
+        var lineItemsButton = Page.GetByTestId("invoice-line-items-button");
+        if (await lineItemsButton.GetAttributeAsync("aria-expanded") != "true")
+        {
+            await lineItemsButton.ClickAsync();
+        }
+
+        await Assertions.Expect(lineItemsButton).ToHaveAttributeAsync("aria-expanded", "true", new LocatorAssertionsToHaveAttributeOptions
+        {
+            Timeout = 30_000,
+        });
+        await VisibleInvoiceLines().First.WaitForAsync(new LocatorWaitForOptions
         {
             State = WaitForSelectorState.Visible,
             Timeout = 30_000,
@@ -151,7 +160,7 @@ public abstract class InvoiceUatTestBase : UatTestBase
 
     protected async Task AssertInvoiceLineTypeCountAsync(string expectedType, int expectedCount)
     {
-        await Assertions.Expect(Page.GetByTestId("invoice-line-type").Filter(new LocatorFilterOptions
+        await Assertions.Expect(Page.Locator("[data-testid=\"invoice-line-type\"]:visible").Filter(new LocatorFilterOptions
         {
             HasTextRegex = new System.Text.RegularExpressions.Regex($"^{System.Text.RegularExpressions.Regex.Escape(expectedType)}$")
         })).ToHaveCountAsync(expectedCount, new LocatorAssertionsToHaveCountOptions
@@ -283,7 +292,9 @@ public abstract class InvoiceUatTestBase : UatTestBase
 
     protected ILocator ExpenseRowAt(int index) => Page.GetByTestId("gig-expense-item").Nth(index);
 
-    private ILocator InvoiceLine(string expectedText) => Page.GetByTestId("invoice-line-item").Filter(new LocatorFilterOptions
+    private ILocator VisibleInvoiceLines() => Page.Locator("[data-testid=\"invoice-line-item\"]:visible");
+
+    private ILocator InvoiceLine(string expectedText) => VisibleInvoiceLines().Filter(new LocatorFilterOptions
     {
         HasText = expectedText,
     });


### PR DESCRIPTION
## Summary
- make the invoice line-items UAT helper open the pane only when it is closed
- wait for the line-items toggle to report aria-expanded=true
- scope invoice line assertions to visible rows so hidden pane content is ignored

## Tests
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj

The affected UAT test could not be run locally without GLOVELLY_UAT_BASE_URL, but the failure mode matches the helper closing an already-open toggle pane.