### PR TITLE
Add gig import safeguards and real-time workspace refresh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,6 +226,8 @@ jobs:
           flags: >-
             --allow-unauthenticated
             --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+            --timeout=3600s
+            --max-instances=1
 
       - name: Show staging URL
         run: echo "Deployed staging to ${{ steps.deploy_staging.outputs.url }}"
@@ -355,6 +357,8 @@ jobs:
           flags: >-
             --allow-unauthenticated
             --service-account=glovelly-runner@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+            --timeout=3600s
+            --max-instances=1
 
       - name: Show production URL
         run: echo "Deployed production to ${{ steps.deploy_production.outputs.url }}"

--- a/backend/Glovelly.Api.Tests/GigImportEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigImportEndpointsTests.cs
@@ -12,6 +12,7 @@ namespace Glovelly.Api.Tests;
 
 public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
 {
+    private static readonly Guid OtherClientId = Guid.Parse("33333333-3333-3333-3333-333333333333");
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private readonly GlovellyApiFactory _factory;
     private readonly HttpClient _client;
@@ -117,7 +118,140 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(GigImportBatchStatus.Draft, await db.GigImportBatches.Where(value => value.Id == batchId).Select(value => value.Status).SingleAsync(TestContext.Current.CancellationToken));
     }
 
-    private async Task SeedImportBatchAsync(Guid batchId, Guid draftId, bool includeRequiredFields = true)
+    [Fact]
+    public async Task GetBatch_WithSameDateAndVenueExistingGig_ReturnsDuplicateWarning()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        await SeedExistingGigAsync("Different show", new DateOnly(2026, 11, 28), "Music Hall, Aberdeen, AB10 1AA", OtherClientId);
+        await SeedImportBatchAsync(batchId, draftId);
+
+        var response = await _client.GetAsync($"/gig-imports/{batchId}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var warnings = await ReadSingleDraftWarningsAsync(response);
+        Assert.Contains(warnings, warning => warning == "Possible duplicate: existing gig found on 2026-11-28 at Music Hall, Aberdeen, AB10 1AA.");
+    }
+
+    [Fact]
+    public async Task GetBatch_WithSameClientAndDateExistingGig_ReturnsDuplicateWarning()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        await SeedExistingGigAsync("Different show", new DateOnly(2026, 11, 28), "Other venue", TestData.FoxAndFinchId);
+        await SeedImportBatchAsync(batchId, draftId);
+
+        var response = await _client.GetAsync($"/gig-imports/{batchId}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var warnings = await ReadSingleDraftWarningsAsync(response);
+        Assert.Contains(warnings, warning => warning == "Possible duplicate: existing gig found for this client on 2026-11-28.");
+    }
+
+    [Fact]
+    public async Task GetBatch_WithSimilarTitleAndDateExistingGig_ReturnsDuplicateWarning()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        await SeedExistingGigAsync("Swing into Christmas", new DateOnly(2026, 11, 28), "Other venue", OtherClientId);
+        await SeedImportBatchAsync(batchId, draftId);
+
+        var response = await _client.GetAsync($"/gig-imports/{batchId}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var warnings = await ReadSingleDraftWarningsAsync(response);
+        Assert.Contains(warnings, warning => warning == "Possible duplicate: similar existing gig found on 2026-11-28: Swing into Christmas.");
+    }
+
+    [Fact]
+    public async Task GetBatch_WithPreviouslyImportedSourceFingerprint_ReturnsDuplicateWarning()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        await SeedPriorImportBatchAsync("sha256:tour-bible");
+        await SeedImportBatchAsync(batchId, draftId, sourceFingerprint: "sha256:tour-bible");
+
+        var response = await _client.GetAsync($"/gig-imports/{batchId}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var warnings = await ReadSingleDraftWarningsAsync(response);
+        Assert.Contains(warnings, warning => warning == "Possible duplicate: this source fingerprint has been imported before.");
+    }
+
+    [Fact]
+    public async Task GetBatch_WithOtherUsersMatchingGig_DoesNotReturnDuplicateWarning()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        await SeedExistingGigAsync(
+            "Swing Into Christmas",
+            new DateOnly(2026, 11, 28),
+            "Music Hall, Aberdeen, AB10 1AA",
+            TestData.FoxAndFinchId,
+            TestAuthContext.AlternateUserId);
+        await SeedImportBatchAsync(batchId, draftId);
+
+        var response = await _client.GetAsync($"/gig-imports/{batchId}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var warnings = await ReadSingleDraftWarningsAsync(response);
+        Assert.DoesNotContain(warnings, warning => warning.StartsWith("Possible duplicate:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task UpdateDraft_WhenEditedIntoDuplicate_ReturnsUpdatedWarning()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        await SeedExistingGigAsync("Different show", new DateOnly(2026, 12, 8), "Bath Forum", OtherClientId);
+        await SeedImportBatchAsync(batchId, draftId);
+
+        var response = await _client.PutAsJsonAsync($"/gig-imports/{batchId}/drafts/{draftId}", new
+        {
+            proposedClientId = TestData.FoxAndFinchId,
+            clientName = "Fox & Finch",
+            title = "Edited row",
+            date = "2026-12-08",
+            venueName = "Bath Forum",
+            venueAddress = (string?)null,
+            postcode = (string?)null,
+            fee = 250m,
+            perDiem = 30m,
+            confidence = "High",
+            warnings = Array.Empty<string>(),
+            status = "Pending",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        var warnings = payload.GetProperty("warnings").EnumerateArray().Select(value => value.GetString()).ToArray();
+        Assert.Contains("Possible duplicate: existing gig found on 2026-12-08 at Bath Forum.", warnings);
+    }
+
+    [Fact]
+    public async Task CommitAcceptedRows_WithDuplicateWarning_StillCreatesGig()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        await SeedExistingGigAsync("Different show", new DateOnly(2026, 11, 28), "Music Hall, Aberdeen, AB10 1AA", OtherClientId);
+        await SeedImportBatchAsync(batchId, draftId);
+
+        var response = await _client.PostAsJsonAsync($"/gig-imports/{batchId}/commit", new
+        {
+            draftIds = Array.Empty<Guid>(),
+            commitAccepted = true,
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(1, payload.GetProperty("createdCount").GetInt32());
+    }
+
+    private async Task SeedImportBatchAsync(
+        Guid batchId,
+        Guid draftId,
+        bool includeRequiredFields = true,
+        string? sourceFingerprint = null)
     {
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -126,6 +260,7 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             Id = batchId,
             SourceName = "Swing Into Christmas 2026",
+            SourceFingerprint = sourceFingerprint,
             Status = GigImportBatchStatus.Draft,
             CreatedAtUtc = new DateTimeOffset(2026, 5, 20, 10, 0, 0, TimeSpan.Zero),
             CreatedByUserId = TestAuthContext.UserId,
@@ -150,6 +285,63 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         });
 
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task SeedExistingGigAsync(
+        string title,
+        DateOnly date,
+        string venue,
+        Guid clientId,
+        Guid? createdByUserId = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        db.Gigs.Add(new Gig
+        {
+            Id = Guid.NewGuid(),
+            ClientId = clientId,
+            CreatedByUserId = createdByUserId ?? TestAuthContext.UserId,
+            UpdatedByUserId = createdByUserId ?? TestAuthContext.UserId,
+            Title = title,
+            Date = date,
+            Venue = venue,
+            Fee = 200m,
+            TravelMiles = 0m,
+            WasDriving = false,
+            Status = GigStatus.Confirmed,
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task SeedPriorImportBatchAsync(string sourceFingerprint)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        db.GigImportBatches.Add(new GigImportBatch
+        {
+            Id = Guid.NewGuid(),
+            SourceName = "Earlier tour bible",
+            SourceFingerprint = sourceFingerprint,
+            Status = GigImportBatchStatus.Committed,
+            CreatedAtUtc = new DateTimeOffset(2026, 5, 19, 10, 0, 0, TimeSpan.Zero),
+            CreatedByUserId = TestAuthContext.UserId,
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<string[]> ReadSingleDraftWarningsAsync(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        return payload
+            .GetProperty("drafts")[0]
+            .GetProperty("warnings")
+            .EnumerateArray()
+            .Select(value => value.GetString()!)
+            .ToArray();
     }
 
     private async Task SeedImportBatchWithDecisionStatesAsync(

--- a/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
+++ b/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
@@ -315,6 +315,8 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
 
         var lines = invoice.GetProperty("lines").EnumerateArray().OrderBy(line => line.GetProperty("sortOrder").GetInt32()).ToArray();
         Assert.Equal(2, lines.Length);
+        Assert.Equal(1, lines[0].GetProperty("sortOrder").GetInt32());
+        Assert.Equal(2, lines[1].GetProperty("sortOrder").GetInt32());
         Assert.Contains("First date gig (2026-05-10)", lines[0].GetProperty("description").GetString());
         Assert.Contains("Second date gig (2026-05-20)", lines[1].GetProperty("description").GetString());
 

--- a/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
@@ -306,8 +306,9 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var message = Assert.Single(_factory.Emails.SentEmails);
+        var dueDate = invoice.GetProperty("dueDate").GetString();
         Assert.Contains("Hello Fox & Finch Events,", message.PlainTextBody);
-        Assert.Contains("Invoice GLV-BODY-001 is due on 2026-06-26.", message.PlainTextBody);
+        Assert.Contains($"Invoice GLV-BODY-001 is due on {dueDate}.", message.PlainTextBody);
         Assert.Contains("Test Admin", message.PlainTextBody);
         Assert.Contains("Additional message:", message.PlainTextBody);
         Assert.Contains("One-off note.", message.PlainTextBody);

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ internal static class InfrastructureServiceCollectionExtensions
         services.AddSingleton(settings);
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen();
+        services.AddSignalR();
         services.AddOptions<EmailSettings>()
             .Bind(configuration.GetSection("Email"));
         services.AddOptions<AccessRequestProtectionSettings>()
@@ -46,6 +47,7 @@ internal static class InfrastructureServiceCollectionExtensions
             options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
         });
         services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
+        services.AddScoped<IWorkspaceEventPublisher, WorkspaceEventPublisher>();
         services.AddScoped<IGlovellyMcpQueryService, GlovellyMcpQueryService>();
         services.AddScoped<IMcpOAuthService, McpOAuthService>();
         services.AddScoped<IClaimsTransformation, GoogleOidcClaimsTransformation>();

--- a/backend/Glovelly.Api/Endpoints/GigAttachmentEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigAttachmentEndpoints.cs
@@ -35,6 +35,7 @@ internal static class GigAttachmentEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IExpenseAttachmentStore attachmentStore,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IOptions<ExpenseAttachmentSettings> attachmentOptions) =>
         {
             if (!request.HasFormContentType)
@@ -80,7 +81,12 @@ internal static class GigAttachmentEndpoints
             };
 
             db.ExpenseAttachments.Add(attachment);
+            if (expense.Gig is not null)
+            {
+                EndpointSupport.StampUpdate(expense.Gig, userId);
+            }
             await db.SaveChangesAsync();
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gigId, DateTimeOffset.UtcNow));
 
             return Results.Created($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachment.Id}", attachment);
         });
@@ -123,6 +129,7 @@ internal static class GigAttachmentEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IExpenseAttachmentStore attachmentStore) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -133,8 +140,13 @@ internal static class GigAttachmentEndpoints
             }
 
             await attachmentStore.DeleteAsync(attachment.StorageKey);
+            if (attachment.Expense?.Gig is not null)
+            {
+                EndpointSupport.StampUpdate(attachment.Expense.Gig, userId);
+            }
             db.ExpenseAttachments.Remove(attachment);
             await db.SaveChangesAsync();
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gigId, DateTimeOffset.UtcNow));
 
             return Results.NoContent();
         });

--- a/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
@@ -45,6 +45,7 @@ internal static class GigCrudEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             ICalendarSyncWorkQueue calendarSyncWorkQueue) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -69,6 +70,7 @@ internal static class GigCrudEndpoints
             await db.SaveChangesAsync();
             if (userId.HasValue)
             {
+                await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gig.Id, DateTimeOffset.UtcNow));
                 await calendarSyncWorkQueue.EnqueueGigAsync(
                     userId.Value,
                     gig.Id,
@@ -86,6 +88,7 @@ internal static class GigCrudEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IInvoiceWorkflowService invoiceWorkflowService,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             ICalendarSyncWorkQueue calendarSyncWorkQueue) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -135,6 +138,7 @@ internal static class GigCrudEndpoints
             await db.SaveChangesAsync();
             if (userId.HasValue)
             {
+                await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "created", gig.Id, DateTimeOffset.UtcNow));
                 await calendarSyncWorkQueue.EnqueueGigAsync(
                     userId.Value,
                     gig.Id,
@@ -152,6 +156,7 @@ internal static class GigCrudEndpoints
             ICurrentUserAccessor currentUserAccessor,
             IExpenseAttachmentStore attachmentStore,
             IInvoiceWorkflowService invoiceWorkflowService,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             ICalendarSyncWorkQueue calendarSyncWorkQueue) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -259,6 +264,7 @@ internal static class GigCrudEndpoints
                 .FirstAsync(value => value.Id == id);
             if (userId.HasValue)
             {
+                await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gig.Id, DateTimeOffset.UtcNow));
                 await calendarSyncWorkQueue.EnqueueGigAsync(
                     userId.Value,
                     gig.Id,
@@ -277,6 +283,7 @@ internal static class GigCrudEndpoints
             ICurrentUserAccessor currentUserAccessor,
             IExpenseAttachmentStore attachmentStore,
             IInvoiceWorkflowService invoiceWorkflowService,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             ICalendarSyncWorkQueue calendarSyncWorkQueue) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -310,6 +317,7 @@ internal static class GigCrudEndpoints
             await db.SaveChangesAsync();
             if (userId.HasValue)
             {
+                await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "deleted", id, DateTimeOffset.UtcNow));
                 await calendarSyncWorkQueue.EnqueueGigAsync(
                     userId.Value,
                     id,

--- a/backend/Glovelly.Api/Endpoints/GigExpenseEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigExpenseEndpoints.cs
@@ -1,6 +1,7 @@
 using Glovelly.Api.Auth;
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
+using Glovelly.Api.Services;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 
@@ -15,6 +16,7 @@ internal static class GigExpenseEndpoints
             GigExpenseReimbursementUpdateRequest request,
             AppDbContext db,
             ClaimsPrincipal user,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             ICurrentUserAccessor currentUserAccessor) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -92,6 +94,7 @@ internal static class GigExpenseEndpoints
 
             EndpointSupport.StampUpdate(gig, userId);
             await db.SaveChangesAsync();
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gigId, DateTimeOffset.UtcNow));
 
             var savedGig = await db.Gigs
                 .WhereVisibleTo(userId)

--- a/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
@@ -65,6 +65,7 @@ internal static class GigImportEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IGigImportDuplicateDetectionService duplicateDetectionService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -126,6 +127,7 @@ internal static class GigImportEndpoints
                 JsonOptions);
 
             await db.SaveChangesAsync();
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gig-imports", "updated", batchId, DateTimeOffset.UtcNow));
 
             var duplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
                 userId,
@@ -187,6 +189,7 @@ internal static class GigImportEndpoints
                 UpdateBatchStatusAfterCommittedDecisions(batch);
 
                 await db.SaveChangesAsync();
+                await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gig-imports", "updated", batch.Id, DateTimeOffset.UtcNow));
 
                 var duplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
                     userId,
@@ -218,6 +221,7 @@ internal static class GigImportEndpoints
 
             await db.SaveChangesAsync();
             await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "created", null, DateTimeOffset.UtcNow));
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gig-imports", "updated", batch.Id, DateTimeOffset.UtcNow));
 
             var remainingDuplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
                 userId,

--- a/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Glovelly.Api.Auth;
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
+using Glovelly.Api.Services;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 
@@ -34,7 +35,8 @@ internal static class GigImportEndpoints
             Guid batchId,
             AppDbContext db,
             ClaimsPrincipal user,
-            ICurrentUserAccessor currentUserAccessor) =>
+            ICurrentUserAccessor currentUserAccessor,
+            IGigImportDuplicateDetectionService duplicateDetectionService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var batch = await db.GigImportBatches
@@ -43,7 +45,17 @@ internal static class GigImportEndpoints
                 .Include(value => value.Drafts)
                 .FirstOrDefaultAsync(value => value.Id == batchId);
 
-            return batch is null ? Results.NotFound() : Results.Ok(ToDetail(batch));
+            if (batch is null)
+            {
+                return Results.NotFound();
+            }
+
+            var duplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
+                userId,
+                batch,
+                batch.Drafts.ToList());
+
+            return Results.Ok(ToDetail(batch, duplicateWarnings));
         });
 
         group.MapPut("/{batchId:guid}/drafts/{draftId:guid}", async (
@@ -52,7 +64,8 @@ internal static class GigImportEndpoints
             GigImportDraftUpdateRequest request,
             AppDbContext db,
             ClaimsPrincipal user,
-            ICurrentUserAccessor currentUserAccessor) =>
+            ICurrentUserAccessor currentUserAccessor,
+            IGigImportDuplicateDetectionService duplicateDetectionService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var draft = await db.GigImportDrafts
@@ -108,11 +121,18 @@ internal static class GigImportEndpoints
             draft.TravelNotes = Normalize(request.TravelNotes);
             draft.SourceReference = Normalize(request.SourceReference);
             draft.Confidence = request.Confidence ?? draft.Confidence;
-            draft.WarningsJson = JsonSerializer.Serialize(request.Warnings ?? ReadWarnings(draft.WarningsJson), JsonOptions);
+            draft.WarningsJson = JsonSerializer.Serialize(
+                PersistedWarnings(request.Warnings ?? ReadWarnings(draft.WarningsJson)),
+                JsonOptions);
 
             await db.SaveChangesAsync();
 
-            return Results.Ok(ToDraftDetail(draft));
+            var duplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
+                userId,
+                draft.Batch,
+                [draft]);
+
+            return Results.Ok(ToDraftDetail(draft, duplicateWarnings));
         });
 
         group.MapPost("/{batchId:guid}/commit", async (
@@ -120,7 +140,8 @@ internal static class GigImportEndpoints
             GigImportCommitRequest request,
             AppDbContext db,
             ClaimsPrincipal user,
-            ICurrentUserAccessor currentUserAccessor) =>
+            ICurrentUserAccessor currentUserAccessor,
+            IGigImportDuplicateDetectionService duplicateDetectionService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var batch = await db.GigImportBatches
@@ -166,10 +187,15 @@ internal static class GigImportEndpoints
 
                 await db.SaveChangesAsync();
 
+                var duplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
+                    userId,
+                    batch,
+                    batch.Drafts.ToList());
+
                 return Results.Ok(new GigImportCommitResult(
                     0,
                     [],
-                    ToDetail(batch)));
+                    ToDetail(batch, duplicateWarnings)));
             }
 
             var errors = await ValidateCommitDraftsAsync(db, userId, draftsToCommit);
@@ -191,10 +217,15 @@ internal static class GigImportEndpoints
 
             await db.SaveChangesAsync();
 
+            var remainingDuplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
+                userId,
+                batch,
+                batch.Drafts.ToList());
+
             return Results.Ok(new GigImportCommitResult(
                 gigs.Count,
                 gigs.Select(gig => gig.Id).ToList(),
-                ToDetail(batch)));
+                ToDetail(batch, remainingDuplicateWarnings)));
         });
 
         return app;
@@ -403,7 +434,9 @@ internal static class GigImportEndpoints
             batch.Drafts.Count(draft => draft.Confidence == GigImportDraftConfidence.High));
     }
 
-    private static GigImportBatchDetailDto ToDetail(GigImportBatch batch)
+    private static GigImportBatchDetailDto ToDetail(
+        GigImportBatch batch,
+        IReadOnlyDictionary<Guid, IReadOnlyList<string>>? duplicateWarnings = null)
     {
         return new GigImportBatchDetailDto(
             ToSummary(batch),
@@ -411,7 +444,7 @@ internal static class GigImportEndpoints
                 .OrderBy(draft => IsHandledForOrdering(batch, draft))
                 .ThenBy(draft => draft.ProposedDate ?? DateOnly.MaxValue)
                 .ThenBy(draft => draft.ProposedTitle)
-                .Select(ToDraftDetail)
+                .Select(draft => ToDraftDetail(draft, duplicateWarnings))
                 .ToList());
     }
 
@@ -421,8 +454,12 @@ internal static class GigImportEndpoints
             (batch.Status != GigImportBatchStatus.Draft && draft.Status == GigImportDraftStatus.Rejected);
     }
 
-    private static GigImportDraftDetailDto ToDraftDetail(GigImportDraft draft)
+    private static GigImportDraftDetailDto ToDraftDetail(
+        GigImportDraft draft,
+        IReadOnlyDictionary<Guid, IReadOnlyList<string>>? duplicateWarnings = null)
     {
+        var warnings = CombinedWarnings(draft, duplicateWarnings);
+
         return new GigImportDraftDetailDto(
             draft.Id,
             draft.BatchId,
@@ -448,9 +485,28 @@ internal static class GigImportEndpoints
             draft.TravelNotes,
             draft.SourceReference,
             draft.Confidence.ToString(),
-            ReadWarnings(draft.WarningsJson),
+            warnings,
             draft.Status.ToString(),
             MissingFields(draft));
+    }
+
+    private static IReadOnlyList<string> CombinedWarnings(
+        GigImportDraft draft,
+        IReadOnlyDictionary<Guid, IReadOnlyList<string>>? duplicateWarnings)
+    {
+        var warnings = PersistedWarnings(ReadWarnings(draft.WarningsJson)).ToList();
+        if (duplicateWarnings?.TryGetValue(draft.Id, out var generatedWarnings) == true)
+        {
+            foreach (var warning in generatedWarnings)
+            {
+                if (!warnings.Contains(warning, StringComparer.Ordinal))
+                {
+                    warnings.Add(warning);
+                }
+            }
+        }
+
+        return warnings;
     }
 
     private static IReadOnlyList<string> MissingFields(GigImportDraft draft)
@@ -489,6 +545,15 @@ internal static class GigImportEndpoints
         {
             return [];
         }
+    }
+
+    private static IReadOnlyList<string> PersistedWarnings(IReadOnlyList<string> warnings)
+    {
+        return warnings
+            .Where(warning => !warning.StartsWith(GigImportDuplicateDetectionService.GeneratedWarningPrefix, StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .Take(25)
+            .ToList();
     }
 
     private static bool CanSee(GigImportBatch batch, Guid? userId)

--- a/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
@@ -141,6 +141,7 @@ internal static class GigImportEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IGigImportDuplicateDetectionService duplicateDetectionService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -216,6 +217,7 @@ internal static class GigImportEndpoints
             UpdateBatchStatusAfterCommittedDecisions(batch);
 
             await db.SaveChangesAsync();
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "created", null, DateTimeOffset.UtcNow));
 
             var remainingDuplicateWarnings = await duplicateDetectionService.FindWarningsAsync(
                 userId,

--- a/backend/Glovelly.Api/Endpoints/GigInvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigInvoiceEndpoints.cs
@@ -14,10 +14,19 @@ internal static class GigInvoiceEndpoints
             GenerateInvoiceFromGigSelectionRequest request,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IInvoiceWorkflowService invoiceWorkflowService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var result = await invoiceWorkflowService.GenerateInvoiceFromGigSelectionAsync(request.GigIds, userId);
+
+            if (result.Status is GenerateInvoiceFromGigSelectionStatus.Created)
+            {
+                foreach (var gigId in request.GigIds.Where(value => value != Guid.Empty).Distinct())
+                {
+                    await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gigId, DateTimeOffset.UtcNow));
+                }
+            }
 
             return result.Status switch
             {
@@ -39,6 +48,7 @@ internal static class GigInvoiceEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IInvoiceWorkflowService invoiceWorkflowService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -70,6 +80,7 @@ internal static class GigInvoiceEndpoints
 
             var invoice = await invoiceWorkflowService.GenerateInvoiceForGigAsync(gig, client, userId);
             await db.SaveChangesAsync();
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gig.Id, DateTimeOffset.UtcNow));
 
             return Results.Created($"/invoices/{invoice.Id}", invoice);
         });

--- a/backend/Glovelly.Api/Endpoints/GigReceiptEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigReceiptEndpoints.cs
@@ -18,6 +18,7 @@ internal static class GigReceiptEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IExpenseAttachmentStore attachmentStore,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IOptions<ExpenseAttachmentSettings> attachmentOptions,
             IOptions<QuickReceiptCaptureSettings> quickReceiptOptions,
             TimeProvider timeProvider) =>
@@ -111,6 +112,7 @@ internal static class GigReceiptEndpoints
             db.GigExpenses.Add(expense);
             EndpointSupport.StampUpdate(gig, userId);
             await db.SaveChangesAsync();
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gig.Id, DateTimeOffset.UtcNow));
 
             var savedGig = await db.Gigs
                 .WhereVisibleTo(userId)
@@ -138,6 +140,7 @@ internal static class GigReceiptEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             IInvoiceWorkflowService invoiceWorkflowService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -214,6 +217,10 @@ internal static class GigReceiptEndpoints
             }
 
             await db.SaveChangesAsync();
+            foreach (var affectedGigId in affectedGigIds)
+            {
+                await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", affectedGigId, DateTimeOffset.UtcNow));
+            }
 
             var savedGigs = await db.Gigs
                 .WhereVisibleTo(userId)

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -398,6 +398,7 @@ public static class InvoiceEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IInvoicePdfService invoicePdfService,
+            IWorkspaceEventPublisher workspaceEventPublisher,
             ILoggerFactory loggerFactory) =>
         {
             var logger = loggerFactory.CreateLogger("InvoiceEndpoints");
@@ -440,6 +441,10 @@ public static class InvoiceEndpoints
 
             db.Invoices.Remove(invoice);
             await db.SaveChangesAsync();
+            foreach (var gig in linkedGigs)
+            {
+                await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gig.Id, DateTimeOffset.UtcNow));
+            }
 
             return Results.NoContent();
         });

--- a/backend/Glovelly.Api/Hubs/WorkspaceEventsHub.cs
+++ b/backend/Glovelly.Api/Hubs/WorkspaceEventsHub.cs
@@ -1,0 +1,30 @@
+using Glovelly.Api.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Glovelly.Api.Hubs;
+
+[Authorize(Policy = GlovellyPolicies.GlovellyUser)]
+public sealed class WorkspaceEventsHub(ICurrentUserAccessor currentUserAccessor) : Hub
+{
+    public static string BuildUserGroupName(Guid userId) => $"user:{userId:N}";
+
+    public override async Task OnConnectedAsync()
+    {
+        if (Context.User is null)
+        {
+            Context.Abort();
+            return;
+        }
+
+        var userId = currentUserAccessor.TryGetUserId(Context.User);
+        if (!userId.HasValue)
+        {
+            Context.Abort();
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, BuildUserGroupName(userId.Value));
+        await base.OnConnectedAsync();
+    }
+}

--- a/backend/Glovelly.Api/Program.cs
+++ b/backend/Glovelly.Api/Program.cs
@@ -1,5 +1,6 @@
 using Glovelly.Api.Configuration;
 using Glovelly.Api.Endpoints;
+using Glovelly.Api.Hubs;
 
 var builder = WebApplication.CreateBuilder(args);
 var startupSettings = StartupSettings.From(builder.Configuration, builder.Environment);
@@ -27,6 +28,7 @@ app.MapInvoiceEmailTemplateEndpoints();
 app.MapCrudEndpoints();
 app.MapExpenseStatementEndpoints();
 app.MapAdminEndpoints();
+app.MapHub<WorkspaceEventsHub>("/workspace-events");
 app.MapFallbackToFile("index.html");
 
 app.Run();

--- a/backend/Glovelly.Api/Services/GigImportDuplicateDetectionService.cs
+++ b/backend/Glovelly.Api/Services/GigImportDuplicateDetectionService.cs
@@ -1,0 +1,240 @@
+using System.Text;
+using Glovelly.Api.Data;
+using Glovelly.Api.Endpoints;
+using Glovelly.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Glovelly.Api.Services;
+
+public sealed class GigImportDuplicateDetectionService(AppDbContext db) : IGigImportDuplicateDetectionService
+{
+    public const string GeneratedWarningPrefix = "Possible duplicate:";
+
+    private delegate string? GigDuplicateRule(GigImportDraft draft, GigCandidate gig);
+
+    private static readonly IReadOnlyList<GigDuplicateRule> GigRules =
+    [
+        SameDateAndVenue,
+        SameClientAndDate,
+        SameDateAndSimilarTitle,
+    ];
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<string>>> FindWarningsAsync(
+        Guid? userId,
+        GigImportBatch batch,
+        IReadOnlyList<GigImportDraft> drafts,
+        CancellationToken cancellationToken = default)
+    {
+        var warnings = drafts.ToDictionary(draft => draft.Id, _ => new List<string>());
+        var reviewDrafts = drafts
+            .Where(draft => draft.Status != GigImportDraftStatus.Committed)
+            .ToList();
+        if (reviewDrafts.Count == 0)
+        {
+            return ToResult(warnings);
+        }
+
+        await AddExistingGigWarningsAsync(userId, reviewDrafts, warnings, cancellationToken);
+        AddInBatchWarnings(reviewDrafts, warnings);
+        await AddSourceFingerprintWarningsAsync(userId, batch, reviewDrafts, warnings, cancellationToken);
+
+        return ToResult(warnings);
+    }
+
+    private async Task AddExistingGigWarningsAsync(
+        Guid? userId,
+        IReadOnlyList<GigImportDraft> drafts,
+        Dictionary<Guid, List<string>> warnings,
+        CancellationToken cancellationToken)
+    {
+        var dates = drafts
+            .Select(draft => draft.ProposedDate)
+            .Where(date => date.HasValue)
+            .Select(date => date!.Value)
+            .Distinct()
+            .ToList();
+
+        if (dates.Count == 0)
+        {
+            return;
+        }
+
+        var existingGigs = await db.Gigs
+            .WhereVisibleTo(userId)
+            .AsNoTracking()
+            .Where(gig => dates.Contains(gig.Date))
+            .Select(gig => new GigCandidate(gig.ClientId, gig.Date, gig.Title, gig.Venue))
+            .ToListAsync(cancellationToken);
+
+        foreach (var draft in drafts.Where(draft => draft.ProposedDate.HasValue))
+        {
+            foreach (var gig in existingGigs.Where(gig => gig.Date == draft.ProposedDate!.Value))
+            {
+                foreach (var rule in GigRules)
+                {
+                    var warning = rule(draft, gig);
+                    if (!string.IsNullOrWhiteSpace(warning))
+                    {
+                        AddWarning(warnings[draft.Id], warning);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void AddInBatchWarnings(
+        IReadOnlyList<GigImportDraft> drafts,
+        Dictionary<Guid, List<string>> warnings)
+    {
+        var groups = drafts
+            .Where(draft => draft.ProposedDate.HasValue)
+            .Select(draft => new
+            {
+                Draft = draft,
+                HasDuplicateSignal = !string.IsNullOrWhiteSpace(BuildVenue(draft)) ||
+                    !string.IsNullOrWhiteSpace(draft.ProposedTitle),
+                Key = $"{draft.ProposedDate!.Value:yyyy-MM-dd}|{NormalizeForComparison(BuildVenue(draft))}|{NormalizeForComparison(draft.ProposedTitle)}",
+            })
+            .Where(value => value.HasDuplicateSignal)
+            .GroupBy(value => value.Key)
+            .Where(group => group.Count() > 1);
+
+        foreach (var group in groups)
+        {
+            foreach (var value in group)
+            {
+                AddWarning(
+                    warnings[value.Draft.Id],
+                    $"{GeneratedWarningPrefix} another staged row has the same date, venue, and title.");
+            }
+        }
+    }
+
+    private async Task AddSourceFingerprintWarningsAsync(
+        Guid? userId,
+        GigImportBatch batch,
+        IReadOnlyList<GigImportDraft> drafts,
+        Dictionary<Guid, List<string>> warnings,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(batch.SourceFingerprint))
+        {
+            return;
+        }
+
+        var sourceSeenBefore = await db.GigImportBatches
+            .WhereVisibleTo(userId)
+            .AsNoTracking()
+            .AnyAsync(
+                other => other.Id != batch.Id &&
+                    other.SourceFingerprint == batch.SourceFingerprint &&
+                    other.Status != GigImportBatchStatus.Abandoned,
+                cancellationToken);
+
+        if (!sourceSeenBefore)
+        {
+            return;
+        }
+
+        foreach (var draft in drafts)
+        {
+            AddWarning(warnings[draft.Id], $"{GeneratedWarningPrefix} this source fingerprint has been imported before.");
+        }
+    }
+
+    private static string? SameDateAndVenue(GigImportDraft draft, GigCandidate gig)
+    {
+        var draftVenue = NormalizeForComparison(BuildVenue(draft));
+        var existingVenue = NormalizeForComparison(gig.Venue);
+        if (draftVenue.Length == 0 || existingVenue.Length == 0)
+        {
+            return null;
+        }
+
+        if (!existingVenue.Contains(draftVenue, StringComparison.Ordinal) &&
+            !draftVenue.Contains(existingVenue, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return $"{GeneratedWarningPrefix} existing gig found on {gig.Date:yyyy-MM-dd} at {gig.Venue}.";
+    }
+
+    private static string? SameClientAndDate(GigImportDraft draft, GigCandidate gig)
+    {
+        return draft.ProposedClientId == gig.ClientId
+            ? $"{GeneratedWarningPrefix} existing gig found for this client on {gig.Date:yyyy-MM-dd}."
+            : null;
+    }
+
+    private static string? SameDateAndSimilarTitle(GigImportDraft draft, GigCandidate gig)
+    {
+        var draftTitle = NormalizeForComparison(draft.ProposedTitle);
+        var existingTitle = NormalizeForComparison(gig.Title);
+        if (draftTitle.Length < 5 || existingTitle.Length < 5)
+        {
+            return null;
+        }
+
+        var titlesMatch = draftTitle == existingTitle ||
+            existingTitle.Contains(draftTitle, StringComparison.Ordinal) ||
+            draftTitle.Contains(existingTitle, StringComparison.Ordinal);
+
+        return titlesMatch
+            ? $"{GeneratedWarningPrefix} similar existing gig found on {gig.Date:yyyy-MM-dd}: {gig.Title}."
+            : null;
+    }
+
+    private static string BuildVenue(GigImportDraft draft)
+    {
+        return string.Join(", ", new[]
+        {
+            draft.ProposedVenueName,
+            draft.ProposedVenueAddress,
+            draft.ProposedVenuePostcode,
+        }.Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => value!.Trim()));
+    }
+
+    private static string NormalizeForComparison(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        var previousWasSpace = false;
+        foreach (var character in value.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Append(character);
+                previousWasSpace = false;
+            }
+            else if (!previousWasSpace)
+            {
+                builder.Append(' ');
+                previousWasSpace = true;
+            }
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static void AddWarning(List<string> warnings, string warning)
+    {
+        if (!warnings.Contains(warning, StringComparer.Ordinal))
+        {
+            warnings.Add(warning);
+        }
+    }
+
+    private static IReadOnlyDictionary<Guid, IReadOnlyList<string>> ToResult(Dictionary<Guid, List<string>> warnings)
+    {
+        return warnings.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyList<string>)pair.Value.Take(10).ToList());
+    }
+
+    private sealed record GigCandidate(Guid ClientId, DateOnly Date, string Title, string Venue);
+}

--- a/backend/Glovelly.Api/Services/GlovellyMcpQueryService.cs
+++ b/backend/Glovelly.Api/Services/GlovellyMcpQueryService.cs
@@ -20,7 +20,9 @@ public interface IGlovellyMcpQueryService
     Task<GigImportDraftBulkAddResult> AddGigImportDraftsAsync(Guid userId, GigImportDraftBulkAddRequest request, CancellationToken cancellationToken);
 }
 
-public sealed class GlovellyMcpQueryService(AppDbContext db) : IGlovellyMcpQueryService
+public sealed class GlovellyMcpQueryService(
+    AppDbContext db,
+    IWorkspaceEventPublisher workspaceEventPublisher) : IGlovellyMcpQueryService
 {
     private const string DefaultCurrency = "GBP";
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -215,6 +217,7 @@ public sealed class GlovellyMcpQueryService(AppDbContext db) : IGlovellyMcpQuery
 
         db.GigImportBatches.Add(batch);
         await db.SaveChangesAsync(cancellationToken);
+        await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gig-imports", "created", batch.Id, DateTimeOffset.UtcNow), cancellationToken);
 
         return new GigImportBatchCreateResult(true, [], ToGigImportBatchSummary(batch, 0));
     }
@@ -275,7 +278,13 @@ public sealed class GlovellyMcpQueryService(AppDbContext db) : IGlovellyMcpQuery
         GigImportDraftAddRequest request,
         CancellationToken cancellationToken)
     {
-        return await AddGigImportDraftCoreAsync(userId, request, 0, cancellationToken);
+        var result = await AddGigImportDraftCoreAsync(userId, request, 0, cancellationToken);
+        if (result.Created)
+        {
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gig-imports", "updated", request.BatchId, DateTimeOffset.UtcNow), cancellationToken);
+        }
+
+        return result;
     }
 
     public async Task<GigImportDraftBulkAddResult> AddGigImportDraftsAsync(
@@ -303,6 +312,11 @@ public sealed class GlovellyMcpQueryService(AppDbContext db) : IGlovellyMcpQuery
         {
             var draftRequest = drafts[index] with { BatchId = request.BatchId };
             results.Add(await AddGigImportDraftCoreAsync(userId, draftRequest, index, cancellationToken));
+        }
+
+        if (results.Any(result => result.Created))
+        {
+            await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gig-imports", "updated", request.BatchId, DateTimeOffset.UtcNow), cancellationToken);
         }
 
         return new GigImportDraftBulkAddResult(

--- a/backend/Glovelly.Api/Services/IGigImportDuplicateDetectionService.cs
+++ b/backend/Glovelly.Api/Services/IGigImportDuplicateDetectionService.cs
@@ -1,0 +1,12 @@
+using Glovelly.Api.Models;
+
+namespace Glovelly.Api.Services;
+
+public interface IGigImportDuplicateDetectionService
+{
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<string>>> FindWarningsAsync(
+        Guid? userId,
+        GigImportBatch batch,
+        IReadOnlyList<GigImportDraft> drafts,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/Glovelly.Api/Services/IWorkspaceEventPublisher.cs
+++ b/backend/Glovelly.Api/Services/IWorkspaceEventPublisher.cs
@@ -1,0 +1,6 @@
+namespace Glovelly.Api.Services;
+
+public interface IWorkspaceEventPublisher
+{
+    Task PublishAsync(Guid? userId, WorkspaceEvent workspaceEvent, CancellationToken cancellationToken = default);
+}

--- a/backend/Glovelly.Api/Services/InvoiceLineGenerationService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceLineGenerationService.cs
@@ -161,12 +161,18 @@ public sealed class InvoiceLineGenerationService(
 
     private async Task<int> GetNextSortOrderAsync(Guid invoiceId, CancellationToken cancellationToken)
     {
-        var currentMax = await dbContext.InvoiceLines
+        var persistedMax = await dbContext.InvoiceLines
             .Where(line => line.InvoiceId == invoiceId)
             .Select(line => (int?)line.SortOrder)
             .MaxAsync(cancellationToken);
+        var trackedMax = dbContext.ChangeTracker
+            .Entries<InvoiceLine>()
+            .Where(entry => entry.State is not EntityState.Deleted and not EntityState.Detached)
+            .Where(entry => entry.Entity.InvoiceId == invoiceId)
+            .Select(entry => (int?)entry.Entity.SortOrder)
+            .Max();
 
-        return (currentMax ?? 0) + 1;
+        return Math.Max(persistedMax ?? 0, trackedMax ?? 0) + 1;
     }
 
     private async Task<(decimal? MileageRate, decimal? PassengerMileageRate)> ResolveMileageRatesAsync(

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInvoiceWorkflowService, InvoiceWorkflowService>();
         services.AddScoped<IInvoicePdfService, InvoicePdfService>();
         services.AddScoped<IInvoiceDeliveryService, InvoiceDeliveryService>();
+        services.AddScoped<IGigImportDuplicateDetectionService, GigImportDuplicateDetectionService>();
         services.AddScoped<IGoogleConnectionService, GoogleConnectionService>();
         services.AddSingleton<ICalendarEventPayloadHasher, CalendarEventPayloadHasher>();
         services.AddScoped<IGigCalendarEventMapper, GigCalendarEventMapper>();

--- a/backend/Glovelly.Api/Services/WorkspaceEvent.cs
+++ b/backend/Glovelly.Api/Services/WorkspaceEvent.cs
@@ -1,0 +1,7 @@
+namespace Glovelly.Api.Services;
+
+public sealed record WorkspaceEvent(
+    string Scope,
+    string Action,
+    Guid? EntityId,
+    DateTimeOffset OccurredAtUtc);

--- a/backend/Glovelly.Api/Services/WorkspaceEventPublisher.cs
+++ b/backend/Glovelly.Api/Services/WorkspaceEventPublisher.cs
@@ -1,0 +1,19 @@
+using Glovelly.Api.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Glovelly.Api.Services;
+
+internal sealed class WorkspaceEventPublisher(IHubContext<WorkspaceEventsHub> hubContext) : IWorkspaceEventPublisher
+{
+    public Task PublishAsync(Guid? userId, WorkspaceEvent workspaceEvent, CancellationToken cancellationToken = default)
+    {
+        if (!userId.HasValue)
+        {
+            return Task.CompletedTask;
+        }
+
+        return hubContext.Clients
+            .Group(WorkspaceEventsHub.BuildUserGroupName(userId.Value))
+            .SendAsync("workspaceChanged", workspaceEvent, cancellationToken);
+    }
+}

--- a/docs/engineering/deployment-pipeline.md
+++ b/docs/engineering/deployment-pipeline.md
@@ -72,6 +72,8 @@ Avoid duplicating secret ownership unnecessarily. Runtime secrets should general
 
 Cloud Run receives non-secret environment variables for values such as deployment name, bucket names, email mode/display names, MCP issuer/resource URLs, and client display/scopes.
 
+The app uses SignalR for authenticated workspace invalidation events at `/workspace-events`. Cloud Run supports these WebSocket connections, but deployments should use a timeout long enough for active browser sessions and reconnects. While the default in-memory SignalR hub has no distributed backplane, keep the service on a single instance or treat events as best-effort with the frontend focus/visibility refresh as a fallback.
+
 Secrets are bound from Secret Manager for values such as:
 
 - Google OAuth client ID and client secret

--- a/docs/uat/gig-imports.md
+++ b/docs/uat/gig-imports.md
@@ -45,7 +45,7 @@ The import review modal opens from the profile menu. Imported gigs are not a pri
 
 ## Review And Autosave Rows
 
-> **Automation:** Manual UAT
+> **Automation:** Backend automated for duplicate warning refresh; manual UAT for modal autosave behavior.
 
 ### Steps
 
@@ -59,6 +59,24 @@ The import review modal opens from the profile menu. Imported gigs are not a pri
 ### Expected Results
 
 Draft edits autosave. There is no row-level `Save` button. Accepting or rejecting a row updates the batch counts immediately, but rejected rows do not jump to the bottom before commit.
+
+## Duplicate Warning Review
+
+> **Automation:** Backend automated; manual UAT: `Glovelly.Api.Tests.GigImportEndpointsTests` covers duplicate warning rules and non-blocking commit behavior; modal presentation remains manual.
+
+### Steps
+
+1. Create or identify an existing gig on a known date and venue, such as `2026-12-08` at `Bath Forum`.
+2. Stage an import row with the same date and venue.
+3. Open `Imported gigs` and select the staged batch.
+4. Confirm the row shows a possible duplicate warning before commit.
+5. Edit the row to remove the duplicate signal, such as changing the date or venue, then wait for autosave or reload the batch.
+6. Change the row back to the duplicate date and venue.
+7. Accept the row and click `Commit decisions`.
+
+### Expected Results
+
+Duplicate rows show warning text in the review modal. Editing date, title, client, or venue refreshes the warning after autosave or reload. Duplicate warnings do not disable accepting the row and do not block commit; accepted rows still become real gigs when committed.
 
 ## Commit Decisions
 

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -279,7 +279,7 @@ Expected result: the app blocks generation and explains that selected gigs must 
 
 ## Imported Gig Review Smoke Check
 
-> **Automation:** Backend automated; manual UAT: `Glovelly.Api.Tests.GigImportEndpointsTests` covers commit rules; modal entry, autosave, and notification dots remain manual.
+> **Automation:** Backend automated; manual UAT: `Glovelly.Api.Tests.GigImportEndpointsTests` covers commit rules and duplicate warnings; modal entry, autosave, warning presentation, and notification dots remain manual.
 
 Run the focused [Imported gigs](gig-imports.md) journey when the change touches MCP, gigs, or profile-menu workflows. For broad pre-merge smoke, at minimum:
 
@@ -287,9 +287,10 @@ Run the focused [Imported gigs](gig-imports.md) journey when the change touches 
 2. Open `Imported gigs`.
 3. If staged imports exist, select a batch and confirm rows load in the modal.
 4. If there are pending rows, edit a harmless field and confirm there is no row-level save button.
-5. Close the modal and reopen it.
+5. If a row resembles an existing gig, confirm it shows a possible duplicate warning without disabling commit.
+6. Close the modal and reopen it.
 
-Expected result: imported gigs stay in a modal launched from the profile menu, row edits autosave, and the main Clients/Gigs/Invoices navigation is unchanged.
+Expected result: imported gigs stay in a modal launched from the profile menu, row edits autosave, duplicate warnings are advisory only, and the main Clients/Gigs/Invoices navigation is unchanged.
 
 ## Monthly Invoice Journey
 

--- a/frontend/glovelly-web/package-lock.json
+++ b/frontend/glovelly-web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "glovelly-web",
       "version": "0.0.0",
       "dependencies": {
+        "@microsoft/signalr": "^10.0.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
       },
@@ -528,6 +529,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/signalr": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1172,6 +1186,18 @@
         }
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1579,6 +1605,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1616,6 +1660,16 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2201,6 +2255,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -2337,15 +2411,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -2367,6 +2458,12 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.3",
@@ -2418,6 +2515,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2467,6 +2570,27 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -2547,6 +2671,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2586,6 +2719,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/vite": {
@@ -2666,6 +2809,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2690,6 +2849,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/frontend/glovelly-web/package.json
+++ b/frontend/glovelly-web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@microsoft/signalr": "^10.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/frontend/glovelly-web/public/sw.js
+++ b/frontend/glovelly-web/public/sw.js
@@ -19,6 +19,7 @@ const API_PREFIXES = [
   '/oauth',
   '/seller-profile',
   '/test-auth',
+  '/workspace-events',
 ]
 
 self.addEventListener('install', (event) => {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1421,16 +1421,8 @@
   padding: 12px;
   border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
   border-radius: 18px;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, #f47d2a 8%, transparent), transparent 58%),
-    #fbf8f2;
+  background: var(--compact-control-background);
   box-shadow: var(--surface-shadow-soft);
-}
-
-:root[data-theme='dark'] .compact-list-controls {
-  background:
-    linear-gradient(135deg, color-mix(in srgb, #f47d2a 10%, transparent), transparent 58%),
-    #18212d;
 }
 
 .compact-list-main-controls {
@@ -1489,9 +1481,9 @@
 .compact-filter-chip:focus-visible,
 .compact-filter-chip.selected {
   background:
-    linear-gradient(135deg, color-mix(in srgb, #f47d2a 14%, transparent), transparent 62%),
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 14%, transparent), transparent 62%),
     var(--surface-accent);
-  border-color: color-mix(in srgb, #f47d2a 42%, var(--surface-border));
+  border-color: color-mix(in srgb, var(--compact-control-accent) 42%, var(--surface-border));
   color: var(--heading);
 }
 

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -2723,10 +2723,8 @@ button:disabled {
   }
 
   .profile-dropdown {
-    /* Center the dropdown on small screens and constrain width so it stays on-screen */
-    left: 50%;
+    left: 0;
     right: auto;
-    transform: translateX(-90%);
     min-width: min(280px, calc(100vw - 64px));
     max-width: calc(100vw - 32px);
   }

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -2300,6 +2300,10 @@ button:disabled {
     opacity: 0;
     transform: none;
     visibility: hidden;
+    transition:
+      max-height 320ms ease,
+      opacity 180ms ease,
+      visibility 0s linear 320ms;
   }
 
   .editor-slot.open {
@@ -2307,6 +2311,10 @@ button:disabled {
     max-height: 2000px;
     opacity: 1;
     visibility: visible;
+    transition:
+      max-height 360ms ease,
+      opacity 180ms ease,
+      visibility 0s linear 0s;
   }
 
   .editor-slot > .panel,

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -461,6 +461,13 @@ function App({ appMetadata }: AppProps) {
         void refreshGigsFromServer('realtime')
         void refreshInvoicesFromServer('realtime')
       }
+
+      if (event.scope === 'gig-imports') {
+        void loadGigImportBatches(true)
+        if (selectedGigImportBatchId) {
+          void loadGigImportBatch(selectedGigImportBatchId)
+        }
+      }
     },
   })
 
@@ -637,18 +644,6 @@ function App({ appMetadata }: AppProps) {
     resetSellerProfile,
     resetUserSettings,
   ])
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      return
-    }
-
-    const intervalId = window.setInterval(() => {
-      void loadGigImportBatches(true)
-    }, 30000)
-
-    return () => window.clearInterval(intervalId)
-  }, [isAuthenticated, loadGigImportBatches])
 
   useEffect(() => {
     if (!isAuthenticated) {

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AdminSection,
   AppShell,
@@ -44,6 +44,7 @@ import { useQuickReceipt } from './hooks/useQuickReceipt'
 import { useSellerProfile } from './hooks/useSellerProfile'
 import { useThemePreference } from './hooks/useThemePreference'
 import { useUserSettings } from './hooks/useUserSettings'
+import { useWorkspaceEvents } from './hooks/useWorkspaceEvents'
 import type {
   AppMetadata,
   AppSection,
@@ -78,6 +79,7 @@ function App({ appMetadata }: AppProps) {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [authUser, setAuthUser] = useState<AuthUser | null>(null)
   const [isCheckingSession, setIsCheckingSession] = useState(true)
+  const lastWorkspaceRefreshAtRef = useRef(0)
   const [shouldCloseBrowserNotice, setShouldCloseBrowserNotice] = useState(false)
   const {
     closeProfileMenu,
@@ -397,6 +399,71 @@ function App({ appMetadata }: AppProps) {
     onDownloaded: setInvoiceStatus,
   })
 
+  const refreshGigsFromServer = useCallback(async (reason: 'focus' | 'realtime') => {
+    if (!isAuthenticated) {
+      return
+    }
+
+    const now = Date.now()
+    if (reason === 'focus' && now - lastWorkspaceRefreshAtRef.current < 5000) {
+      return
+    }
+
+    lastWorkspaceRefreshAtRef.current = now
+
+    try {
+      const response = await fetchWithSession(buildApiUrl('/gigs'))
+      if (isSessionExpiredResponse(response)) {
+        expireSession('Your session expired. Sign in again to keep working.')
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error('Unable to refresh gigs.')
+      }
+
+      setGigs((await response.json()) as Gig[])
+    } catch {
+      if (reason === 'focus') {
+        setStatus('We could not refresh your workspace right now.')
+      }
+    }
+  }, [expireSession, isAuthenticated, setGigs])
+
+  const refreshInvoicesFromServer = useCallback(async (reason: 'focus' | 'realtime') => {
+    if (!isAuthenticated) {
+      return
+    }
+
+    try {
+      const response = await fetchWithSession(buildApiUrl('/invoices'))
+      if (isSessionExpiredResponse(response)) {
+        expireSession('Your session expired. Sign in again to keep working.')
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error('Unable to refresh invoices.')
+      }
+
+      setInvoices((await response.json()) as Invoice[])
+    } catch {
+      if (reason === 'focus') {
+        setStatus('We could not refresh your invoices right now.')
+      }
+    }
+  }, [expireSession, isAuthenticated, setInvoices])
+
+  useWorkspaceEvents({
+    enabled: isAuthenticated,
+    onWorkspaceChanged: (event) => {
+      if (event.scope === 'gigs') {
+        void refreshGigsFromServer('realtime')
+        void refreshInvoicesFromServer('realtime')
+      }
+    },
+  })
+
   useEffect(() => {
     if (!isAdmin && activeSection === 'admin') {
       setActiveSection('gigs')
@@ -583,6 +650,27 @@ function App({ appMetadata }: AppProps) {
     return () => window.clearInterval(intervalId)
   }, [isAuthenticated, loadGigImportBatches])
 
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return
+    }
+
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void refreshGigsFromServer('focus')
+        void refreshInvoicesFromServer('focus')
+      }
+    }
+
+    window.addEventListener('focus', refreshWhenVisible)
+    document.addEventListener('visibilitychange', refreshWhenVisible)
+
+    return () => {
+      window.removeEventListener('focus', refreshWhenVisible)
+      document.removeEventListener('visibilitychange', refreshWhenVisible)
+    }
+  }, [isAuthenticated, refreshGigsFromServer, refreshInvoicesFromServer])
+
   const monthlyInvoiceEligibleGigs = useMemo(() => {
     if (!selectedClient || !monthlyInvoiceMonth) {
       return []
@@ -670,12 +758,36 @@ function App({ appMetadata }: AppProps) {
     void handleDelete()
   }
 
-  const openSelectedGigInvoice = () => {
+  const openSelectedGigInvoice = async () => {
     if (!selectedGig?.invoiceId) {
       return
     }
 
-    setSelectedInvoiceId(selectedGig.invoiceId)
+    const invoiceId = selectedGig.invoiceId
+    if (!invoices.some((invoice) => invoice.id === invoiceId)) {
+      try {
+        const response = await fetchWithSession(buildApiUrl(`/invoices/${invoiceId}`))
+        if (isSessionExpiredResponse(response)) {
+          expireSession('Your session expired. Sign in again to keep working.')
+          return
+        }
+
+        if (!response.ok) {
+          throw new Error('Unable to open linked invoice.')
+        }
+
+        const invoice = (await response.json()) as Invoice
+        setInvoices((current) => [
+          invoice,
+          ...current.filter((value) => value.id !== invoice.id),
+        ])
+      } catch (error) {
+        setGigStatus(error instanceof Error ? error.message : 'Unable to open linked invoice.')
+        return
+      }
+    }
+
+    setSelectedInvoiceId(invoiceId)
     setActiveSection('invoices')
   }
 
@@ -878,6 +990,10 @@ function App({ appMetadata }: AppProps) {
 
   const openPreviewedInvoice = () => {
     if (invoicePreviewInvoice) {
+      setInvoices((current) => [
+        invoicePreviewInvoice,
+        ...current.filter((invoice) => invoice.id !== invoicePreviewInvoice.id),
+      ])
       setSelectedInvoiceId(invoicePreviewInvoice.id)
     }
 

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -232,6 +232,15 @@ export function AppShell({
                           <option value="system">System</option>
                           <option value="light">Light</option>
                           <option value="dark">Dark</option>
+                          <option value="neon">Neon</option>
+                          <option value="mahogany">Mahogany</option>
+                          <option value="candy">Candy</option>
+                          <option value="blue-note">Blue Note</option>
+                          <option value="parchment">Parchment</option>
+                          <option value="studio-tape">Studio Tape</option>
+                          <option value="synthwave">Synthwave</option>
+                          <option value="sunset-soundcheck">Sunset Soundcheck</option>
+                          <option value="velvet-rope">Velvet Rope</option>
                         </select>
                       </label>
                       <button

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -280,7 +280,10 @@ export function useGigsWorkspace({
   }, [resetExpenseStatementWorkspace])
 
   const mergeSavedGig = useCallback((savedGig: Gig) => {
-    setGigs((current) => current.map((gig) => (gig.id === savedGig.id ? savedGig : gig)))
+    setGigs((current) => [
+      savedGig,
+      ...current.filter((gig) => gig.id !== savedGig.id),
+    ])
     setGigForm((current) => ({
       ...current,
       expenses: toEditableGigExpenses(savedGig),
@@ -385,7 +388,10 @@ export function useGigsWorkspace({
       }
 
       const savedGig = (await response.json()) as Gig
-      setGigs((current) => [savedGig, ...current])
+      setGigs((current) => [
+        savedGig,
+        ...current.filter((gig) => gig.id !== savedGig.id),
+      ])
       setSelectedGigId(savedGig.id)
       setSelectedGigIds([])
       setGigMode('edit')
@@ -1070,7 +1076,10 @@ export function useGigsWorkspace({
           return current.map((gig) => (gig.id === savedGig.id ? savedGig : gig))
         }
 
-        return [savedGig, ...current]
+        return [
+          savedGig,
+          ...current.filter((gig) => gig.id !== savedGig.id),
+        ]
       })
 
       setSelectedGigId(savedGig.id)

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -162,8 +162,9 @@ export function useInvoicesWorkspace({
     })
   }, [clientNamesById, deferredInvoiceSearchQuery, invoiceQuickFilter, invoiceSort, invoices])
 
-  const selectedInvoice =
-    invoicesById.get(selectedInvoiceId) ?? filteredInvoices[0] ?? null
+  const selectedInvoice = selectedInvoiceId
+    ? invoicesById.get(selectedInvoiceId) ?? null
+    : filteredInvoices[0] ?? null
 
   const applyInvoices = useCallback((nextInvoices: Invoice[]) => {
     setInvoices(nextInvoices)

--- a/frontend/glovelly-web/src/hooks/useWorkspaceEvents.ts
+++ b/frontend/glovelly-web/src/hooks/useWorkspaceEvents.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react'
+import { HubConnectionBuilder, HubConnectionState, LogLevel } from '@microsoft/signalr'
+import { buildApiUrl } from '../api'
+
+export type WorkspaceEvent = {
+  scope: string
+  action: string
+  entityId: string | null
+  occurredAtUtc: string
+}
+
+type UseWorkspaceEventsOptions = {
+  enabled: boolean
+  onWorkspaceChanged: (event: WorkspaceEvent) => void
+}
+
+export function useWorkspaceEvents({
+  enabled,
+  onWorkspaceChanged,
+}: UseWorkspaceEventsOptions) {
+  const onWorkspaceChangedRef = useRef(onWorkspaceChanged)
+
+  useEffect(() => {
+    onWorkspaceChangedRef.current = onWorkspaceChanged
+  }, [onWorkspaceChanged])
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    const connection = new HubConnectionBuilder()
+      .withUrl(buildApiUrl('/workspace-events'), {
+        withCredentials: true,
+      })
+      .withAutomaticReconnect()
+      .configureLogging(LogLevel.Warning)
+      .build()
+
+    connection.on('workspaceChanged', (event: WorkspaceEvent) => {
+      onWorkspaceChangedRef.current(event)
+    })
+
+    void connection.start().catch(() => {
+      // Focus refresh remains the fallback if the real-time connection cannot start.
+    })
+
+    return () => {
+      connection.off('workspaceChanged')
+      if (connection.state !== HubConnectionState.Disconnected) {
+        void connection.stop()
+      }
+    }
+  }, [enabled])
+}

--- a/frontend/glovelly-web/src/index.css
+++ b/frontend/glovelly-web/src/index.css
@@ -45,6 +45,10 @@
   --danger-text: #812d2d;
   --brand-gradient: linear-gradient(135deg, #1b3f61, #255a7a);
   --brand-gradient-soft: linear-gradient(135deg, #1b3f61, #346f85);
+  --compact-control-accent: #f47d2a;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 8%, transparent), transparent 58%),
+    #fbf8f2;
 }
 
 :root[data-theme='dark'] {
@@ -82,6 +86,387 @@
   --danger-text: #f6a3a3;
   --brand-gradient: linear-gradient(135deg, #4f89b6, #2f688e);
   --brand-gradient-soft: linear-gradient(135deg, #5d90b8, #3f7298);
+  --compact-control-accent: #f47d2a;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 10%, transparent), transparent 58%),
+    #18212d;
+}
+
+:root[data-theme='neon'] {
+  --text: #d8fff8;
+  --heading: #fbff8f;
+  --muted: #8ee7df;
+  --muted-strong: #ff7ee7;
+  --page-background:
+    radial-gradient(circle at 15% 8%, rgba(0, 255, 194, 0.32), transparent 28%),
+    radial-gradient(circle at 86% 12%, rgba(255, 0, 221, 0.26), transparent 30%),
+    radial-gradient(circle at 50% 88%, rgba(251, 255, 0, 0.14), transparent 34%),
+    linear-gradient(180deg, #070816 0%, #0b1028 46%, #05030f 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(0, 255, 194, 0.08), transparent 32%),
+    linear-gradient(315deg, rgba(255, 0, 221, 0.07), transparent 28%);
+
+  --surface-border: rgba(0, 255, 213, 0.34);
+  --surface-panel:
+    linear-gradient(180deg, rgba(12, 22, 47, 0.92), rgba(12, 9, 31, 0.9)),
+    rgba(7, 8, 23, 0.92);
+  --surface-elevated: rgba(15, 24, 50, 0.94);
+  --surface-subtle: rgba(20, 32, 64, 0.82);
+  --surface-soft: rgba(13, 18, 43, 0.9);
+  --surface-accent:
+    linear-gradient(180deg, rgba(22, 43, 76, 0.94), rgba(42, 17, 68, 0.9));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(0, 255, 213, 0.22), rgba(255, 0, 221, 0.12));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(14, 24, 53, 0.96), rgba(17, 10, 42, 0.96)),
+    rgba(8, 10, 27, 0.96);
+  --surface-shadow: 0 24px 64px rgba(0, 255, 213, 0.16);
+  --surface-shadow-strong: 0 24px 54px rgba(255, 0, 221, 0.22);
+  --surface-shadow-soft: 0 16px 32px rgba(0, 255, 213, 0.12);
+  --focus-ring: 2px solid rgba(251, 255, 0, 0.72);
+  --input-placeholder: #70b8ba;
+  --danger-text: #ff9bbb;
+  --brand-gradient: linear-gradient(135deg, #00ffd5, #ff00dd 58%, #fbff00);
+  --brand-gradient-soft: linear-gradient(135deg, #12e8ff, #b45cff 55%, #fff36a);
+  --compact-control-accent: #00ffd5;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, #00ffd5 18%, transparent), transparent 48%),
+    linear-gradient(315deg, color-mix(in srgb, #ff00dd 14%, transparent), transparent 54%),
+    rgba(12, 9, 31, 0.94);
+}
+
+:root[data-theme='mahogany'] {
+  --text: #f0dfcf;
+  --heading: #fff3dc;
+  --muted: #c9ab92;
+  --muted-strong: #d99b68;
+  --page-background:
+    radial-gradient(circle at 12% 10%, rgba(210, 133, 74, 0.28), transparent 30%),
+    radial-gradient(circle at 88% 18%, rgba(97, 31, 21, 0.34), transparent 30%),
+    linear-gradient(180deg, #2a120d 0%, #351810 44%, #1d0d09 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 220, 176, 0.08), transparent 32%),
+    linear-gradient(315deg, rgba(92, 35, 20, 0.18), transparent 28%);
+
+  --surface-border: rgba(247, 193, 137, 0.22);
+  --surface-panel:
+    linear-gradient(180deg, rgba(68, 30, 18, 0.92), rgba(48, 20, 13, 0.9)),
+    rgba(45, 18, 12, 0.92);
+  --surface-elevated: rgba(70, 31, 19, 0.94);
+  --surface-subtle: rgba(87, 39, 24, 0.8);
+  --surface-soft: rgba(55, 24, 16, 0.9);
+  --surface-accent:
+    linear-gradient(180deg, rgba(96, 45, 27, 0.94), rgba(63, 26, 17, 0.92));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(207, 128, 63, 0.26), rgba(73, 31, 20, 0.74));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(75, 34, 21, 0.96), rgba(52, 23, 15, 0.96)),
+    rgba(45, 19, 12, 0.96);
+  --surface-shadow: 0 24px 60px rgba(18, 6, 3, 0.46);
+  --surface-shadow-strong: 0 24px 48px rgba(12, 4, 2, 0.58);
+  --surface-shadow-soft: 0 16px 30px rgba(15, 5, 3, 0.42);
+  --focus-ring: 2px solid rgba(232, 159, 88, 0.68);
+  --input-placeholder: #b48d72;
+  --danger-text: #ffb4a2;
+  --brand-gradient: linear-gradient(135deg, #d78745, #8f3f24);
+  --brand-gradient-soft: linear-gradient(135deg, #edb06b, #9e5230);
+  --compact-control-accent: #d78745;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 16%, transparent), transparent 58%),
+    rgba(48, 20, 13, 0.94);
+}
+
+:root[data-theme='candy'] {
+  --text: #6d4162;
+  --heading: #4a2850;
+  --muted: #8d6684;
+  --muted-strong: #b65188;
+  --page-background:
+    radial-gradient(circle at 12% 8%, rgba(255, 139, 202, 0.42), transparent 30%),
+    radial-gradient(circle at 88% 14%, rgba(133, 222, 255, 0.42), transparent 28%),
+    radial-gradient(circle at 48% 88%, rgba(255, 232, 123, 0.36), transparent 34%),
+    linear-gradient(180deg, #fff0f8 0%, #f5f1ff 46%, #eafaff 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.48), transparent 32%),
+    linear-gradient(315deg, rgba(255, 156, 218, 0.16), transparent 28%);
+
+  --surface-border: rgba(182, 81, 136, 0.16);
+  --surface-panel:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 241, 250, 0.82)),
+    rgba(255, 255, 255, 0.82);
+  --surface-elevated: rgba(255, 255, 255, 0.9);
+  --surface-subtle: rgba(255, 237, 248, 0.76);
+  --surface-soft: rgba(255, 248, 253, 0.84);
+  --surface-accent:
+    linear-gradient(180deg, rgba(255, 247, 253, 0.94), rgba(239, 250, 255, 0.9));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(255, 139, 202, 0.24), rgba(255, 255, 255, 0.72));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 242, 250, 0.96)),
+    rgba(255, 255, 255, 0.98);
+  --surface-shadow: 0 24px 60px rgba(130, 78, 116, 0.13);
+  --surface-shadow-strong: 0 24px 48px rgba(128, 72, 116, 0.19);
+  --surface-shadow-soft: 0 16px 30px rgba(128, 72, 116, 0.11);
+  --focus-ring: 2px solid rgba(255, 105, 190, 0.54);
+  --input-placeholder: #b590aa;
+  --danger-text: #a72f5e;
+  --brand-gradient: linear-gradient(135deg, #ff7ac8, #8adfff 58%, #ffe477);
+  --brand-gradient-soft: linear-gradient(135deg, #ff9bd6, #9ee8ff 58%, #ffed98);
+  --compact-control-accent: #ff7ac8;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, #ff7ac8 18%, transparent), transparent 48%),
+    linear-gradient(315deg, color-mix(in srgb, #8adfff 18%, transparent), transparent 54%),
+    rgba(255, 255, 255, 0.86);
+}
+
+:root[data-theme='blue-note'] {
+  --text: #d7d2c2;
+  --heading: #fff4d6;
+  --muted: #a9afbc;
+  --muted-strong: #d2a94d;
+  --page-background:
+    radial-gradient(circle at 14% 10%, rgba(202, 153, 56, 0.24), transparent 30%),
+    radial-gradient(circle at 86% 12%, rgba(48, 81, 142, 0.28), transparent 31%),
+    linear-gradient(180deg, #08111f 0%, #101b33 48%, #070b14 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 232, 170, 0.06), transparent 32%),
+    linear-gradient(315deg, rgba(74, 112, 184, 0.12), transparent 28%);
+
+  --surface-border: rgba(223, 181, 84, 0.22);
+  --surface-panel:
+    linear-gradient(180deg, rgba(22, 34, 61, 0.93), rgba(11, 18, 34, 0.91)),
+    rgba(10, 16, 30, 0.92);
+  --surface-elevated: rgba(22, 33, 58, 0.94);
+  --surface-subtle: rgba(31, 44, 75, 0.8);
+  --surface-soft: rgba(18, 28, 51, 0.9);
+  --surface-accent:
+    linear-gradient(180deg, rgba(36, 53, 89, 0.94), rgba(19, 30, 55, 0.92));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(202, 153, 56, 0.23), rgba(18, 30, 56, 0.74));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(27, 41, 70, 0.96), rgba(15, 25, 47, 0.96)),
+    rgba(10, 17, 32, 0.96);
+  --surface-shadow: 0 24px 60px rgba(2, 6, 13, 0.5);
+  --surface-shadow-strong: 0 24px 48px rgba(1, 4, 10, 0.6);
+  --surface-shadow-soft: 0 16px 30px rgba(1, 5, 12, 0.44);
+  --focus-ring: 2px solid rgba(223, 181, 84, 0.68);
+  --input-placeholder: #8891a2;
+  --danger-text: #ffad9e;
+  --brand-gradient: linear-gradient(135deg, #d3a94f, #355d9e);
+  --brand-gradient-soft: linear-gradient(135deg, #e6c06a, #4b75b5);
+  --compact-control-accent: #d3a94f;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 16%, transparent), transparent 58%),
+    rgba(12, 20, 38, 0.94);
+}
+
+:root[data-theme='parchment'] {
+  --text: #504333;
+  --heading: #291f16;
+  --muted: #776956;
+  --muted-strong: #9a4d36;
+  --page-background:
+    radial-gradient(circle at 12% 8%, rgba(185, 95, 54, 0.18), transparent 30%),
+    radial-gradient(circle at 88% 16%, rgba(43, 74, 118, 0.15), transparent 30%),
+    linear-gradient(180deg, #f6ead1 0%, #efe0c2 48%, #e7d4af 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 252, 238, 0.34), transparent 32%),
+    linear-gradient(315deg, rgba(133, 79, 40, 0.12), transparent 28%);
+
+  --surface-border: rgba(82, 62, 40, 0.13);
+  --surface-panel:
+    linear-gradient(180deg, rgba(255, 248, 226, 0.92), rgba(245, 232, 199, 0.84)),
+    rgba(250, 241, 216, 0.84);
+  --surface-elevated: rgba(255, 248, 226, 0.9);
+  --surface-subtle: rgba(239, 222, 188, 0.74);
+  --surface-soft: rgba(249, 238, 211, 0.82);
+  --surface-accent:
+    linear-gradient(180deg, rgba(255, 247, 224, 0.94), rgba(237, 218, 181, 0.86));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(154, 77, 54, 0.13), rgba(255, 248, 226, 0.66));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(255, 250, 235, 0.98), rgba(245, 232, 202, 0.96)),
+    rgba(255, 248, 226, 0.98);
+  --surface-shadow: 0 24px 60px rgba(80, 61, 39, 0.12);
+  --surface-shadow-strong: 0 24px 48px rgba(69, 49, 28, 0.18);
+  --surface-shadow-soft: 0 16px 30px rgba(80, 61, 39, 0.1);
+  --focus-ring: 2px solid rgba(43, 74, 118, 0.48);
+  --input-placeholder: #9d8d74;
+  --danger-text: #8c2e24;
+  --brand-gradient: linear-gradient(135deg, #293f65, #9a4d36);
+  --brand-gradient-soft: linear-gradient(135deg, #3f5d8d, #b86445);
+  --compact-control-accent: #9a4d36;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 12%, transparent), transparent 58%),
+    rgba(255, 248, 226, 0.86);
+}
+
+:root[data-theme='studio-tape'] {
+  --text: #ead8bd;
+  --heading: #fff0cf;
+  --muted: #b8a084;
+  --muted-strong: #f0a34d;
+  --page-background:
+    radial-gradient(circle at 16% 10%, rgba(240, 163, 77, 0.24), transparent 30%),
+    radial-gradient(circle at 84% 14%, rgba(96, 85, 72, 0.34), transparent 30%),
+    linear-gradient(180deg, #201914 0%, #30251d 48%, #17120f 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 216, 153, 0.07), transparent 32%),
+    linear-gradient(315deg, rgba(91, 76, 61, 0.22), transparent 28%);
+
+  --surface-border: rgba(240, 163, 77, 0.22);
+  --surface-panel:
+    linear-gradient(180deg, rgba(61, 47, 36, 0.93), rgba(39, 30, 24, 0.91)),
+    rgba(35, 27, 22, 0.92);
+  --surface-elevated: rgba(62, 48, 38, 0.94);
+  --surface-subtle: rgba(78, 61, 48, 0.8);
+  --surface-soft: rgba(48, 38, 31, 0.9);
+  --surface-accent:
+    linear-gradient(180deg, rgba(81, 63, 48, 0.94), rgba(51, 39, 31, 0.92));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(240, 163, 77, 0.22), rgba(46, 35, 28, 0.74));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(66, 51, 40, 0.96), rgba(43, 33, 27, 0.96)),
+    rgba(35, 27, 22, 0.96);
+  --surface-shadow: 0 24px 60px rgba(9, 6, 4, 0.48);
+  --surface-shadow-strong: 0 24px 48px rgba(6, 4, 3, 0.6);
+  --surface-shadow-soft: 0 16px 30px rgba(8, 6, 4, 0.42);
+  --focus-ring: 2px solid rgba(240, 163, 77, 0.7);
+  --input-placeholder: #a68d74;
+  --danger-text: #ffb19c;
+  --brand-gradient: linear-gradient(135deg, #f0a34d, #6c5a46);
+  --brand-gradient-soft: linear-gradient(135deg, #ffbd68, #8a7359);
+  --compact-control-accent: #f0a34d;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 15%, transparent), transparent 58%),
+    rgba(39, 30, 24, 0.94);
+}
+
+:root[data-theme='synthwave'] {
+  --text: #ffe0ff;
+  --heading: #fff1a6;
+  --muted: #d4a5e8;
+  --muted-strong: #ff9a6b;
+  --page-background:
+    radial-gradient(circle at 15% 12%, rgba(255, 92, 168, 0.28), transparent 30%),
+    radial-gradient(circle at 86% 12%, rgba(83, 213, 255, 0.24), transparent 30%),
+    radial-gradient(circle at 50% 88%, rgba(255, 139, 58, 0.2), transparent 34%),
+    linear-gradient(180deg, #160525 0%, #2b0c48 48%, #090418 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 92, 168, 0.08), transparent 32%),
+    linear-gradient(315deg, rgba(83, 213, 255, 0.08), transparent 28%);
+
+  --surface-border: rgba(255, 92, 168, 0.26);
+  --surface-panel:
+    linear-gradient(180deg, rgba(48, 16, 76, 0.93), rgba(28, 9, 49, 0.91)),
+    rgba(23, 7, 41, 0.92);
+  --surface-elevated: rgba(49, 17, 78, 0.94);
+  --surface-subtle: rgba(66, 26, 96, 0.8);
+  --surface-soft: rgba(38, 12, 65, 0.9);
+  --surface-accent:
+    linear-gradient(180deg, rgba(71, 25, 105, 0.94), rgba(38, 14, 72, 0.92));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(255, 92, 168, 0.22), rgba(83, 213, 255, 0.1));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(54, 18, 86, 0.96), rgba(31, 11, 58, 0.96)),
+    rgba(23, 7, 41, 0.96);
+  --surface-shadow: 0 24px 64px rgba(255, 92, 168, 0.14);
+  --surface-shadow-strong: 0 24px 54px rgba(83, 213, 255, 0.14);
+  --surface-shadow-soft: 0 16px 32px rgba(255, 92, 168, 0.1);
+  --focus-ring: 2px solid rgba(255, 241, 166, 0.68);
+  --input-placeholder: #b988d0;
+  --danger-text: #ffb0c1;
+  --brand-gradient: linear-gradient(135deg, #ff5ca8, #53d5ff 55%, #ff8b3a);
+  --brand-gradient-soft: linear-gradient(135deg, #ff7dc0, #75deff 55%, #ffae66);
+  --compact-control-accent: #ff5ca8;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, #ff5ca8 18%, transparent), transparent 48%),
+    linear-gradient(315deg, color-mix(in srgb, #53d5ff 12%, transparent), transparent 54%),
+    rgba(28, 9, 49, 0.94);
+}
+
+:root[data-theme='sunset-soundcheck'] {
+  --text: #fff0df;
+  --heading: #fff8d7;
+  --muted: #f0c2bc;
+  --muted-strong: #ffb06d;
+  --page-background:
+    radial-gradient(circle at 14% 10%, rgba(255, 169, 92, 0.32), transparent 30%),
+    radial-gradient(circle at 84% 14%, rgba(151, 82, 166, 0.3), transparent 30%),
+    radial-gradient(circle at 50% 88%, rgba(255, 99, 112, 0.22), transparent 34%),
+    linear-gradient(180deg, #32113b 0%, #74304a 46%, #f07a55 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 226, 155, 0.1), transparent 32%),
+    linear-gradient(315deg, rgba(109, 60, 151, 0.16), transparent 28%);
+
+  --surface-border: rgba(255, 198, 129, 0.25);
+  --surface-panel:
+    linear-gradient(180deg, rgba(83, 32, 67, 0.9), rgba(81, 35, 54, 0.88)),
+    rgba(67, 28, 60, 0.9);
+  --surface-elevated: rgba(91, 39, 68, 0.92);
+  --surface-subtle: rgba(116, 52, 76, 0.78);
+  --surface-soft: rgba(77, 32, 60, 0.88);
+  --surface-accent:
+    linear-gradient(180deg, rgba(126, 55, 81, 0.92), rgba(89, 38, 65, 0.9));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(255, 176, 109, 0.24), rgba(255, 99, 112, 0.12));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(94, 42, 71, 0.96), rgba(82, 35, 60, 0.95)),
+    rgba(67, 28, 60, 0.95);
+  --surface-shadow: 0 24px 60px rgba(57, 17, 45, 0.34);
+  --surface-shadow-strong: 0 24px 50px rgba(47, 13, 39, 0.44);
+  --surface-shadow-soft: 0 16px 30px rgba(57, 17, 45, 0.28);
+  --focus-ring: 2px solid rgba(255, 218, 132, 0.7);
+  --input-placeholder: #e2aaa9;
+  --danger-text: #ffd0c4;
+  --brand-gradient: linear-gradient(135deg, #ffb06d, #ff6370 54%, #8c5dcc);
+  --brand-gradient-soft: linear-gradient(135deg, #ffc47f, #ff8290 54%, #a778df);
+  --compact-control-accent: #ffb06d;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, #ffb06d 18%, transparent), transparent 48%),
+    linear-gradient(315deg, color-mix(in srgb, #8c5dcc 13%, transparent), transparent 54%),
+    rgba(81, 35, 54, 0.93);
+}
+
+:root[data-theme='velvet-rope'] {
+  --text: #f3d9d5;
+  --heading: #fff1dd;
+  --muted: #cfaaa5;
+  --muted-strong: #d7ad61;
+  --page-background:
+    radial-gradient(circle at 15% 10%, rgba(215, 173, 97, 0.22), transparent 30%),
+    radial-gradient(circle at 86% 12%, rgba(103, 20, 55, 0.36), transparent 31%),
+    linear-gradient(180deg, #240814 0%, #3a0f22 48%, #17050d 100%);
+  --page-overlay:
+    linear-gradient(135deg, rgba(255, 229, 180, 0.07), transparent 32%),
+    linear-gradient(315deg, rgba(116, 20, 57, 0.18), transparent 28%);
+
+  --surface-border: rgba(215, 173, 97, 0.24);
+  --surface-panel:
+    linear-gradient(180deg, rgba(73, 19, 41, 0.93), rgba(48, 12, 27, 0.91)),
+    rgba(41, 10, 23, 0.92);
+  --surface-elevated: rgba(75, 20, 43, 0.94);
+  --surface-subtle: rgba(95, 27, 54, 0.8);
+  --surface-soft: rgba(56, 14, 32, 0.9);
+  --surface-accent:
+    linear-gradient(180deg, rgba(98, 29, 55, 0.94), rgba(62, 16, 36, 0.92));
+  --surface-highlight:
+    linear-gradient(180deg, rgba(215, 173, 97, 0.23), rgba(60, 15, 35, 0.74));
+  --surface-overlay:
+    linear-gradient(180deg, rgba(80, 22, 46, 0.96), rgba(53, 14, 31, 0.96)),
+    rgba(41, 10, 23, 0.96);
+  --surface-shadow: 0 24px 60px rgba(9, 2, 5, 0.5);
+  --surface-shadow-strong: 0 24px 48px rgba(6, 1, 4, 0.62);
+  --surface-shadow-soft: 0 16px 30px rgba(8, 2, 5, 0.44);
+  --focus-ring: 2px solid rgba(215, 173, 97, 0.72);
+  --input-placeholder: #b98f91;
+  --danger-text: #ffb3a7;
+  --brand-gradient: linear-gradient(135deg, #d7ad61, #8f234b);
+  --brand-gradient-soft: linear-gradient(135deg, #e8c77c, #a8345d);
+  --compact-control-accent: #d7ad61;
+  --compact-control-background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compact-control-accent) 16%, transparent), transparent 58%),
+    rgba(48, 12, 27, 0.94);
 }
 
 * {

--- a/frontend/glovelly-web/src/main.tsx
+++ b/frontend/glovelly-web/src/main.tsx
@@ -3,15 +3,11 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { loadAppMetadata } from './api'
-
-const THEME_STORAGE_KEY = 'glovelly.theme-preference'
+import { isThemePreference, themeStorageKey } from './theme'
 
 const applyInitialTheme = () => {
-  const rawPreference = window.localStorage.getItem(THEME_STORAGE_KEY)
-  const preference =
-    rawPreference === 'light' || rawPreference === 'dark' || rawPreference === 'system'
-      ? rawPreference
-      : 'system'
+  const rawPreference = window.localStorage.getItem(themeStorageKey)
+  const preference = isThemePreference(rawPreference) ? rawPreference : 'system'
 
   const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
     ? 'dark'

--- a/frontend/glovelly-web/src/theme.ts
+++ b/frontend/glovelly-web/src/theme.ts
@@ -2,13 +2,28 @@ import type { ThemePreference } from './types'
 
 export const themeStorageKey = 'glovelly.theme-preference'
 
+export const themePreferences = [
+  'system',
+  'light',
+  'dark',
+  'neon',
+  'mahogany',
+  'candy',
+  'blue-note',
+  'parchment',
+  'studio-tape',
+  'synthwave',
+  'sunset-soundcheck',
+  'velvet-rope',
+] as const
+
+export function isThemePreference(value: string | null): value is ThemePreference {
+  return themePreferences.some((preference) => preference === value)
+}
+
 export function getStoredThemePreference(): ThemePreference {
   const rawPreference = window.localStorage.getItem(themeStorageKey)
-  if (
-    rawPreference === 'system' ||
-    rawPreference === 'light' ||
-    rawPreference === 'dark'
-  ) {
+  if (isThemePreference(rawPreference)) {
     return rawPreference
   }
 

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -414,7 +414,19 @@ export type GigForm = {
 }
 
 export type AppSection = 'clients' | 'admin' | 'gigs' | 'invoices'
-export type ThemePreference = 'system' | 'light' | 'dark'
+export type ThemePreference =
+  | 'system'
+  | 'light'
+  | 'dark'
+  | 'neon'
+  | 'mahogany'
+  | 'candy'
+  | 'blue-note'
+  | 'parchment'
+  | 'studio-tape'
+  | 'synthwave'
+  | 'sunset-soundcheck'
+  | 'velvet-rope'
 export type AppMetadata = {
   title: string
   deploymentName: string | null

--- a/frontend/glovelly-web/vite.config.ts
+++ b/frontend/glovelly-web/vite.config.ts
@@ -28,6 +28,11 @@ export default defineConfig({
         target: 'http://localhost:5153',
         changeOrigin: true,
       },
+      '/workspace-events': {
+        target: 'http://localhost:5153',
+        changeOrigin: true,
+        ws: true,
+      },
       '/clients': {
         target: 'http://localhost:5153',
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- add duplicate detection and commit safeguards for gig imports
- add SignalR workspace invalidation events for gig/receipt changes with a focus refresh fallback
- smooth vertical editor pane closing for save/discard flows

## Verification
- ./verify.sh
- npm --prefix frontend/glovelly-web run lint
- npm --prefix frontend/glovelly-web run build

Note: the frontend build still emits non-failing Rolldown warnings from @microsoft/signalr pure annotations in node_modules.