### PR TITLE
Automatically advance business lifecycle states

### DIFF
--- a/.github/scripts/deploy-business-lifecycle-job.sh
+++ b/.github/scripts/deploy-business-lifecycle-job.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    printf 'Missing required environment variable: %s\n' "$name" >&2
+    exit 1
+  fi
+}
+
+require_env GCP_PROJECT_ID
+require_env GCP_REGION
+require_env IMAGE_URI
+require_env DEPLOYMENT_NAME
+require_env DEPLOYMENT_URL
+require_env GCP_BUCKET_NAME
+require_env GCP_CONNECTION_STRING_SECRET_ID
+require_env GCP_CLOUD_RUN_SERVICE
+
+job_name="${BUSINESS_LIFECYCLE_JOB_NAME:-${GCP_CLOUD_RUN_SERVICE}-business-lifecycle}"
+scheduler_name="${BUSINESS_LIFECYCLE_SCHEDULER_NAME:-${job_name}-schedule}"
+scheduler_location="${GCP_SCHEDULER_LOCATION:-${GCP_REGION}}"
+schedule="${BUSINESS_LIFECYCLE_SCHEDULE:-*/15 * * * *}"
+time_zone="${BUSINESS_LIFECYCLE_TIME_ZONE:-Etc/UTC}"
+task_timeout="${BUSINESS_LIFECYCLE_TASK_TIMEOUT:-300s}"
+runtime_service_account="${BUSINESS_LIFECYCLE_SERVICE_ACCOUNT:-glovelly-runner@${GCP_PROJECT_ID}.iam.gserviceaccount.com}"
+
+env_vars="App__DeploymentName=${DEPLOYMENT_NAME},BlobStorage__BucketName=${GCP_BUCKET_NAME},Email__Mode=Resend,Email__AccessRequests__FromDisplayName=Glovelly,Email__Invoices__FromDisplayName=Glovelly,ExpenseAttachments__BucketName=${GCP_BUCKET_NAME},Mcp__OAuth__Issuer=${DEPLOYMENT_URL},Mcp__OAuth__Resource=${DEPLOYMENT_URL}/mcp,Mcp__OAuth__Clients__0__DisplayName=ChatGPT,Mcp__OAuth__Clients__0__Scopes__0=mcp:read"
+secrets="Authentication__Google__ClientId=google-client-id:latest,Authentication__Google__ClientSecret=google-client-secret:latest,ConnectionStrings__Glovelly=${GCP_CONNECTION_STRING_SECRET_ID}:latest,Email__Resend__ApiKey=glovelly-resend-api-key:latest,Email__AccessRequests__FromAddress=glovelly-access-requests-from-address:latest,Email__Invoices__FromAddress=glovelly-invoices-from-address:latest,Mileage__GoogleRoutes__ApiKey=glovelly-routes-api-key:latest,Mcp__OAuth__Clients__0__ClientId=chatgpt-oauth-client-id:latest,Mcp__OAuth__Clients__0__ClientSecret=chatgpt-oauth-client-secret:latest"
+if [[ -n "${GCP_CHATGPT_REDIRECT_SECRET_ID:-}" ]]; then
+  secrets="${secrets},Mcp__OAuth__Clients__0__RedirectUris__0=${GCP_CHATGPT_REDIRECT_SECRET_ID}:latest"
+fi
+if [[ -n "${GCP_UAT_SECRET_ID:-}" ]]; then
+  secrets="${secrets},GLOVELLY_UAT_SECRET=${GCP_UAT_SECRET_ID}:latest"
+fi
+
+gcloud run jobs deploy "$job_name" \
+  --project "$GCP_PROJECT_ID" \
+  --region "$GCP_REGION" \
+  --image "$IMAGE_URI" \
+  --command dotnet \
+  --args "worker/Glovelly.Worker.dll,business-lifecycle,advance" \
+  --service-account "$runtime_service_account" \
+  --set-env-vars "$env_vars" \
+  --set-secrets "$secrets" \
+  --max-retries 0 \
+  --task-timeout "$task_timeout"
+
+scheduler_uri="https://${GCP_REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${GCP_PROJECT_ID}/jobs/${job_name}:run"
+
+if gcloud scheduler jobs describe "$scheduler_name" --project "$GCP_PROJECT_ID" --location "$scheduler_location" >/dev/null 2>&1; then
+  gcloud scheduler jobs update http "$scheduler_name" \
+    --project "$GCP_PROJECT_ID" \
+    --location "$scheduler_location" \
+    --schedule "$schedule" \
+    --time-zone "$time_zone" \
+    --uri "$scheduler_uri" \
+    --http-method POST \
+    --oauth-service-account-email "$runtime_service_account" \
+    --oauth-token-scope "https://www.googleapis.com/auth/cloud-platform"
+else
+  gcloud scheduler jobs create http "$scheduler_name" \
+    --project "$GCP_PROJECT_ID" \
+    --location "$scheduler_location" \
+    --schedule "$schedule" \
+    --time-zone "$time_zone" \
+    --uri "$scheduler_uri" \
+    --http-method POST \
+    --oauth-service-account-email "$runtime_service_account" \
+    --oauth-token-scope "https://www.googleapis.com/auth/cloud-platform"
+fi
+
+printf 'Deployed Business lifecycle job %s and scheduler %s.\n' "$job_name" "$scheduler_name"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,6 +248,22 @@ jobs:
           GCP_SCHEDULER_LOCATION: ${{ vars.GCP_SCHEDULER_LOCATION }}
         run: bash .github/scripts/deploy-calendar-sync-job.sh
 
+      - name: Deploy Business lifecycle job staging
+        env:
+          IMAGE_URI: ${{ needs.build.outputs.image_uri }}
+          DEPLOYMENT_NAME: ${{ vars.DEPLOYMENT_NAME }}
+          DEPLOYMENT_URL: ${{ vars.DEPLOYMENT_URL }}
+          GCP_BUCKET_NAME: ${{ vars.GCP_BUCKET_NAME }}
+          GCP_CLOUD_RUN_SERVICE: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
+          GCP_CONNECTION_STRING_SECRET_ID: ${{ vars.GCP_CONNECTION_STRING_SECRET_ID }}
+          GCP_CHATGPT_REDIRECT_SECRET_ID: ${{ vars.GCP_CHATGPT_REDIRECT_SECRET_ID }}
+          GCP_UAT_SECRET_ID: ${{ vars.GCP_UAT_SECRET_ID }}
+          BUSINESS_LIFECYCLE_JOB_NAME: ${{ vars.GCP_BUSINESS_LIFECYCLE_JOB_NAME }}
+          BUSINESS_LIFECYCLE_SCHEDULER_NAME: ${{ vars.GCP_BUSINESS_LIFECYCLE_SCHEDULER_NAME }}
+          BUSINESS_LIFECYCLE_SCHEDULE: ${{ vars.BUSINESS_LIFECYCLE_SCHEDULE }}
+          GCP_SCHEDULER_LOCATION: ${{ vars.GCP_SCHEDULER_LOCATION }}
+        run: bash .github/scripts/deploy-business-lifecycle-job.sh
+
       - name: Comment staging URL on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
@@ -377,6 +393,21 @@ jobs:
           CALENDAR_SYNC_SCHEDULE: ${{ vars.CALENDAR_SYNC_SCHEDULE }}
           GCP_SCHEDULER_LOCATION: ${{ vars.GCP_SCHEDULER_LOCATION }}
         run: bash .github/scripts/deploy-calendar-sync-job.sh
+
+      - name: Deploy Business lifecycle job production
+        env:
+          IMAGE_URI: ${{ needs.build.outputs.image_uri }}
+          DEPLOYMENT_NAME: ${{ vars.DEPLOYMENT_NAME }}
+          DEPLOYMENT_URL: ${{ vars.DEPLOYMENT_URL }}
+          GCP_BUCKET_NAME: ${{ vars.GCP_BUCKET_NAME }}
+          GCP_CLOUD_RUN_SERVICE: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
+          GCP_CONNECTION_STRING_SECRET_ID: ${{ vars.GCP_CONNECTION_STRING_SECRET_ID }}
+          GCP_CHATGPT_REDIRECT_SECRET_ID: ${{ vars.GCP_CHATGPT_REDIRECT_SECRET_ID }}
+          BUSINESS_LIFECYCLE_JOB_NAME: ${{ vars.GCP_BUSINESS_LIFECYCLE_JOB_NAME }}
+          BUSINESS_LIFECYCLE_SCHEDULER_NAME: ${{ vars.GCP_BUSINESS_LIFECYCLE_SCHEDULER_NAME }}
+          BUSINESS_LIFECYCLE_SCHEDULE: ${{ vars.BUSINESS_LIFECYCLE_SCHEDULE }}
+          GCP_SCHEDULER_LOCATION: ${{ vars.GCP_SCHEDULER_LOCATION }}
+        run: bash .github/scripts/deploy-business-lifecycle-job.sh
 
   production_smoke:
     name: Run production smoke tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ dotnet tool run docfx docs/docfx.json --serve  # local handbook
 - `Configuration/StartupSettings.cs` chooses PostgreSQL vs in-memory by presence of `ConnectionStrings:Glovelly`; development seed data only runs for non-Postgres, non-testing startup.
 - `Endpoints/CrudEndpoints.cs` maps protected `/clients`, `/gigs`, `/gig-imports`, `/invoices`, `/invoice-lines`, and `/seller-profile` groups. Auth/access/Google Drive/MCP/admin/expense statements are mapped separately in `Program.cs`.
 - `Endpoints/EndpointSupport.cs` owns high-risk shared behavior: `WhereVisibleTo`, create/update stamping, gig validation, invoice status transition rules, filename/subject validation, and gig expense normalization.
+- Product wording may call `GigStatus.Confirmed` gigs "planned gigs"; code and persisted JSON use `Confirmed`.
 - `Services/InvoiceWorkflowService.cs` and related invoice services own invoice creation, generated lines, PDFs, issue/reissue, delivery, and gig linkage. Do not duplicate that flow inside endpoints.
 - `Services/GlovellyMcpQueryService.cs` performs user-scoped MCP EF projections; MCP tools should remain scoped by authenticated user visibility.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The workflow:
 - Injects the Resend API key into Cloud Run as `Email__Resend__ApiKey`
 - Deploys `main` to the `glovelly` Cloud Run service
 - Deploys each internal pull request to the shared `glovelly-staging` Cloud Run service and comments the preview URL on the PR
-- Deploys the Calendar sync Cloud Run Job and Cloud Scheduler trigger for eligible environments
+- Deploys the Calendar sync and Business lifecycle Cloud Run Jobs and Cloud Scheduler triggers for eligible environments
 
 The image is published to the Google Artifact Registry image configured in `.github/workflows/main.yml`.
 

--- a/backend/Glovelly.Api.Tests/BusinessLifecycleAdvancementTests.cs
+++ b/backend/Glovelly.Api.Tests/BusinessLifecycleAdvancementTests.cs
@@ -1,0 +1,215 @@
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
+using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class BusinessLifecycleAdvancementTests : IClassFixture<GlovellyApiFactory>
+{
+    private readonly GlovellyApiFactory _factory;
+
+    public BusinessLifecycleAdvancementTests(GlovellyApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task BusinessLifecycleTask_WhenNextWorkIsInFuture_Skips()
+    {
+        _ = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        var task = scope.ServiceProvider.GetRequiredService<BusinessLifecycleAdvancementScheduledTask>();
+        var now = new DateTimeOffset(2026, 5, 1, 9, 0, 0, TimeSpan.Zero);
+
+        await stateStore.WriteAsync(new ScheduledTaskStateEnvelope<BusinessLifecycleAdvancementTaskState>
+        {
+            TaskName = ScheduledTaskNames.BusinessLifecycleAdvancement,
+            LastSuccessfulRunUtc = now,
+            State = new BusinessLifecycleAdvancementTaskState
+            {
+                NextGigCompletionDate = new DateOnly(2026, 5, 2),
+                NextInvoiceOverdueDate = new DateOnly(2026, 5, 3),
+                LastSuccessfulAdvancementUtc = now
+            }
+        }, TestContext.Current.CancellationToken);
+
+        var decision = await task.ShouldRunAsync(
+            new ScheduledTaskContext(now),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(decision.ShouldRun);
+    }
+
+    [Fact]
+    public async Task BusinessLifecycleTask_WhenNextWorkIsDue_Runs()
+    {
+        _ = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        var task = scope.ServiceProvider.GetRequiredService<BusinessLifecycleAdvancementScheduledTask>();
+        var now = new DateTimeOffset(2026, 5, 2, 9, 0, 0, TimeSpan.Zero);
+
+        await stateStore.WriteAsync(new ScheduledTaskStateEnvelope<BusinessLifecycleAdvancementTaskState>
+        {
+            TaskName = ScheduledTaskNames.BusinessLifecycleAdvancement,
+            LastSuccessfulRunUtc = now.AddHours(-1),
+            State = new BusinessLifecycleAdvancementTaskState
+            {
+                NextGigCompletionDate = new DateOnly(2026, 5, 2),
+                LastSuccessfulAdvancementUtc = now.AddHours(-1)
+            }
+        }, TestContext.Current.CancellationToken);
+
+        var decision = await task.ShouldRunAsync(
+            new ScheduledTaskContext(now),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(decision.ShouldRun);
+    }
+
+    [Fact]
+    public async Task BusinessLifecycleTask_AdvancesDueGigsAndInvoicesAndRecomputesWakeState()
+    {
+        _ = _factory.CreateClient();
+        var now = new DateTimeOffset(2026, 5, 2, 9, 0, 0, TimeSpan.Zero);
+        var pastGigId = Guid.Parse("11111111-1111-1111-1111-111111111171");
+        var futureGigId = Guid.Parse("11111111-1111-1111-1111-111111111172");
+        var draftPastGigId = Guid.Parse("11111111-1111-1111-1111-111111111173");
+        var pastInvoiceId = Guid.Parse("22222222-2222-2222-2222-222222222271");
+        var futureInvoiceId = Guid.Parse("22222222-2222-2222-2222-222222222272");
+        var paidPastInvoiceId = Guid.Parse("22222222-2222-2222-2222-222222222273");
+
+        using (var seedScope = _factory.Services.CreateScope())
+        {
+            var db = seedScope.ServiceProvider.GetRequiredService<AppDbContext>();
+            db.Gigs.AddRange(
+                BuildGig(pastGigId, new DateOnly(2026, 5, 1), GigStatus.Confirmed),
+                BuildGig(futureGigId, new DateOnly(2026, 5, 4), GigStatus.Confirmed),
+                BuildGig(draftPastGigId, new DateOnly(2026, 5, 1), GigStatus.Draft));
+            db.Invoices.AddRange(
+                BuildInvoice(pastInvoiceId, "GLV-LIFE-001", new DateOnly(2026, 5, 1), InvoiceStatus.Issued),
+                BuildInvoice(futureInvoiceId, "GLV-LIFE-002", new DateOnly(2026, 5, 5), InvoiceStatus.Issued),
+                BuildInvoice(paidPastInvoiceId, "GLV-LIFE-003", new DateOnly(2026, 5, 1), InvoiceStatus.Paid));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var runScope = _factory.Services.CreateScope())
+        {
+            var task = runScope.ServiceProvider.GetRequiredService<BusinessLifecycleAdvancementScheduledTask>();
+            var result = await task.ExecuteAsync(
+                new BusinessLifecycleAdvancementOptions(),
+                new ScheduledTaskContext(now),
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(1, result.CompletedGigs);
+            Assert.Equal(2, result.OverdueInvoices);
+            Assert.Equal(new DateOnly(2026, 5, 5), result.NextGigCompletionDate);
+            Assert.Equal(new DateOnly(2026, 5, 6), result.NextInvoiceOverdueDate);
+        }
+
+        using var assertScope = _factory.Services.CreateScope();
+        var assertDb = assertScope.ServiceProvider.GetRequiredService<AppDbContext>();
+        Assert.Equal(GigStatus.Completed, await GetGigStatusAsync(assertDb, pastGigId));
+        Assert.Equal(GigStatus.Confirmed, await GetGigStatusAsync(assertDb, futureGigId));
+        Assert.Equal(GigStatus.Draft, await GetGigStatusAsync(assertDb, draftPastGigId));
+        Assert.Equal(InvoiceStatus.Overdue, await GetInvoiceStatusAsync(assertDb, pastInvoiceId));
+        Assert.Equal(InvoiceStatus.Issued, await GetInvoiceStatusAsync(assertDb, futureInvoiceId));
+        Assert.Equal(InvoiceStatus.Paid, await GetInvoiceStatusAsync(assertDb, paidPastInvoiceId));
+        Assert.True(await assertDb.CalendarSyncWorkItems.AnyAsync(
+            item => item.GigId == pastGigId && item.Reason == CalendarSyncWorkItemReason.GigUpdated,
+            TestContext.Current.CancellationToken));
+
+        var stateStore = assertScope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        var envelope = await stateStore.ReadAsync<BusinessLifecycleAdvancementTaskState>(
+            ScheduledTaskNames.BusinessLifecycleAdvancement,
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(envelope);
+        Assert.Equal(new DateOnly(2026, 5, 5), envelope.State.NextGigCompletionDate);
+        Assert.Equal(new DateOnly(2026, 5, 6), envelope.State.NextInvoiceOverdueDate);
+        Assert.Equal(now, envelope.State.LastSuccessfulAdvancementUtc);
+    }
+
+    [Fact]
+    public async Task BusinessLifecycleSignal_TracksEarlierConfirmedGigCandidateOnly()
+    {
+        _ = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        var signal = scope.ServiceProvider.GetRequiredService<IBusinessLifecycleSignal>();
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        await stateStore.WriteAsync(new ScheduledTaskStateEnvelope<BusinessLifecycleAdvancementTaskState>
+        {
+            TaskName = ScheduledTaskNames.BusinessLifecycleAdvancement
+        }, TestContext.Current.CancellationToken);
+
+        await signal.TrackGigAsync(
+            BuildGig(Guid.NewGuid(), new DateOnly(2026, 5, 10), GigStatus.Confirmed),
+            TestContext.Current.CancellationToken);
+        await signal.TrackGigAsync(
+            BuildGig(Guid.NewGuid(), new DateOnly(2026, 5, 20), GigStatus.Confirmed),
+            TestContext.Current.CancellationToken);
+        await signal.TrackGigAsync(
+            BuildGig(Guid.NewGuid(), new DateOnly(2026, 5, 1), GigStatus.Draft),
+            TestContext.Current.CancellationToken);
+
+        var envelope = await stateStore.ReadAsync<BusinessLifecycleAdvancementTaskState>(
+            ScheduledTaskNames.BusinessLifecycleAdvancement,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(envelope);
+        Assert.Equal(new DateOnly(2026, 5, 11), envelope.State.NextGigCompletionDate);
+        Assert.Null(envelope.State.NextInvoiceOverdueDate);
+    }
+
+    private static Gig BuildGig(Guid id, DateOnly date, GigStatus status)
+    {
+        return new Gig
+        {
+            Id = id,
+            ClientId = TestData.FoxAndFinchId,
+            CreatedByUserId = TestAuthContext.UserId,
+            UpdatedByUserId = TestAuthContext.UserId,
+            Title = $"Lifecycle gig {id:N}",
+            Date = date,
+            Venue = "Lifecycle Hall",
+            Fee = 100,
+            Status = status
+        };
+    }
+
+    private static Invoice BuildInvoice(Guid id, string invoiceNumber, DateOnly dueDate, InvoiceStatus status)
+    {
+        return new Invoice
+        {
+            Id = id,
+            InvoiceNumber = invoiceNumber,
+            ClientId = TestData.FoxAndFinchId,
+            CreatedByUserId = TestAuthContext.UserId,
+            UpdatedByUserId = TestAuthContext.UserId,
+            InvoiceDate = dueDate.AddDays(-14),
+            DueDate = dueDate,
+            Status = status,
+            Description = "Lifecycle invoice"
+        };
+    }
+
+    private static async Task<GigStatus> GetGigStatusAsync(AppDbContext dbContext, Guid id)
+    {
+        return await dbContext.Gigs
+            .Where(gig => gig.Id == id)
+            .Select(gig => gig.Status)
+            .SingleAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<InvoiceStatus> GetInvoiceStatusAsync(AppDbContext dbContext, Guid id)
+    {
+        return await dbContext.Invoices
+            .Where(invoice => invoice.Id == id)
+            .Select(invoice => invoice.Status)
+            .SingleAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -590,7 +590,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task QuickReceiptDraft_WithNearbyGig_CreatesDraftExpenseAndAttachment()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var today = new DateOnly(2026, 1, 1);
         var createResponse = await _client.PostAsJsonAsync("/gigs", new
         {
             clientId = TestData.FoxAndFinchId,
@@ -601,7 +601,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
             travelMiles = 0.00m,
             notes = "Receipt draft test",
             wasDriving = true,
-            status = 1,
+            status = "Completed",
             expenses = Array.Empty<object>(),
             invoicedAt = (string?)null,
         }, TestContext.Current.CancellationToken);
@@ -636,7 +636,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task QuickReceiptDraft_WithCandidateInsideAmbiguityWindow_FlagsNearbyCandidates()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var today = new DateOnly(2026, 1, 1);
         foreach (var (title, offset) in new[] { ("Yesterday show", -1), ("Tomorrow show", 1), ("Next week show", 7) })
         {
             var createResponse = await _client.PostAsJsonAsync("/gigs", new
@@ -649,7 +649,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
                 travelMiles = 0.00m,
                 notes = "Ambiguous receipt draft test",
                 wasDriving = true,
-                status = 1,
+                status = offset < 0 ? "Completed" : "Confirmed",
                 expenses = Array.Empty<object>(),
                 invoicedAt = (string?)null,
             }, TestContext.Current.CancellationToken);
@@ -678,7 +678,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task QuickReceiptDraft_WithCandidateOutsideAmbiguityWindow_DoesNotFlagNearbyCandidates()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var today = new DateOnly(2026, 1, 1);
         foreach (var (title, offset) in new[] { ("Today show", 0), ("Last month show", -20) })
         {
             var createResponse = await _client.PostAsJsonAsync("/gigs", new
@@ -691,7 +691,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
                 travelMiles = 0.00m,
                 notes = "Distant ambiguity test",
                 wasDriving = true,
-                status = 1,
+                status = offset < 0 ? "Completed" : "Confirmed",
                 expenses = Array.Empty<object>(),
                 invoicedAt = (string?)null,
             }, TestContext.Current.CancellationToken);
@@ -715,7 +715,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task QuickReceiptDraft_WithNoCandidateInsideWindow_ReturnsEmptyCandidates()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var today = new DateOnly(2026, 1, 1);
         foreach (var (title, offset) in new[] { ("Old show", -45), ("Future show", 60) })
         {
             var createResponse = await _client.PostAsJsonAsync("/gigs", new
@@ -728,7 +728,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
                 travelMiles = 0.00m,
                 notes = "Distant receipt draft test",
                 wasDriving = true,
-                status = 1,
+                status = offset < 0 ? "Completed" : "Confirmed",
                 expenses = Array.Empty<object>(),
                 invoicedAt = (string?)null,
             }, TestContext.Current.CancellationToken);
@@ -755,7 +755,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
         {
             clientId = TestData.FoxAndFinchId,
             title = "Future receipt target",
-            date = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime).AddDays(60).ToString("yyyy-MM-dd"),
+            date = new DateOnly(2026, 1, 1).AddDays(60).ToString("yyyy-MM-dd"),
             venue = "Airport",
             fee = 120.00m,
             travelMiles = 0.00m,
@@ -784,7 +784,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task UpdateQuickReceiptDraft_SavesDetailsAndMovesGig()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var today = new DateOnly(2026, 1, 1);
         var firstGigResponse = await _client.PostAsJsonAsync("/gigs", new
         {
             clientId = TestData.FoxAndFinchId,
@@ -1122,6 +1122,111 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task CreateGig_WhenPlannedDateIsInPast_ReturnsValidationProblem()
+    {
+        var pastDate = new DateOnly(2025, 12, 31);
+
+        var response = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Past planned gig",
+            date = $"{pastDate:yyyy-MM-dd}",
+            venue = "Botanical Gardens",
+            fee = 125.00m,
+            travelMiles = 0,
+            wasDriving = false,
+            status = "Confirmed",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(
+            "Planned gigs cannot be in the past.",
+            problem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
+
+    [Fact]
+    public async Task CreateGig_WhenPlannedDateIsToday_CreatesGig()
+    {
+        var today = new DateOnly(2026, 1, 1);
+
+        var response = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Today planned gig",
+            date = $"{today:yyyy-MM-dd}",
+            venue = "Botanical Gardens",
+            fee = 125.00m,
+            travelMiles = 0,
+            wasDriving = false,
+            status = "Confirmed",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateGig_WhenPlannedDateIsInPast_ReturnsValidationProblem()
+    {
+        var futureDate = new DateOnly(2026, 1, 8);
+        var pastDate = new DateOnly(2025, 12, 31);
+        var createdGig = await CreateGigAsync(_client, "Past planned update target", $"{futureDate:yyyy-MM-dd}");
+        var gigId = createdGig.GetProperty("id").GetGuid();
+
+        var response = await _client.PutAsJsonAsync($"/gigs/{gigId}", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Past planned update target",
+            date = $"{pastDate:yyyy-MM-dd}",
+            venue = "Botanical Gardens",
+            fee = 125.00m,
+            travelMiles = 0,
+            wasDriving = false,
+            status = "Confirmed",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(
+            "Planned gigs cannot be in the past.",
+            problem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
+
+    [Fact]
+    public async Task UpdateGigStatus_WhenPastGigWouldReturnToPlanned_ReturnsValidationProblem()
+    {
+        var pastDate = new DateOnly(2025, 12, 31);
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Past completed gig",
+            date = $"{pastDate:yyyy-MM-dd}",
+            venue = "Botanical Gardens",
+            fee = 125.00m,
+            travelMiles = 0,
+            wasDriving = false,
+            status = "Completed",
+        }, TestContext.Current.CancellationToken);
+        createResponse.EnsureSuccessStatusCode();
+        var createdGig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        var gigId = createdGig.GetProperty("id").GetGuid();
+
+        var response = await _client.PatchAsJsonAsync($"/gigs/{gigId}/status", new
+        {
+            status = "Confirmed",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(
+            "Planned gigs cannot be in the past.",
+            problem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
+
+    [Fact]
     public async Task DeleteGig_WhenPlanned_DeletesGig()
     {
         var createResponse = await _client.PostAsJsonAsync("/gigs", new
@@ -1414,8 +1519,8 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task QuickExternalResourceDraftFile_WithNearbyGig_CreatesDraftResourceAndAttachment()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
-        var gig = await CreateGigAsync(_client, "Attachment quick match", today.AddDays(-1).ToString("yyyy-MM-dd"));
+        var today = new DateOnly(2026, 1, 1);
+        var gig = await CreateGigAsync(_client, "Attachment quick match", today.AddDays(-1).ToString("yyyy-MM-dd"), "Completed");
         var gigId = gig.GetProperty("id").GetGuid();
 
         using var form = BuildReceiptDraftForm("# Contract notes"u8.ToArray(), "contract.md", "text/markdown");
@@ -1471,8 +1576,8 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task QuickExternalResourceDraftFile_WithNoCandidateInsideWindow_ReturnsEmptyCandidates()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
-        _ = await CreateGigAsync(_client, "Old attachment show", today.AddDays(-45).ToString("yyyy-MM-dd"));
+        var today = new DateOnly(2026, 1, 1);
+        _ = await CreateGigAsync(_client, "Old attachment show", today.AddDays(-45).ToString("yyyy-MM-dd"), "Completed");
         _ = await CreateGigAsync(_client, "Future attachment show", today.AddDays(60).ToString("yyyy-MM-dd"));
 
         using var form = BuildReceiptDraftForm("plan"u8.ToArray(), "plan.pdf", "application/pdf");
@@ -1489,7 +1594,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     [Fact]
     public async Task UpdateQuickExternalResourceDraft_SavesDetailsMovesGigAndUpdatesPrimary()
     {
-        var today = DateOnly.FromDateTime(DateTimeOffset.Now.DateTime);
+        var today = new DateOnly(2026, 1, 1);
         var firstGig = await CreateGigAsync(_client, "Attachment first target", today.ToString("yyyy-MM-dd"));
         var firstGigId = firstGig.GetProperty("id").GetGuid();
         var secondGig = await CreateGigAsync(_client, "Attachment corrected target", today.AddDays(2).ToString("yyyy-MM-dd"));
@@ -1570,7 +1675,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Empty(savedGig.GetProperty("externalResources").EnumerateArray());
     }
 
-    private static async Task<JsonElement> CreateGigAsync(HttpClient client, string title, string date = "2026-08-01")
+    private static async Task<JsonElement> CreateGigAsync(HttpClient client, string title, string date = "2026-08-01", string status = "Confirmed")
     {
         var createResponse = await client.PostAsJsonAsync("/gigs", new
         {
@@ -1581,7 +1686,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
             fee = 125.00m,
             travelMiles = 0,
             wasDriving = false,
-            status = "Confirmed",
+            status,
         }, TestContext.Current.CancellationToken);
         createResponse.EnsureSuccessStatusCode();
 

--- a/backend/Glovelly.Api.Tests/GigImportEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigImportEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Glovelly.Api.Data;
 using Glovelly.Api.Models;
+using Glovelly.Api.Services;
 using Glovelly.Api.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,6 +30,14 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         var batchId = Guid.NewGuid();
         var draftId = Guid.NewGuid();
         await SeedImportBatchAsync(batchId, draftId);
+        using (var stateScope = _factory.Services.CreateScope())
+        {
+            var resetStateStore = stateScope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+            await resetStateStore.WriteAsync(new ScheduledTaskStateEnvelope<BusinessLifecycleAdvancementTaskState>
+            {
+                TaskName = ScheduledTaskNames.BusinessLifecycleAdvancement
+            }, TestContext.Current.CancellationToken);
+        }
 
         var response = await _client.PostAsJsonAsync($"/gig-imports/{batchId}/commit", new
         {
@@ -58,6 +67,12 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(batchId, gig.SourceImportBatchId);
         Assert.Equal(draftId, gig.SourceImportDraftId);
         Assert.Equal(GigImportDraftStatus.Committed, draftStatus);
+        var stateStore = scope.ServiceProvider.GetRequiredService<IScheduledTaskStateStore>();
+        var envelope = await stateStore.ReadAsync<BusinessLifecycleAdvancementTaskState>(
+            ScheduledTaskNames.BusinessLifecycleAdvancement,
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(envelope);
+        Assert.Equal(new DateOnly(2026, 11, 29), envelope.State.NextGigCompletionDate);
         Assert.Collection(gig.Expenses, expense =>
         {
             Assert.Equal("Per diem", expense.Description);
@@ -84,6 +99,28 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         var errors = problem.GetProperty("errors").GetProperty($"drafts.{draftId}");
         Assert.Contains(errors.EnumerateArray(), value => value.GetString() == "Client is required.");
         Assert.Contains(errors.EnumerateArray(), value => value.GetString() == "Title is required.");
+        Assert.Equal(0, await CountGigsAsync());
+    }
+
+    [Fact]
+    public async Task CommitSelectedRows_WithPastPlannedDate_ReturnsValidationProblem()
+    {
+        var batchId = Guid.NewGuid();
+        var draftId = Guid.NewGuid();
+        var pastDate = new DateOnly(2025, 12, 31);
+        await SeedImportBatchAsync(batchId, draftId, proposedDate: pastDate);
+
+        var response = await _client.PostAsJsonAsync($"/gig-imports/{batchId}/commit", new
+        {
+            draftIds = new[] { draftId },
+            commitAccepted = false,
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        var errors = problem.GetProperty("errors").GetProperty($"drafts.{draftId}");
+        Assert.Contains(errors.EnumerateArray(), value => value.GetString() == "Planned gigs cannot be in the past.");
         Assert.Equal(0, await CountGigsAsync());
     }
 
@@ -251,7 +288,8 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         Guid batchId,
         Guid draftId,
         bool includeRequiredFields = true,
-        string? sourceFingerprint = null)
+        string? sourceFingerprint = null,
+        DateOnly? proposedDate = null)
     {
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -271,7 +309,7 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
                     Id = draftId,
                     ProposedClientId = includeRequiredFields ? TestData.FoxAndFinchId : null,
                     ProposedTitle = includeRequiredFields ? "Swing Into Christmas" : null,
-                    ProposedDate = includeRequiredFields ? new DateOnly(2026, 11, 28) : null,
+                    ProposedDate = includeRequiredFields ? proposedDate ?? new DateOnly(2026, 11, 28) : null,
                     ProposedVenueName = includeRequiredFields ? "Music Hall" : null,
                     ProposedVenueAddress = includeRequiredFields ? "Aberdeen" : null,
                     ProposedVenuePostcode = includeRequiredFields ? "AB10 1AA" : null,

--- a/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
+++ b/backend/Glovelly.Api.Tests/Infrastructure/GlovellyApiFactory.cs
@@ -62,6 +62,7 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
             services.RemoveAll<IMileageEstimationService>();
             services.RemoveAll<IBlobStore>();
             services.RemoveAll<IExpenseAttachmentStore>();
+            services.RemoveAll<TimeProvider>();
 
             if (!_useRealAuthentication)
             {
@@ -73,6 +74,7 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
             services.AddSingleton<IMileageEstimationService>(_fakeMileageEstimationService);
             services.AddSingleton<IBlobStore, InMemoryBlobStore>();
             services.AddSingleton<IExpenseAttachmentStore, ExpenseAttachmentStore>();
+            services.AddSingleton<TimeProvider>(new FixedTimeProvider(new DateTimeOffset(2026, 1, 1, 9, 0, 0, TimeSpan.Zero)));
             services.PostConfigure<EmailSettings>(settings =>
             {
                 settings.AccessRequests.FromAddress = "access@glovelly.test";
@@ -202,5 +204,10 @@ public sealed class GlovellyApiFactory : WebApplicationFactory<Program>
         dbContext.Clients.AddRange(clients);
         dbContext.Invoices.AddRange(invoices);
         dbContext.SaveChanges();
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
     }
 }

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -56,6 +56,28 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
     }
 
     [Fact]
+    public async Task UpdateStatus_WhenOverdueCannotReturnDirectlyToIssued_ReturnsValidationProblem()
+    {
+        var makeOverdueResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.FoxInvoiceId}/status", new
+        {
+            status = "Overdue",
+        }, TestContext.Current.CancellationToken);
+        makeOverdueResponse.EnsureSuccessStatusCode();
+
+        var response = await _client.PutAsJsonAsync($"/invoices/{TestData.FoxInvoiceId}/status", new
+        {
+            status = "Issued",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(
+            "Invoice status cannot move from Overdue to Issued.",
+            problem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
+
+    [Fact]
     public async Task UpdateStatus_WhenInvoiceHasLines_ResponseKeepsLineTotals()
     {
         var createLineResponse = await _client.PostAsJsonAsync("/invoice-lines", new

--- a/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
@@ -178,7 +178,7 @@ internal static class EndpointSupport
         profile.UpdatedUtc = DateTimeOffset.UtcNow;
     }
 
-    public static IResult? ValidateGigRequest(Gig gig)
+    public static IResult? ValidateGigRequest(Gig gig, DateOnly today)
     {
         var errors = new Dictionary<string, string[]>();
 
@@ -216,6 +216,10 @@ internal static class EndpointSupport
         {
             errors["status"] = ["Status is invalid."];
         }
+        else if (IsPastPlannedGig(gig.Status, gig.Date, today))
+        {
+            errors["status"] = ["Planned gigs cannot be in the past."];
+        }
 
         if (gig.PassengerCount.HasValue && gig.PassengerCount.Value < 0)
         {
@@ -238,6 +242,18 @@ internal static class EndpointSupport
         }
 
         return errors.Count > 0 ? Results.ValidationProblem(errors) : null;
+    }
+
+    public static IResult? ValidateGigLifecycleStatus(GigStatus status, DateOnly date, DateOnly today)
+    {
+        return IsPastPlannedGig(status, date, today)
+            ? ValidationProblem("status", "Planned gigs cannot be in the past.")
+            : null;
+    }
+
+    public static bool IsPastPlannedGig(GigStatus status, DateOnly date, DateOnly today)
+    {
+        return status == GigStatus.Confirmed && date < today;
     }
 
     public static List<GigExpense> NormalizeGigExpenses(ICollection<GigExpense>? expenses, bool preserveIds = true)

--- a/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
@@ -45,7 +45,8 @@ internal static class GigCrudEndpoints
             ICurrentUserAccessor currentUserAccessor,
             IWorkspaceEventPublisher workspaceEventPublisher,
             ICalendarSyncWorkQueue calendarSyncWorkQueue,
-            IBusinessLifecycleSignal businessLifecycleSignal) =>
+            IBusinessLifecycleSignal businessLifecycleSignal,
+            TimeProvider timeProvider) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
@@ -61,6 +62,15 @@ internal static class GigCrudEndpoints
             if (!Enum.IsDefined(request.Status))
             {
                 return EndpointSupport.ValidationProblem("status", "Status is invalid.");
+            }
+
+            var statusValidation = EndpointSupport.ValidateGigLifecycleStatus(
+                request.Status,
+                gig.Date,
+                DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime));
+            if (statusValidation is not null)
+            {
+                return statusValidation;
             }
 
             gig.Status = request.Status;
@@ -89,10 +99,13 @@ internal static class GigCrudEndpoints
             IInvoiceWorkflowService invoiceWorkflowService,
             IWorkspaceEventPublisher workspaceEventPublisher,
             ICalendarSyncWorkQueue calendarSyncWorkQueue,
-            IBusinessLifecycleSignal businessLifecycleSignal) =>
+            IBusinessLifecycleSignal businessLifecycleSignal,
+            TimeProvider timeProvider) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
-            var gigValidation = EndpointSupport.ValidateGigRequest(gig);
+            var gigValidation = EndpointSupport.ValidateGigRequest(
+                gig,
+                DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime));
             if (gigValidation is not null)
             {
                 return gigValidation;
@@ -160,7 +173,8 @@ internal static class GigCrudEndpoints
             IInvoiceWorkflowService invoiceWorkflowService,
             IWorkspaceEventPublisher workspaceEventPublisher,
             ICalendarSyncWorkQueue calendarSyncWorkQueue,
-            IBusinessLifecycleSignal businessLifecycleSignal) =>
+            IBusinessLifecycleSignal businessLifecycleSignal,
+            TimeProvider timeProvider) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
@@ -173,7 +187,9 @@ internal static class GigCrudEndpoints
                 return Results.NotFound();
             }
 
-            var gigValidation = EndpointSupport.ValidateGigRequest(request);
+            var gigValidation = EndpointSupport.ValidateGigRequest(
+                request,
+                DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime));
             if (gigValidation is not null)
             {
                 return gigValidation;

--- a/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
@@ -44,7 +44,8 @@ internal static class GigCrudEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IWorkspaceEventPublisher workspaceEventPublisher,
-            ICalendarSyncWorkQueue calendarSyncWorkQueue) =>
+            ICalendarSyncWorkQueue calendarSyncWorkQueue,
+            IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
@@ -65,6 +66,7 @@ internal static class GigCrudEndpoints
             gig.Status = request.Status;
             EndpointSupport.StampUpdate(gig, userId);
             await db.SaveChangesAsync();
+            await businessLifecycleSignal.TrackGigAsync(gig);
             if (userId.HasValue)
             {
                 await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gig.Id, DateTimeOffset.UtcNow));
@@ -86,7 +88,8 @@ internal static class GigCrudEndpoints
             ICurrentUserAccessor currentUserAccessor,
             IInvoiceWorkflowService invoiceWorkflowService,
             IWorkspaceEventPublisher workspaceEventPublisher,
-            ICalendarSyncWorkQueue calendarSyncWorkQueue) =>
+            ICalendarSyncWorkQueue calendarSyncWorkQueue,
+            IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gigValidation = EndpointSupport.ValidateGigRequest(gig);
@@ -134,6 +137,7 @@ internal static class GigCrudEndpoints
             db.Gigs.Add(gig);
             await invoiceWorkflowService.SyncGeneratedInvoiceLinesForGigAsync(gig, userId);
             await db.SaveChangesAsync();
+            await businessLifecycleSignal.TrackGigAsync(gig);
             if (userId.HasValue)
             {
                 await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "created", gig.Id, DateTimeOffset.UtcNow));
@@ -155,7 +159,8 @@ internal static class GigCrudEndpoints
             IExpenseAttachmentStore attachmentStore,
             IInvoiceWorkflowService invoiceWorkflowService,
             IWorkspaceEventPublisher workspaceEventPublisher,
-            ICalendarSyncWorkQueue calendarSyncWorkQueue) =>
+            ICalendarSyncWorkQueue calendarSyncWorkQueue,
+            IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var gig = await db.Gigs
@@ -258,6 +263,7 @@ internal static class GigCrudEndpoints
             gig = await db.Gigs
                 .IncludeGigDetails()
                 .FirstAsync(value => value.Id == id);
+            await businessLifecycleSignal.TrackGigAsync(gig);
             if (userId.HasValue)
             {
                 await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "updated", gig.Id, DateTimeOffset.UtcNow));

--- a/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
@@ -66,6 +66,8 @@ internal static class GigImportEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IWorkspaceEventPublisher workspaceEventPublisher,
+            IBusinessLifecycleSignal businessLifecycleSignal,
+            TimeProvider timeProvider,
             IGigImportDuplicateDetectionService duplicateDetectionService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -144,6 +146,8 @@ internal static class GigImportEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IWorkspaceEventPublisher workspaceEventPublisher,
+            IBusinessLifecycleSignal businessLifecycleSignal,
+            TimeProvider timeProvider,
             IGigImportDuplicateDetectionService duplicateDetectionService) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -202,7 +206,11 @@ internal static class GigImportEndpoints
                     ToDetail(batch, duplicateWarnings)));
             }
 
-            var errors = await ValidateCommitDraftsAsync(db, userId, draftsToCommit);
+            var errors = await ValidateCommitDraftsAsync(
+                db,
+                userId,
+                draftsToCommit,
+                DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime));
             if (errors.Count > 0)
             {
                 return Results.ValidationProblem(errors);
@@ -220,6 +228,11 @@ internal static class GigImportEndpoints
             UpdateBatchStatusAfterCommittedDecisions(batch);
 
             await db.SaveChangesAsync();
+            foreach (var gig in gigs)
+            {
+                await businessLifecycleSignal.TrackGigAsync(gig);
+            }
+
             await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gigs", "created", null, DateTimeOffset.UtcNow));
             await workspaceEventPublisher.PublishAsync(userId, new WorkspaceEvent("gig-imports", "updated", batch.Id, DateTimeOffset.UtcNow));
 
@@ -268,7 +281,8 @@ internal static class GigImportEndpoints
     private static async Task<Dictionary<string, string[]>> ValidateCommitDraftsAsync(
         AppDbContext db,
         Guid? userId,
-        IReadOnlyList<GigImportDraft> drafts)
+        IReadOnlyList<GigImportDraft> drafts,
+        DateOnly today)
     {
         var errors = new Dictionary<string, string[]>();
         var clientIds = drafts
@@ -306,6 +320,10 @@ internal static class GigImportEndpoints
             if (!draft.ProposedDate.HasValue)
             {
                 draftErrors.Add("Date is required.");
+            }
+            else if (EndpointSupport.IsPastPlannedGig(GigStatus.Confirmed, draft.ProposedDate.Value, today))
+            {
+                draftErrors.Add("Planned gigs cannot be in the past.");
             }
 
             if (string.IsNullOrWhiteSpace(BuildVenue(draft)))

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -84,7 +84,12 @@ public static class InvoiceEndpoints
             return invoice is null ? Results.NotFound() : Results.Ok(invoice);
         });
 
-        group.MapPost("/", async (Invoice invoice, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
+        group.MapPost("/", async (
+            Invoice invoice,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             if (!await db.Clients
@@ -119,6 +124,7 @@ public static class InvoiceEndpoints
 
             db.Invoices.Add(invoice);
             await db.SaveChangesAsync();
+            await businessLifecycleSignal.TrackInvoiceAsync(invoice);
 
             return Results.Created($"/invoices/{invoice.Id}", invoice);
         });
@@ -129,7 +135,8 @@ public static class InvoiceEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
-            IInvoiceWorkflowService invoiceWorkflowService) =>
+            IInvoiceWorkflowService invoiceWorkflowService,
+            IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
@@ -192,6 +199,7 @@ public static class InvoiceEndpoints
             EndpointSupport.StampUpdate(invoice, userId);
 
             await db.SaveChangesAsync();
+            await businessLifecycleSignal.TrackInvoiceAsync(invoice);
 
             return Results.Ok(invoice);
         });
@@ -202,7 +210,8 @@ public static class InvoiceEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
-            IInvoiceWorkflowService invoiceWorkflowService) =>
+            IInvoiceWorkflowService invoiceWorkflowService,
+            IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var invoice = await db.Invoices
@@ -235,6 +244,7 @@ public static class InvoiceEndpoints
 
                 await invoiceWorkflowService.IssueInvoiceAsync(invoice, invoice.Client, userId);
                 await db.SaveChangesAsync();
+                await businessLifecycleSignal.TrackInvoiceAsync(invoice);
 
                 return Results.Ok(invoice);
             }
@@ -243,6 +253,7 @@ public static class InvoiceEndpoints
             invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow;
             EndpointSupport.StampUpdate(invoice, userId);
             await db.SaveChangesAsync();
+            await businessLifecycleSignal.TrackInvoiceAsync(invoice);
 
             return Results.Ok(invoice);
         });

--- a/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementOptions.cs
+++ b/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementOptions.cs
@@ -1,0 +1,3 @@
+namespace Glovelly.Api.Services;
+
+public sealed record BusinessLifecycleAdvancementOptions;

--- a/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementProcessor.cs
+++ b/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementProcessor.cs
@@ -1,0 +1,69 @@
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Glovelly.Api.Services;
+
+public sealed class BusinessLifecycleAdvancementProcessor(
+    AppDbContext dbContext,
+    ICalendarSyncWorkQueue calendarSyncWorkQueue) : IBusinessLifecycleAdvancementProcessor
+{
+    public async Task<BusinessLifecycleAdvancementResult> AdvanceAsync(
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken = default)
+    {
+        var today = DateOnly.FromDateTime(nowUtc.UtcDateTime);
+        var gigsToComplete = await dbContext.Gigs
+            .Where(gig => gig.Status == GigStatus.Confirmed && gig.Date < today)
+            .ToListAsync(cancellationToken);
+        var invoicesToMarkOverdue = await dbContext.Invoices
+            .Where(invoice => invoice.Status == InvoiceStatus.Issued && invoice.DueDate < today)
+            .ToListAsync(cancellationToken);
+
+        foreach (var gig in gigsToComplete)
+        {
+            gig.Status = GigStatus.Completed;
+        }
+
+        foreach (var invoice in invoicesToMarkOverdue)
+        {
+            invoice.Status = InvoiceStatus.Overdue;
+            invoice.StatusUpdatedUtc = nowUtc;
+        }
+
+        if (gigsToComplete.Count > 0 || invoicesToMarkOverdue.Count > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        foreach (var gig in gigsToComplete.Where(gig => gig.CreatedByUserId.HasValue))
+        {
+            var userId = gig.CreatedByUserId!.Value;
+            await calendarSyncWorkQueue.EnqueueGigAsync(
+                userId,
+                gig.Id,
+                CalendarSyncWorkItemReason.GigUpdated,
+                cancellationToken);
+        }
+
+        var nextConfirmedGigDate = await dbContext.Gigs
+            .Where(gig => gig.Status == GigStatus.Confirmed)
+            .Select(gig => (DateOnly?)gig.Date)
+            .MinAsync(cancellationToken);
+        var nextIssuedInvoiceDueDate = await dbContext.Invoices
+            .Where(invoice => invoice.Status == InvoiceStatus.Issued)
+            .Select(invoice => (DateOnly?)invoice.DueDate)
+            .MinAsync(cancellationToken);
+
+        return new BusinessLifecycleAdvancementResult(
+            gigsToComplete.Count,
+            invoicesToMarkOverdue.Count,
+            nextConfirmedGigDate.HasValue ? GetTransitionDate(nextConfirmedGigDate.Value) : null,
+            nextIssuedInvoiceDueDate.HasValue ? GetTransitionDate(nextIssuedInvoiceDueDate.Value) : null);
+    }
+
+    private static DateOnly GetTransitionDate(DateOnly sourceDate)
+    {
+        return sourceDate == DateOnly.MaxValue ? DateOnly.MaxValue : sourceDate.AddDays(1);
+    }
+}

--- a/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementResult.cs
+++ b/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementResult.cs
@@ -1,0 +1,7 @@
+namespace Glovelly.Api.Services;
+
+public sealed record BusinessLifecycleAdvancementResult(
+    int CompletedGigs,
+    int OverdueInvoices,
+    DateOnly? NextGigCompletionDate,
+    DateOnly? NextInvoiceOverdueDate);

--- a/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementScheduledTask.cs
+++ b/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementScheduledTask.cs
@@ -1,0 +1,112 @@
+namespace Glovelly.Api.Services;
+
+public sealed class BusinessLifecycleAdvancementScheduledTask(
+    IScheduledTaskStateStore stateStore,
+    IServiceScopeFactory serviceScopeFactory,
+    ILogger<BusinessLifecycleAdvancementScheduledTask> logger) : IScheduledTask<BusinessLifecycleAdvancementOptions, BusinessLifecycleAdvancementResult>
+{
+    private static readonly TimeSpan SafetyInterval = TimeSpan.FromDays(1);
+
+    public string Name => ScheduledTaskNames.BusinessLifecycleAdvancement;
+
+    public async Task<ExecutionDecision> ShouldRunAsync(
+        ScheduledTaskContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ScheduledTaskStateEnvelope<BusinessLifecycleAdvancementTaskState>? envelope;
+        try
+        {
+            envelope = await stateStore.ReadAsync<BusinessLifecycleAdvancementTaskState>(Name, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                exception,
+                "Scheduled task {TaskName} wake-gate state could not be read; running so Postgres remains the source of truth.",
+                Name);
+            return ExecutionDecision.Run("Task state could not be read.");
+        }
+
+        if (envelope is null)
+        {
+            return ExecutionDecision.Run("Task state is missing.");
+        }
+
+        var today = DateOnly.FromDateTime(context.NowUtc.UtcDateTime);
+        var nextDate = Earliest(envelope.State.NextGigCompletionDate, envelope.State.NextInvoiceOverdueDate);
+        if (nextDate.HasValue && nextDate.Value <= today)
+        {
+            return ExecutionDecision.Run($"Business lifecycle work is due from {nextDate:yyyy-MM-dd}.");
+        }
+
+        if (envelope.State.LastSuccessfulAdvancementUtc is null)
+        {
+            return ExecutionDecision.Run("Task has no recorded successful advancement.");
+        }
+
+        if (context.NowUtc - envelope.State.LastSuccessfulAdvancementUtc.Value >= SafetyInterval)
+        {
+            return ExecutionDecision.Run("Safety interval elapsed since last successful advancement.");
+        }
+
+        return nextDate.HasValue
+            ? ExecutionDecision.Skip($"Next business lifecycle work is due on {nextDate:yyyy-MM-dd}.")
+            : ExecutionDecision.Skip("No pending business lifecycle work is known.");
+    }
+
+    public async Task<BusinessLifecycleAdvancementResult> ExecuteAsync(
+        BusinessLifecycleAdvancementOptions options,
+        ScheduledTaskContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = serviceScopeFactory.CreateScope();
+        var processor = scope.ServiceProvider.GetRequiredService<IBusinessLifecycleAdvancementProcessor>();
+        var result = await processor.AdvanceAsync(context.NowUtc, cancellationToken);
+
+        try
+        {
+            await MarkSuccessfulRunAsync(context.NowUtc, result, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                exception,
+                "Scheduled task {TaskName} completed but wake-gate state could not be updated. A future safety run can recover from Postgres.",
+                Name);
+        }
+
+        return result;
+    }
+
+    private async Task MarkSuccessfulRunAsync(
+        DateTimeOffset nowUtc,
+        BusinessLifecycleAdvancementResult result,
+        CancellationToken cancellationToken)
+    {
+        var envelope = await stateStore.ReadAsync<BusinessLifecycleAdvancementTaskState>(Name, cancellationToken)
+            ?? new ScheduledTaskStateEnvelope<BusinessLifecycleAdvancementTaskState>
+            {
+                TaskName = Name
+            };
+
+        envelope.TaskName = Name;
+        envelope.LastDecisionUtc = nowUtc;
+        envelope.LastSuccessfulRunUtc = nowUtc;
+        envelope.State.NextGigCompletionDate = result.NextGigCompletionDate;
+        envelope.State.NextInvoiceOverdueDate = result.NextInvoiceOverdueDate;
+        envelope.State.LastSuccessfulAdvancementUtc = nowUtc;
+
+        await stateStore.WriteAsync(envelope, cancellationToken);
+    }
+
+    private static DateOnly? Earliest(DateOnly? first, DateOnly? second)
+    {
+        return (first, second) switch
+        {
+            ({ } firstValue, { } secondValue) => firstValue <= secondValue ? firstValue : secondValue,
+            ({ } firstValue, null) => firstValue,
+            (null, { } secondValue) => secondValue,
+            _ => null
+        };
+    }
+}

--- a/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementTaskState.cs
+++ b/backend/Glovelly.Api/Services/BusinessLifecycleAdvancementTaskState.cs
@@ -1,0 +1,10 @@
+namespace Glovelly.Api.Services;
+
+public sealed class BusinessLifecycleAdvancementTaskState
+{
+    public DateOnly? NextGigCompletionDate { get; set; }
+
+    public DateOnly? NextInvoiceOverdueDate { get; set; }
+
+    public DateTimeOffset? LastSuccessfulAdvancementUtc { get; set; }
+}

--- a/backend/Glovelly.Api/Services/BusinessLifecycleSignal.cs
+++ b/backend/Glovelly.Api/Services/BusinessLifecycleSignal.cs
@@ -1,0 +1,76 @@
+using Glovelly.Api.Models;
+
+namespace Glovelly.Api.Services;
+
+public sealed class BusinessLifecycleSignal(
+    IScheduledTaskStateStore stateStore,
+    ILogger<BusinessLifecycleSignal> logger) : IBusinessLifecycleSignal
+{
+    public Task TrackGigAsync(Gig gig, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(gig);
+
+        return gig.Status == GigStatus.Confirmed
+            ? TrackCandidateAsync(GetTransitionDate(gig.Date), isGigCandidate: true, cancellationToken)
+            : Task.CompletedTask;
+    }
+
+    public Task TrackInvoiceAsync(Invoice invoice, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(invoice);
+
+        return invoice.Status == InvoiceStatus.Issued
+            ? TrackCandidateAsync(GetTransitionDate(invoice.DueDate), isGigCandidate: false, cancellationToken)
+            : Task.CompletedTask;
+    }
+
+    private async Task TrackCandidateAsync(
+        DateOnly candidateDate,
+        bool isGigCandidate,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var envelope = await stateStore.ReadAsync<BusinessLifecycleAdvancementTaskState>(
+                ScheduledTaskNames.BusinessLifecycleAdvancement,
+                cancellationToken)
+                ?? new ScheduledTaskStateEnvelope<BusinessLifecycleAdvancementTaskState>
+                {
+                    TaskName = ScheduledTaskNames.BusinessLifecycleAdvancement
+                };
+
+            var currentDate = isGigCandidate
+                ? envelope.State.NextGigCompletionDate
+                : envelope.State.NextInvoiceOverdueDate;
+
+            if (currentDate.HasValue && currentDate.Value <= candidateDate)
+            {
+                return;
+            }
+
+            envelope.TaskName = ScheduledTaskNames.BusinessLifecycleAdvancement;
+            if (isGigCandidate)
+            {
+                envelope.State.NextGigCompletionDate = candidateDate;
+            }
+            else
+            {
+                envelope.State.NextInvoiceOverdueDate = candidateDate;
+            }
+
+            await stateStore.WriteAsync(envelope, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                exception,
+                "Failed to update scheduled task {TaskName} candidate state. The next safety run can recover from Postgres.",
+                ScheduledTaskNames.BusinessLifecycleAdvancement);
+        }
+    }
+
+    private static DateOnly GetTransitionDate(DateOnly sourceDate)
+    {
+        return sourceDate == DateOnly.MaxValue ? DateOnly.MaxValue : sourceDate.AddDays(1);
+    }
+}

--- a/backend/Glovelly.Api/Services/IBusinessLifecycleAdvancementProcessor.cs
+++ b/backend/Glovelly.Api/Services/IBusinessLifecycleAdvancementProcessor.cs
@@ -1,0 +1,8 @@
+namespace Glovelly.Api.Services;
+
+public interface IBusinessLifecycleAdvancementProcessor
+{
+    Task<BusinessLifecycleAdvancementResult> AdvanceAsync(
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/Glovelly.Api/Services/IBusinessLifecycleSignal.cs
+++ b/backend/Glovelly.Api/Services/IBusinessLifecycleSignal.cs
@@ -1,0 +1,10 @@
+using Glovelly.Api.Models;
+
+namespace Glovelly.Api.Services;
+
+public interface IBusinessLifecycleSignal
+{
+    Task TrackGigAsync(Gig gig, CancellationToken cancellationToken = default);
+
+    Task TrackInvoiceAsync(Invoice invoice, CancellationToken cancellationToken = default);
+}

--- a/backend/Glovelly.Api/Services/ScheduledTaskContracts.cs
+++ b/backend/Glovelly.Api/Services/ScheduledTaskContracts.cs
@@ -28,4 +28,5 @@ public sealed record ExecutionDecision(bool ShouldRun, string Reason)
 public static class ScheduledTaskNames
 {
     public const string GoogleCalendarPropagation = "google-calendar-propagation";
+    public const string BusinessLifecycleAdvancement = "business-lifecycle-advancement";
 }

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -30,9 +30,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICalendarSyncWorkQueue, CalendarSyncWorkQueue>();
         services.AddScoped<IGoogleCalendarSyncProcessor, GoogleCalendarSyncProcessor>();
         services.AddScoped<ICalendarSyncQueueDrainer, CalendarSyncQueueDrainer>();
+        services.AddScoped<IBusinessLifecycleAdvancementProcessor, BusinessLifecycleAdvancementProcessor>();
+        services.AddSingleton<IBusinessLifecycleSignal, BusinessLifecycleSignal>();
         services.AddSingleton<IScheduledTaskStateStore, BlobScheduledTaskStateStore>();
         services.AddSingleton<IScheduledTaskSignal, ScheduledTaskSignal>();
         services.AddSingleton<GoogleCalendarPropagationScheduledTask>();
+        services.AddSingleton<BusinessLifecycleAdvancementScheduledTask>();
         services.AddOptions<GoogleRoutesMileageSettings>()
             .BindConfiguration(GoogleRoutesMileageSettings.SectionName);
         services.AddHttpClient<GoogleRoutesMileageEstimationService>();

--- a/backend/Glovelly.Worker/Program.cs
+++ b/backend/Glovelly.Worker/Program.cs
@@ -59,8 +59,21 @@ static RootCommand BuildRootCommand(IServiceProvider services)
     var calendarSyncCommand = new Command("calendar-sync", "Manage Google Calendar sync background work.");
     calendarSyncCommand.Subcommands.Add(drainCommand);
 
+    var advanceCommand = new Command("advance", "Advance due business lifecycle transitions.");
+    advanceCommand.SetAction(async (_, cancellationToken) =>
+    {
+        return await RunBusinessLifecycleAdvancementAsync(
+            new BusinessLifecycleAdvancementOptions(),
+            services,
+            cancellationToken);
+    });
+
+    var businessLifecycleCommand = new Command("business-lifecycle", "Manage automatic business lifecycle transitions.");
+    businessLifecycleCommand.Subcommands.Add(advanceCommand);
+
     var rootCommand = new RootCommand("Glovelly background worker commands.");
     rootCommand.Subcommands.Add(calendarSyncCommand);
+    rootCommand.Subcommands.Add(businessLifecycleCommand);
     return rootCommand;
 }
 
@@ -101,6 +114,44 @@ static async Task<int> RunCalendarSyncDrainAsync(
         result.Skipped,
         result.Recovered,
         result.CompletionReason);
+
+    return 0;
+}
+
+static async Task<int> RunBusinessLifecycleAdvancementAsync(
+    BusinessLifecycleAdvancementOptions options,
+    IServiceProvider services,
+    CancellationToken cancellationToken)
+{
+    var logger = services
+        .GetRequiredService<ILoggerFactory>()
+        .CreateLogger("Glovelly.Worker.BusinessLifecycle");
+    var timeProvider = services.GetRequiredService<TimeProvider>();
+    var scheduledTask = services.GetRequiredService<BusinessLifecycleAdvancementScheduledTask>();
+    var context = new ScheduledTaskContext(timeProvider.GetUtcNow());
+    var decision = await scheduledTask.ShouldRunAsync(context, cancellationToken);
+
+    if (!decision.ShouldRun)
+    {
+        logger.LogInformation(
+            "Scheduled task {TaskName} skipped: {Reason}",
+            scheduledTask.Name,
+            decision.Reason);
+        return 0;
+    }
+
+    logger.LogInformation(
+        "Scheduled task {TaskName} running: {Reason}",
+        scheduledTask.Name,
+        decision.Reason);
+
+    var result = await scheduledTask.ExecuteAsync(options, context, cancellationToken);
+    logger.LogInformation(
+        "Business lifecycle advancement complete: {CompletedGigs} gigs completed, {OverdueInvoices} invoices marked overdue. Next gig completion date: {NextGigCompletionDate}; next invoice overdue date: {NextInvoiceOverdueDate}.",
+        result.CompletedGigs,
+        result.OverdueInvoices,
+        result.NextGigCompletionDate,
+        result.NextInvoiceOverdueDate);
 
     return 0;
 }

--- a/docs/engineering/deployment-pipeline.md
+++ b/docs/engineering/deployment-pipeline.md
@@ -33,9 +33,23 @@ The deployed container can run the same command via the published worker DLL:
 dotnet worker/Glovelly.Worker.dll calendar-sync drain
 ```
 
-The CI deployment creates or updates a Cloud Run Job for this command and a Cloud Scheduler HTTP trigger that invokes the job. The job uses the same image, runtime service account, environment variables, and Secret Manager bindings as the Cloud Run service.
+Business lifecycle advancement, including automatic gig completion and invoice overdue transitions, can be run with:
+
+```bash
+dotnet run --project backend/Glovelly.Worker -- business-lifecycle advance
+```
+
+The deployed container can run the same command via the published worker DLL:
+
+```bash
+dotnet worker/Glovelly.Worker.dll business-lifecycle advance
+```
+
+The CI deployment creates or updates Cloud Run Jobs for these commands and Cloud Scheduler HTTP triggers that invoke the jobs. Each job uses the same image, runtime service account, environment variables, and Secret Manager bindings as the Cloud Run service.
 
 The default job name is `<cloud-run-service>-calendar-sync`; the default scheduler name is `<job-name>-schedule`; the default schedule is every five minutes. These can be overridden per GitHub Environment with `GCP_CALENDAR_SYNC_JOB_NAME`, `GCP_CALENDAR_SYNC_SCHEDULER_NAME`, `CALENDAR_SYNC_SCHEDULE`, and `GCP_SCHEDULER_LOCATION` variables.
+
+The default Business lifecycle job name is `<cloud-run-service>-business-lifecycle`; the default scheduler name is `<job-name>-schedule`; the default schedule is every fifteen minutes. These can be overridden per GitHub Environment with `GCP_BUSINESS_LIFECYCLE_JOB_NAME`, `GCP_BUSINESS_LIFECYCLE_SCHEDULER_NAME`, `BUSINESS_LIFECYCLE_SCHEDULE`, and `GCP_SCHEDULER_LOCATION` variables.
 
 ## GitHub Actions
 

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -2017,10 +2017,28 @@ button.compact-record-row.selected {
   display: flex !important;
 }
 
+.invoice-line-editor-content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
 .invoice-line-list {
   display: grid;
-  gap: 10px;
-  margin-top: 12px;
+  flex: 1 1 auto;
+  gap: 0;
+  align-content: start;
+  grid-auto-rows: max-content;
+  min-height: 180px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 86%, transparent);
+  border-radius: 18px;
+  background: var(--surface-elevated);
+  -webkit-overflow-scrolling: touch;
+  scrollbar-gutter: stable;
 }
 
 .gig-expense-list {
@@ -2238,17 +2256,17 @@ button.compact-record-row.selected {
 .invoice-line-item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 12px;
-  align-items: start;
-  padding: 14px 16px;
-  border-radius: 18px;
-  background: var(--surface-elevated);
-  border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
+  gap: 10px;
+  align-items: center;
+  padding: 9px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 72%, transparent);
+  background: transparent;
 }
 
-.invoice-line-item div {
+.invoice-line-content {
   display: grid;
   gap: 4px;
+  min-width: 0;
 }
 
 .invoice-line-item strong {
@@ -2263,6 +2281,43 @@ button.compact-record-row.selected {
 .invoice-line-link:hover,
 .invoice-line-link:focus-visible {
   color: var(--heading);
+}
+
+.invoice-line-link [data-testid="invoice-line-description"] {
+  color: inherit;
+}
+
+.invoice-line-end {
+  display: grid;
+  align-items: center;
+  justify-content: flex-end;
+  justify-items: end;
+  gap: 6px;
+  min-width: max-content;
+}
+
+.icon-delete-button {
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid color-mix(in srgb, var(--danger-text) 38%, var(--surface-border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--danger-text) 9%, var(--surface-elevated));
+  color: var(--danger-text);
+  cursor: pointer;
+}
+
+.icon-delete-button:hover,
+.icon-delete-button:focus-visible {
+  background: color-mix(in srgb, var(--danger-text) 16%, var(--surface-elevated));
+  color: var(--heading);
+}
+
+.icon-delete-button svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
 }
 
 .invoice-line-item span {
@@ -2465,6 +2520,13 @@ button.compact-record-row.selected {
 .danger-button {
   background: color-mix(in srgb, #a12828 22%, transparent);
   color: var(--danger-text);
+}
+
+.danger-button svg {
+  width: 15px;
+  height: 15px;
+  fill: currentColor;
+  flex: 0 0 auto;
 }
 
 .primary-button:hover,

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -290,6 +290,7 @@ function App({ appMetadata }: AppProps) {
     filteredInvoices,
     googleDrivePublishLink,
     handleAddInvoiceAdjustment,
+    handleDeleteInvoiceAdjustment,
     handleDeleteInvoice,
     handleDownloadInvoicePdf,
     handleInvoiceReissue,
@@ -845,27 +846,25 @@ function App({ appMetadata }: AppProps) {
     }
 
     const invoiceId = selectedGig.invoiceId
-    if (!invoices.some((invoice) => invoice.id === invoiceId)) {
-      try {
-        const response = await fetchWithSession(buildApiUrl(`/invoices/${invoiceId}`))
-        if (isSessionExpiredResponse(response)) {
-          expireSession('Your session expired. Sign in again to keep working.')
-          return
-        }
-
-        if (!response.ok) {
-          throw new Error('Unable to open linked invoice.')
-        }
-
-        const invoice = (await response.json()) as Invoice
-        setInvoices((current) => [
-          invoice,
-          ...current.filter((value) => value.id !== invoice.id),
-        ])
-      } catch (error) {
-        setGigStatus(error instanceof Error ? error.message : 'Unable to open linked invoice.')
+    try {
+      const response = await fetchWithSession(buildApiUrl(`/invoices/${invoiceId}`))
+      if (isSessionExpiredResponse(response)) {
+        expireSession('Your session expired. Sign in again to keep working.')
         return
       }
+
+      if (!response.ok) {
+        throw new Error('Unable to open linked invoice.')
+      }
+
+      const invoice = (await response.json()) as Invoice
+      setInvoices((current) => [
+        invoice,
+        ...current.filter((value) => value.id !== invoice.id),
+      ])
+    } catch (error) {
+      setGigStatus(error instanceof Error ? error.message : 'Unable to open linked invoice.')
+      return
     }
 
     setSelectedInvoiceId(invoiceId)
@@ -1687,6 +1686,7 @@ function App({ appMetadata }: AppProps) {
         onAdjustmentReasonChange={setAdjustmentReason}
         onAddAdjustment={handleAddInvoiceAdjustment}
         onCloseEditor={closeInvoiceEditor}
+        onDeleteAdjustment={handleDeleteInvoiceAdjustment}
         onDeleteInvoice={handleDeleteInvoice}
         onDownloadPdf={handleDownloadInvoicePdf}
         onInvoiceStatusChange={handleInvoiceStatusChangeWithGigPrompt}

--- a/frontend/glovelly-web/src/components/AdminSection.tsx
+++ b/frontend/glovelly-web/src/components/AdminSection.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from 'react'
 import { formatDateTime } from '../formatters'
 import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type { AdminSort, AdminSortKey, AdminUser, AdminUserForm } from '../types'
+import { TrashIcon } from './TrashIcon'
 
 type AdminSectionProps = {
   adminForm: AdminUserForm
@@ -234,6 +235,7 @@ export function AdminSection({
                     : 'Delete inactive user'
                 }
               >
+                <TrashIcon />
                 Delete user
               </button>
             </div>

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -155,7 +155,10 @@ export function AppShell({
               </div>
 
               <div className="header-actions">
-                <label className={`primary-button quick-capture-button quick-receipt-button ${isReturnToTopVisible ? 'mobile-scrolled' : ''}`}>
+                <label
+                  className={`primary-button quick-capture-button quick-receipt-button ${isReturnToTopVisible ? 'mobile-scrolled' : ''}`}
+                  title="Quick add expense receipt"
+                >
                   <span className="quick-capture-icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false">
                       <path d="M8.4 6.5 9.7 4h4.6l1.3 2.5H19a3 3 0 0 1 3 3V17a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3V9.5a3 3 0 0 1 3-3h3.4Z" />
@@ -183,6 +186,7 @@ export function AppShell({
                   onClick={onQuickAttachmentOpen}
                   type="button"
                   disabled={isLoading || isGigLoading || isQuickAttachmentSaving}
+                  title="Quick add attachment"
                 >
                   <span className="quick-capture-icon quick-attachment-icon" aria-hidden="true">
                     +

--- a/frontend/glovelly-web/src/components/ClientsSection.tsx
+++ b/frontend/glovelly-web/src/components/ClientsSection.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react'
 import type { FormEvent } from 'react'
 import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type { Client, ClientForm, ClientSort, ClientSortKey } from '../types'
+import { TrashIcon } from './TrashIcon'
 
 type ClientsSectionProps = {
   filteredClients: Client[]
@@ -224,6 +225,7 @@ export function ClientsSection({
                 disabled={!canDeleteSelectedClient || isLoading}
                 title={clientDeleteHelperText}
               >
+                <TrashIcon />
                 Delete
               </button>
             </div>

--- a/frontend/glovelly-web/src/components/GigAttachmentsPanel.tsx
+++ b/frontend/glovelly-web/src/components/GigAttachmentsPanel.tsx
@@ -8,6 +8,7 @@ import type {
   GigExternalResourcePurpose,
   GigExternalResourceType,
 } from '../types'
+import { TrashIcon } from './TrashIcon'
 
 type GigAttachmentsPanelProps = {
   selectedGig: Gig | null
@@ -175,12 +176,14 @@ export function GigAttachmentsPanel({
                           Edit
                         </button>
                         <button
-                          className="danger-button"
+                          aria-label={`Delete attachment ${resource.title || 'Untitled attachment'}`}
+                          className="icon-delete-button"
                           onClick={() => onDeleteExternalResource(resource)}
                           type="button"
                           disabled={isGigLoading}
+                          title="Delete attachment"
                         >
-                          Delete
+                          <TrashIcon />
                         </button>
                       </div>
                       <div className="resource-attachments">
@@ -218,14 +221,16 @@ export function GigAttachmentsPanel({
                                     Download
                                   </button>
                                   <button
-                                    className="danger-button"
+                                    aria-label={`Delete file ${attachment.fileName}`}
+                                    className="icon-delete-button"
                                     onClick={() =>
                                       onDeleteExternalResourceAttachment(resource, attachment)
                                     }
                                     type="button"
                                     disabled={isGigLoading}
+                                    title="Delete file"
                                   >
-                                    Delete
+                                    <TrashIcon />
                                   </button>
                                 </div>
                               </div>

--- a/frontend/glovelly-web/src/components/GigExpensesPanel.tsx
+++ b/frontend/glovelly-web/src/components/GigExpensesPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import { formatCurrency } from '../formatters'
 import type { Gig, GigExpenseForm, GigExpenseReimbursementStatus } from '../types'
+import { TrashIcon } from './TrashIcon'
 
 type GigExpensesPanelProps = {
   expenses: GigExpenseForm[]
@@ -170,12 +171,14 @@ export function GigExpensesPanel({
                           Edit
                         </button>
                         <button
-                          className="danger-button"
+                          aria-label={`Remove expense ${expense.description || 'Untitled expense'}`}
+                          className="icon-delete-button"
                           onClick={() => void onDeleteExpenseDraft(index)}
                           type="button"
                           disabled={isGigLoading}
+                          title="Remove expense"
                         >
-                          Remove
+                          <TrashIcon />
                         </button>
                       </div>
 
@@ -214,12 +217,14 @@ export function GigExpensesPanel({
                                     {attachment.fileName}
                                   </button>
                                   <button
-                                    className="ghost-button"
+                                    aria-label={`Delete receipt ${attachment.fileName}`}
+                                    className="icon-delete-button"
                                     type="button"
                                     onClick={() => onDeleteExpenseAttachment(expense, attachment.id)}
                                     disabled={isGigLoading}
+                                    title="Delete receipt"
                                   >
-                                    Delete
+                                    <TrashIcon />
                                   </button>
                                 </div>
                               ))}

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from 'react'
 import { GigAttachmentsPanel } from './GigAttachmentsPanel'
 import { GigEditorPanel } from './GigEditorPanel'
 import { GigExpensesPanel } from './GigExpensesPanel'
+import { TrashIcon } from './TrashIcon'
 import { formatCurrency, formatDate, formatGigStatus } from '../formatters'
 import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type {
@@ -424,6 +425,7 @@ export function GigsSection({
                     : 'Delete planned gig'
                 }
               >
+                <TrashIcon />
                 Delete gig
               </button>
             </div>

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -6,9 +6,11 @@ import {
   formatDateTime,
   getAllowedInvoiceStatusTransitions,
 } from '../formatters'
+import { TrashIcon } from './TrashIcon'
 import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type {
   Invoice,
+  InvoiceLine,
   InvoiceQuickFilter,
   InvoiceSort,
   InvoiceSortKey,
@@ -36,6 +38,7 @@ type InvoicesSectionProps = {
   onAdjustmentReasonChange: (value: string) => void
   onAddAdjustment: (invoice: Invoice) => Promise<void>
   onCloseEditor: () => void
+  onDeleteAdjustment: (invoice: Invoice, line: InvoiceLine) => Promise<void>
   onDeleteInvoice: (invoice: Invoice) => Promise<void>
   onDownloadPdf: (invoice: Invoice) => Promise<void>
   onInvoiceStatusChange: (invoice: Invoice, status: InvoiceStatus) => Promise<Invoice | null>
@@ -76,6 +79,7 @@ export function InvoicesSection({
   onAdjustmentReasonChange,
   onAddAdjustment,
   onCloseEditor,
+  onDeleteAdjustment,
   onDeleteInvoice,
   onDownloadPdf,
   onInvoiceStatusChange,
@@ -349,6 +353,7 @@ export function InvoicesSection({
                     : 'Delete draft invoice'
                 }
               >
+                <TrashIcon />
                 Delete draft
               </button>
               <button
@@ -493,7 +498,7 @@ export function InvoicesSection({
             </div>
 
             {selectedInvoice ? (
-              <>
+              <div className="invoice-line-editor-content">
                 <div className="gig-timeline-note">
                   <p className="detail-label">Adjustments</p>
                   <span>
@@ -544,7 +549,7 @@ export function InvoicesSection({
 
                       return (
                         <div className="invoice-line-item" data-testid="invoice-line-item" key={line.id}>
-                          <div>
+                          <div className="invoice-line-content">
                             {gigId ? (
                               <button
                                 className="link-button invoice-line-link"
@@ -552,10 +557,10 @@ export function InvoicesSection({
                                 onClick={() => onOpenGig(gigId)}
                                 type="button"
                               >
-                                {line.description}
+                                <span data-testid="invoice-line-description">{line.description}</span>
                               </button>
                             ) : (
-                              <strong>{line.description}</strong>
+                              <strong data-testid="invoice-line-description">{line.description}</strong>
                             )}
                             <span>
                               <span data-testid="invoice-line-type">{line.type}</span> · {line.quantity} x {formatCurrency(line.unitPrice)}
@@ -564,12 +569,27 @@ export function InvoicesSection({
                               <span>Audit: {formatDateTime(line.createdUtc)}</span>
                             ) : null}
                           </div>
-                          <strong>{formatCurrency(line.lineTotal)}</strong>
+                          <div className="invoice-line-end">
+                            <strong>{formatCurrency(line.lineTotal)}</strong>
+                            {line.type === 'ManualAdjustment' ? (
+                              <button
+                                aria-label={`Remove adjustment ${line.description}`}
+                                className="icon-delete-button"
+                                data-testid="invoice-line-delete-button"
+                                disabled={isInvoiceLoading}
+                                onClick={() => void onDeleteAdjustment(selectedInvoice, line)}
+                                title="Remove adjustment"
+                                type="button"
+                              >
+                                <TrashIcon />
+                              </button>
+                            ) : null}
+                          </div>
                         </div>
                       )
                     })}
                 </div>
-              </>
+              </div>
             ) : (
               <div className="empty-state roomy">
                 <strong>Select an invoice to inspect its line items.</strong>

--- a/frontend/glovelly-web/src/components/TrashIcon.tsx
+++ b/frontend/glovelly-web/src/components/TrashIcon.tsx
@@ -1,0 +1,7 @@
+export function TrashIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M9 3h6l1 2h4v2H4V5h4l1-2Zm1 6v9h2V9h-2Zm4 0v9h2V9h-2ZM7 9h2v9c0 1.1.9 2 2 2h2c1.1 0 2-.9 2-2V9h2v9a4 4 0 0 1-4 4h-2a4 4 0 0 1-4-4V9Z" />
+    </svg>
+  )
+}

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -9,7 +9,7 @@ import {
 } from '../api'
 import { defaultInvoiceStatus } from '../forms'
 import { formatCurrency, formatDateTime } from '../formatters'
-import type { Invoice, InvoiceQuickFilter, InvoiceSort, InvoiceStatus } from '../types'
+import type { Invoice, InvoiceLine, InvoiceQuickFilter, InvoiceSort, InvoiceStatus } from '../types'
 
 type GoogleDrivePublishLink = {
   href: string
@@ -478,9 +478,48 @@ export function useInvoicesWorkspace({
       setAdjustmentAmount('')
       setAdjustmentReason('')
       setInvoiceStatus(`Adjustment saved. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`)
-      setIsInvoiceEditorOpen(false)
     } catch (error) {
       setInvoiceStatus(error instanceof Error ? error.message : 'Unable to add invoice adjustment.')
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
+  const handleDeleteInvoiceAdjustment = async (invoice: Invoice, line: InvoiceLine) => {
+    if (line.type !== 'ManualAdjustment') {
+      setInvoiceStatus('Only manual adjustments can be removed from here.')
+      return
+    }
+
+    if (!window.confirm(`Remove adjustment "${line.description}" from ${invoice.invoiceNumber}?`)) {
+      return
+    }
+
+    setIsInvoiceLoading(true)
+    setInvoiceStatus(`Removing adjustment from ${invoice.invoiceNumber}...`)
+
+    try {
+      const deleteResponse = await fetchWithSession(
+        buildApiUrl(`/invoice-lines/${line.id}`),
+        { method: 'DELETE' }
+      )
+
+      if (!deleteResponse.ok) {
+        throw new Error('Unable to remove invoice adjustment.')
+      }
+
+      const invoiceResponse = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}`))
+      if (!invoiceResponse.ok) {
+        throw new Error('Adjustment removed, but the invoice could not be refreshed.')
+      }
+
+      const updatedInvoice = (await invoiceResponse.json()) as Invoice
+      setInvoices((current) =>
+        current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
+      )
+      setInvoiceStatus(`Adjustment removed. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`)
+    } catch (error) {
+      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to remove invoice adjustment.')
     } finally {
       setIsInvoiceLoading(false)
     }
@@ -538,6 +577,7 @@ export function useInvoicesWorkspace({
     filteredInvoices,
     googleDrivePublishLink,
     handleAddInvoiceAdjustment,
+    handleDeleteInvoiceAdjustment,
     handleDeleteInvoice,
     handleDownloadInvoicePdf,
     handleInvoiceReissue,

--- a/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using Microsoft.Playwright;
 using Xunit;
 
@@ -241,11 +242,23 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                 await summaryButton.ClickAsync();
             }
 
-            var redraftResponse = await RunAndWaitForInvoiceRedraftAsync(
-                async () => await expenseRow.GetByTestId("gig-expense-reimbursement-select")
-                    .SelectOptionAsync(new[] { status }));
+            var reimbursementSelect = expenseRow.GetByTestId("gig-expense-reimbursement-select");
+            var reimbursementResponseTask = WaitForExpenseReimbursementUpdateAsync();
+            var redraftResponseTask = WaitForInvoiceRedraftAsync();
+
+            await reimbursementSelect.SelectOptionAsync(new[] { status });
+
+            var reimbursementResponse = await reimbursementResponseTask;
+            Assert.True(reimbursementResponse.Ok, $"Expected expense reimbursement update to succeed, got HTTP {reimbursementResponse.Status} for {reimbursementResponse.Url}.");
+            await Assertions.Expect(reimbursementSelect).ToHaveValueAsync(status, new LocatorAssertionsToHaveValueOptions
+            {
+                Timeout = 30_000,
+            });
+
+            var redraftResponse = await redraftResponseTask;
 
             AssertRedraftSucceeded(redraftResponse);
+            await AssertRedraftedInvoiceLinePresenceAsync(redraftResponse, expenseDescription, status != "Reimbursed");
             await ExpectContainsAsync(Page.GetByTestId("gig-status"), "regenerated");
         }
         finally
@@ -326,6 +339,42 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                     path.EndsWith("/redraft", StringComparison.Ordinal);
             },
             new PageRunAndWaitForResponseOptions { Timeout = 30_000 });
+
+    private Task<IResponse> WaitForExpenseReimbursementUpdateAsync() =>
+        Page.WaitForResponseAsync(
+            response =>
+            {
+                var path = new Uri(response.Url).AbsolutePath;
+
+                return response.Request.Method == "PATCH" &&
+                    path.StartsWith("/gigs/", StringComparison.Ordinal) &&
+                    path.EndsWith("/expenses/reimbursement", StringComparison.Ordinal);
+            },
+            new PageWaitForResponseOptions { Timeout = 30_000 });
+
+    private Task<IResponse> WaitForInvoiceRedraftAsync() =>
+        Page.WaitForResponseAsync(
+            response =>
+            {
+                var path = new Uri(response.Url).AbsolutePath;
+
+                return response.Request.Method == "POST" &&
+                    path.StartsWith("/invoices/", StringComparison.Ordinal) &&
+                    path.EndsWith("/redraft", StringComparison.Ordinal);
+            },
+            new PageWaitForResponseOptions { Timeout = 30_000 });
+
+    private static async Task AssertRedraftedInvoiceLinePresenceAsync(IResponse redraftResponse, string expenseDescription, bool shouldBePresent)
+    {
+        var body = await redraftResponse.BodyAsync();
+        using var document = JsonDocument.Parse(body);
+        var lines = document.RootElement.GetProperty("lines");
+        var lineExists = lines.EnumerateArray().Any(line =>
+            line.TryGetProperty("description", out var description) &&
+            description.GetString() == expenseDescription);
+
+        Assert.Equal(shouldBePresent, lineExists);
+    }
 
     private static void AssertRedraftSucceeded(IResponse redraftResponse)
     {

--- a/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
@@ -166,7 +166,7 @@ public abstract class InvoiceUatTestBase : UatTestBase
 
     protected async Task AssertInvoiceLineTypeCountAsync(string expectedType, int expectedCount)
     {
-        await Assertions.Expect(Page.Locator("[data-testid=\"invoice-line-type\"]:visible").Filter(new LocatorFilterOptions
+        await Assertions.Expect(Page.GetByTestId("invoice-line-type").Filter(new LocatorFilterOptions
         {
             HasTextRegex = new System.Text.RegularExpressions.Regex($"^{System.Text.RegularExpressions.Regex.Escape(expectedType)}$")
         })).ToHaveCountAsync(expectedCount, new LocatorAssertionsToHaveCountOptions
@@ -298,7 +298,7 @@ public abstract class InvoiceUatTestBase : UatTestBase
 
     protected ILocator ExpenseRowAt(int index) => Page.GetByTestId("gig-expense-item").Nth(index);
 
-    private ILocator VisibleInvoiceLines() => Page.Locator("[data-testid=\"invoice-line-item\"]:visible");
+    private ILocator VisibleInvoiceLines() => Page.GetByTestId("invoice-line-item");
 
     private ILocator InvoiceLine(string expectedText) => VisibleInvoiceLines().Filter(new LocatorFilterOptions
     {

--- a/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceUatTestBase.cs
@@ -118,11 +118,16 @@ public abstract class InvoiceUatTestBase : UatTestBase
     protected async Task OpenInvoiceLinesAsync()
     {
         var lineItemsButton = Page.GetByTestId("invoice-line-items-button");
-        if (await lineItemsButton.GetAttributeAsync("aria-expanded") != "true")
+        if (await lineItemsButton.GetAttributeAsync("aria-expanded") == "true")
         {
             await lineItemsButton.ClickAsync();
+            await Assertions.Expect(lineItemsButton).ToHaveAttributeAsync("aria-expanded", "false", new LocatorAssertionsToHaveAttributeOptions
+            {
+                Timeout = 30_000,
+            });
         }
 
+        await lineItemsButton.ClickAsync();
         await Assertions.Expect(lineItemsButton).ToHaveAttributeAsync("aria-expanded", "true", new LocatorAssertionsToHaveAttributeOptions
         {
             Timeout = 30_000,


### PR DESCRIPTION
## Summary
- add the business lifecycle worker command and scheduled Cloud Run Job wiring
- automatically complete past confirmed gigs and mark past-due issued invoices overdue
- prevent planned/confirmed gigs from being created or restored in the past, including import commits
- include the invoice-line expansion stability fix already on this branch

Closes #171

## Verification
- dotnet test glovelly.sln -m:1
- dotnet build backend/Glovelly.Worker/Glovelly.Worker.csproj
- npm --prefix frontend/glovelly-web run lint
- npm --prefix frontend/glovelly-web run build