### PR TITLE
Always display same-day quick capture candidates

### DIFF
--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -676,6 +676,60 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task QuickReceiptDraft_IncludesAllCandidatesTiedAtCandidateLimit()
+    {
+        var today = new DateOnly(2026, 1, 1);
+        for (var index = 0; index < 6; index++)
+        {
+            var createResponse = await _client.PostAsJsonAsync("/gigs", new
+            {
+                clientId = TestData.FoxAndFinchId,
+                title = $"Same-day candidate {index}",
+                date = today.ToString("yyyy-MM-dd"),
+                venue = "Theatre",
+                fee = 120.00m,
+                travelMiles = 0.00m,
+                notes = "Candidate tie test",
+                wasDriving = true,
+                status = "Confirmed",
+                expenses = Array.Empty<object>(),
+                invoicedAt = (string?)null,
+            }, TestContext.Current.CancellationToken);
+
+            createResponse.EnsureSuccessStatusCode();
+        }
+
+        var nextDayResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Next-day candidate",
+            date = today.AddDays(1).ToString("yyyy-MM-dd"),
+            venue = "Theatre",
+            fee = 120.00m,
+            travelMiles = 0.00m,
+            notes = "Candidate tie test",
+            wasDriving = true,
+            status = "Confirmed",
+            expenses = Array.Empty<object>(),
+            invoicedAt = (string?)null,
+        }, TestContext.Current.CancellationToken);
+        nextDayResponse.EnsureSuccessStatusCode();
+
+        using var form = BuildReceiptDraftForm("receipt"u8.ToArray(), "receipt.pdf", "application/pdf");
+
+        var response = await _client.PostAsync("/gigs/receipt-drafts", form, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        var candidates = result.GetProperty("candidates").EnumerateArray().ToArray();
+
+        Assert.Equal(6, candidates.Length);
+        Assert.All(candidates, candidate => Assert.Equal(0, candidate.GetProperty("daysFromToday").GetInt32()));
+        Assert.DoesNotContain(candidates, candidate => candidate.GetProperty("title").GetString() == "Next-day candidate");
+    }
+
+    [Fact]
     public async Task QuickReceiptDraft_WithCandidateOutsideAmbiguityWindow_DoesNotFlagNearbyCandidates()
     {
         var today = new DateOnly(2026, 1, 1);

--- a/backend/Glovelly.Api/Endpoints/GigQuickCaptureSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/GigQuickCaptureSupport.cs
@@ -35,7 +35,7 @@ internal static class GigQuickCaptureSupport
             .Where(value => value.Status != GigStatus.Cancelled)
             .ToListAsync();
 
-        return gigs
+        var candidates = gigs
             .Select(gig => new QuickGigCandidate(
                 gig.Id,
                 gig.ClientId,
@@ -48,7 +48,14 @@ internal static class GigQuickCaptureSupport
             .OrderBy(candidate => candidate.DaysFromToday)
             .ThenBy(candidate => candidate.Date)
             .ThenBy(candidate => candidate.Title)
-            .Take(settings.CandidateCount)
+            .ToList();
+
+        var cutoff = candidates.Count >= settings.CandidateCount
+            ? candidates[settings.CandidateCount - 1].DaysFromToday
+            : (int?)null;
+
+        return candidates
+            .Where((candidate, index) => !cutoff.HasValue || index < settings.CandidateCount || candidate.DaysFromToday == cutoff.Value)
             .ToList();
     }
 

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -365,7 +365,7 @@ function App({ appMetadata }: AppProps) {
     const today = new Date()
     today.setHours(0, 0, 0, 0)
 
-    return gigs
+    const sortedCandidates = gigs
       .filter((gig) => gig.status !== 'Cancelled')
       .map((gig) => {
         const gigDate = new Date(`${gig.date}T00:00:00`)
@@ -391,7 +391,10 @@ function App({ appMetadata }: AppProps) {
         left.date.localeCompare(right.date) ||
         left.title.localeCompare(right.title)
       )
-      .slice(0, 5)
+
+    const cutoff = sortedCandidates[4]?.daysFromToday
+    return sortedCandidates
+      .filter((candidate, index) => cutoff === undefined || index < 5 || candidate.daysFromToday === cutoff)
       .map((candidate, index) => ({
         ...candidate,
         isSelected: index === 0,


### PR DESCRIPTION
## Summary
- Preserve all quick-capture candidates tied at the candidate-count cutoff distance instead of arbitrarily truncating same-day gigs
- Apply the same candidate selection behavior in frontend quick attachment flows and backend quick receipt/attachment endpoints
- Add regression coverage for candidate ties at the configured candidate limit

## Verification
- dotnet test glovelly.sln -m:1 --filter FullyQualifiedName~GigEndpointsTests
- npm --prefix frontend/glovelly-web run lint
- npm --prefix frontend/glovelly-web run build