### PR TITLE
Support typed gigs without assuming every gig is a performance

### DIFF
--- a/backend/Glovelly.Api.Tests/Contracts/mcp-tools.snapshot.json
+++ b/backend/Glovelly.Api.Tests/Contracts/mcp-tools.snapshot.json
@@ -128,7 +128,7 @@
     "title": "Get Contact"
   },
   {
-    "description": "List gigs by optional contact, status, date range, and invoicing state.",
+    "description": "List gigs by optional contact, status, type, date range, and invoicing state.",
     "inputSchema": {
       "properties": {
         "contactId": {
@@ -143,6 +143,18 @@
         "fromDate": {
           "description": "Inclusive start date in YYYY-MM-DD format.",
           "format": "date",
+          "type": "string"
+        },
+        "gigType": {
+          "description": "Nature of the musician work.",
+          "enum": [
+            "performance",
+            "teaching",
+            "rehearsal",
+            "recording",
+            "admin",
+            "other"
+          ],
           "type": "string"
         },
         "invoicingState": {
@@ -208,6 +220,18 @@
               },
               "gigId": {
                 "format": "uuid",
+                "type": "string"
+              },
+              "gigType": {
+                "description": "Nature of the musician work.",
+                "enum": [
+                  "performance",
+                  "teaching",
+                  "rehearsal",
+                  "recording",
+                  "admin",
+                  "other"
+                ],
                 "type": "string"
               },
               "invoiceId": {
@@ -357,6 +381,18 @@
             },
             "gigId": {
               "format": "uuid",
+              "type": "string"
+            },
+            "gigType": {
+              "description": "Nature of the musician work.",
+              "enum": [
+                "performance",
+                "teaching",
+                "rehearsal",
+                "recording",
+                "admin",
+                "other"
+              ],
               "type": "string"
             },
             "invoice": {
@@ -552,6 +588,18 @@
           "format": "date",
           "type": "string"
         },
+        "gigType": {
+          "description": "Nature of the musician work.",
+          "enum": [
+            "performance",
+            "teaching",
+            "rehearsal",
+            "recording",
+            "admin",
+            "other"
+          ],
+          "type": "string"
+        },
         "status": {
           "description": "Gig status filter. Use confirmed or planned for planned gigs.",
           "enum": [
@@ -606,6 +654,18 @@
               },
               "gigId": {
                 "format": "uuid",
+                "type": "string"
+              },
+              "gigType": {
+                "description": "Nature of the musician work.",
+                "enum": [
+                  "performance",
+                  "teaching",
+                  "rehearsal",
+                  "recording",
+                  "admin",
+                  "other"
+                ],
                 "type": "string"
               },
               "invoiceId": {
@@ -1648,6 +1708,18 @@
           "minimum": 0,
           "type": "number"
         },
+        "gigType": {
+          "description": "Nature of the proposed musician work.",
+          "enum": [
+            "performance",
+            "teaching",
+            "rehearsal",
+            "recording",
+            "admin",
+            "other"
+          ],
+          "type": "string"
+        },
         "notes": {
           "description": "General notes from the source.",
           "maxLength": 4000,
@@ -1797,6 +1869,18 @@
               "description": "Proposed gig fee.",
               "type": "number"
             },
+            "gigType": {
+              "description": "Nature of the proposed musician work.",
+              "enum": [
+                "performance",
+                "teaching",
+                "rehearsal",
+                "recording",
+                "admin",
+                "other"
+              ],
+              "type": "string"
+            },
             "notes": {
               "type": "string"
             },
@@ -1944,6 +2028,18 @@
                 "description": "Proposed gig fee.",
                 "minimum": 0,
                 "type": "number"
+              },
+              "gigType": {
+                "description": "Nature of the proposed musician work.",
+                "enum": [
+                  "performance",
+                  "teaching",
+                  "rehearsal",
+                  "recording",
+                  "admin",
+                  "other"
+                ],
+                "type": "string"
               },
               "notes": {
                 "description": "General notes from the source.",
@@ -2109,6 +2205,18 @@
                   "fee": {
                     "description": "Proposed gig fee.",
                     "type": "number"
+                  },
+                  "gigType": {
+                    "description": "Nature of the proposed musician work.",
+                    "enum": [
+                      "performance",
+                      "teaching",
+                      "rehearsal",
+                      "recording",
+                      "admin",
+                      "other"
+                    ],
+                    "type": "string"
                   },
                   "notes": {
                     "type": "string"
@@ -2336,6 +2444,18 @@
                   "fee": {
                     "description": "Proposed gig fee.",
                     "type": "number"
+                  },
+                  "gigType": {
+                    "description": "Nature of the proposed musician work.",
+                    "enum": [
+                      "performance",
+                      "teaching",
+                      "rehearsal",
+                      "recording",
+                      "admin",
+                      "other"
+                    ],
+                    "type": "string"
                   },
                   "notes": {
                     "type": "string"

--- a/backend/Glovelly.Api.Tests/DevelopmentSeedDataTests.cs
+++ b/backend/Glovelly.Api.Tests/DevelopmentSeedDataTests.cs
@@ -109,6 +109,27 @@ public sealed class DevelopmentSeedDataTests
             line.Quantity == gig.TravelMiles);
     }
 
+    [Fact]
+    public async Task SeedAsync_AdditionalDraftInvoiceLinesLinkToTheirGig()
+    {
+        await using var dbContext = CreateDbContext();
+        await DevelopmentDataSeeder.SeedAsync(
+            dbContext,
+            CreateSeedConfiguration(),
+            new InMemoryExpenseAttachmentStore());
+
+        var invoice = await dbContext.Invoices
+            .Include(value => value.Lines)
+            .SingleAsync(value => value.InvoiceNumber == "GLV-2026-006", TestContext.Current.CancellationToken);
+        var gig = await dbContext.Gigs
+            .SingleAsync(value => value.InvoiceId == invoice.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal(InvoiceStatus.Draft, invoice.Status);
+        Assert.All(invoice.Lines, line => Assert.Equal(gig.Id, line.GigId));
+        Assert.Contains(invoice.Lines, line =>
+            line.Type == InvoiceLineType.PerformanceFee && line.IsSystemGenerated);
+    }
+
     private static AppDbContext CreateDbContext()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()

--- a/backend/Glovelly.Api.Tests/GigImportEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigImportEndpointsTests.cs
@@ -64,6 +64,7 @@ public sealed class GigImportEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(new DateOnly(2026, 11, 28), gig.Date);
         Assert.Equal("Music Hall, Aberdeen, AB10 1AA", gig.Venue);
         Assert.Equal(250m, gig.Fee);
+        Assert.Equal(GigType.Performance, gig.Type);
         Assert.Equal(batchId, gig.SourceImportBatchId);
         Assert.Equal(draftId, gig.SourceImportDraftId);
         Assert.Equal(GigImportDraftStatus.Committed, draftStatus);

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using Glovelly.Api.Models;
 using Glovelly.Api.Tests.Infrastructure;
@@ -262,6 +263,76 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         Assert.False(updatedInvoice.TryGetProperty("pdfBlob", out _));
         Assert.Equal("application/pdf", updatedInvoice.GetProperty("pdfContentType").GetString());
         Assert.True(updatedInvoice.GetProperty("pdfSizeBytes").GetInt64() > 0);
+    }
+
+    [Fact]
+    public async Task UpdateDescription_WhenDraft_PersistsTrimmedDescriptionAndRetainsItOnRedraft()
+    {
+        var createLineResponse = await _client.PostAsJsonAsync("/invoice-lines", new
+        {
+            invoiceId = TestData.RiversideInvoiceId,
+            sortOrder = 1,
+            type = InvoiceLineType.PerformanceFee,
+            description = "Headline performance",
+            quantity = 1m,
+            unitPrice = 200m,
+        }, TestContext.Current.CancellationToken);
+        createLineResponse.EnsureSuccessStatusCode();
+
+        var updateResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/description", new
+        {
+            description = "  June performance services  ",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+        var updatedInvoice = await updateResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("June performance services", updatedInvoice.GetProperty("description").GetString());
+        Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("updatedByUserId").GetGuid());
+        Assert.Single(updatedInvoice.GetProperty("lines").EnumerateArray());
+
+        var redraftResponse = await _client.PostAsync($"/invoices/{TestData.RiversideInvoiceId}/redraft", null, TestContext.Current.CancellationToken);
+        redraftResponse.EnsureSuccessStatusCode();
+
+        var pdfResponse = await _client.GetAsync($"/invoices/{TestData.RiversideInvoiceId}/pdf", TestContext.Current.CancellationToken);
+        pdfResponse.EnsureSuccessStatusCode();
+        var pdfText = Encoding.ASCII.GetString(await pdfResponse.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+        Assert.Contains("June performance services", pdfText);
+    }
+
+    [Fact]
+    public async Task UpdateDescription_WhenBlankOrInvoiceIsNotDraft_ReturnsValidationProblem()
+    {
+        var blankResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/description", new
+        {
+            description = "   ",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, blankResponse.StatusCode);
+        var blankProblem = await blankResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("Invoice description is required.", blankProblem.GetProperty("errors").GetProperty("description")[0].GetString());
+
+        var issuedResponse = await _client.PutAsJsonAsync($"/invoices/{TestData.FoxInvoiceId}/description", new
+        {
+            description = "Updated description",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, issuedResponse.StatusCode);
+        var issuedProblem = await issuedResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("Only Draft invoices can have their description changed.", issuedProblem.GetProperty("errors").GetProperty("status")[0].GetString());
+    }
+
+    [Fact]
+    public async Task UpdateDescription_WhenInvoiceIsNotVisible_ReturnsNotFound()
+    {
+        _client.DefaultRequestHeaders.Remove("X-Test-UserId");
+        _client.DefaultRequestHeaders.Add("X-Test-UserId", TestAuthContext.AlternateUserId.ToString());
+
+        var response = await _client.PutAsJsonAsync($"/invoices/{TestData.RiversideInvoiceId}/description", new
+        {
+            description = "Not visible",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/McpEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/McpEndpointsTests.cs
@@ -139,6 +139,19 @@ public sealed class McpEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public void McpToolCatalog_ExposesGigTypeForGigQueriesAndImportDrafts()
+    {
+        var listGigs = GlovellyMcpToolCatalog.Tools.Single(tool => tool.Name == "glovelly_list_gigs");
+        var listUninvoiced = GlovellyMcpToolCatalog.Tools.Single(tool => tool.Name == "glovelly_list_uninvoiced_gigs");
+        var addDraft = GlovellyMcpToolCatalog.Tools.Single(tool => tool.Name == "glovelly_add_gig_import_draft");
+
+        Assert.Contains("gigType", JsonSerializer.Serialize(listGigs.InputSchema));
+        Assert.Contains("gigType", JsonSerializer.Serialize(listUninvoiced.InputSchema));
+        Assert.Contains("gigType", JsonSerializer.Serialize(addDraft.InputSchema));
+        Assert.Contains("gigType", JsonSerializer.Serialize(addDraft.OutputSchema));
+    }
+
+    [Fact]
     public async Task OptionsMcp_ReturnsChatGptCompatibleCorsHeaders()
     {
         using var request = new HttpRequestMessage(HttpMethod.Options, "/mcp");

--- a/backend/Glovelly.Api.Tests/TypedGigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/TypedGigEndpointsTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Tests.Infrastructure;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class TypedGigEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public TypedGigEndpointsTests(GlovellyApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task CreateGig_PersistsTypeAndGeneratesTypeAwareFeeDescription()
+    {
+        var response = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Weekly piano lesson",
+            date = "2026-06-20",
+            venue = "Studio 2",
+            fee = 60m,
+            travelMiles = 0m,
+            wasDriving = false,
+            status = "Confirmed",
+            type = "Teaching",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var gig = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("Teaching", gig.GetProperty("type").GetString());
+
+        var invoiceResponse = await _client.PostAsync($"/gigs/{gig.GetProperty("id").GetGuid()}/generate-invoice", null, TestContext.Current.CancellationToken);
+        invoiceResponse.EnsureSuccessStatusCode();
+        var invoice = await invoiceResponse.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains(invoice.GetProperty("lines").EnumerateArray(), line =>
+            line.GetProperty("description").GetString() == "Teaching fee for Weekly piano lesson (2026-06-20)");
+    }
+
+    [Fact]
+    public async Task CreateGig_WithInvalidType_ReturnsValidationProblem()
+    {
+        var response = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId,
+            title = "Invalid type",
+            date = "2026-06-20",
+            venue = "Studio 2",
+            fee = 60m,
+            travelMiles = 0m,
+            wasDriving = false,
+            status = "Confirmed",
+            type = 99,
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/backend/Glovelly.Api/Data/Configuration/GigConfiguration.cs
+++ b/backend/Glovelly.Api/Data/Configuration/GigConfiguration.cs
@@ -20,6 +20,9 @@ internal sealed class GigConfiguration : IEntityTypeConfiguration<Gig>
         entity.Property(gig => gig.PassengerCount);
         entity.Property(gig => gig.Notes)
             .HasMaxLength(4000);
+        entity.Property(gig => gig.Type)
+            .HasConversion<string>()
+            .HasMaxLength(50);
         entity.Property(gig => gig.Status)
             .HasConversion<string>()
             .HasMaxLength(50);

--- a/backend/Glovelly.Api/Data/Configuration/GigImportDraftConfiguration.cs
+++ b/backend/Glovelly.Api/Data/Configuration/GigImportDraftConfiguration.cs
@@ -37,6 +37,9 @@ internal sealed class GigImportDraftConfiguration : IEntityTypeConfiguration<Gig
             .HasMaxLength(4000);
         entity.Property(draft => draft.SourceReference)
             .HasMaxLength(500);
+        entity.Property(draft => draft.ProposedGigType)
+            .HasConversion<string>()
+            .HasMaxLength(50);
         entity.Property(draft => draft.Confidence)
             .HasConversion<string>()
             .HasMaxLength(50);

--- a/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
+++ b/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
@@ -647,6 +647,7 @@ public static class DevelopmentDataSeeder
                     Description = $"Performance fee for {lineSubjects[index]}",
                     Quantity = 1m,
                     UnitPrice = 350m + (index * 35m),
+                    GigId = DevelopmentGuid(4000 + index),
                     IsSystemGenerated = true,
                     CreatedByUserId = seededAdminUserId,
                     CreatedUtc = SeededCreatedUtc.AddDays(index)
@@ -660,6 +661,7 @@ public static class DevelopmentDataSeeder
                     Description = $"Mileage for {lineSubjects[index]}",
                     Quantity = 10m + index,
                     UnitPrice = 0.45m,
+                    GigId = DevelopmentGuid(4000 + index),
                     CalculationNotes = "Generated development data for large-list testing.",
                     IsSystemGenerated = true,
                     CreatedByUserId = seededAdminUserId,
@@ -722,7 +724,7 @@ public static class DevelopmentDataSeeder
             {
                 var status = statuses[index % statuses.Length];
                 var date = new DateOnly(2026, 4, 10).AddDays(index * 4);
-                var invoice = index % 4 == 0 ? additionalInvoices[index % additionalInvoices.Count] : null;
+                var invoice = index < additionalInvoices.Count ? additionalInvoices[index] : null;
 
                 return new Gig
                 {

--- a/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/EndpointSupport.cs
@@ -212,6 +212,11 @@ internal static class EndpointSupport
             errors["travelMiles"] = ["Travel miles cannot be negative."];
         }
 
+        if (!Enum.IsDefined(gig.Type))
+        {
+            errors["type"] = ["Gig type is invalid."];
+        }
+
         if (!Enum.IsDefined(gig.Status))
         {
             errors["status"] = ["Status is invalid."];

--- a/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigCrudEndpoints.cs
@@ -239,6 +239,7 @@ internal static class GigCrudEndpoints
             gig.PassengerCount = request.PassengerCount;
             gig.Notes = request.Notes?.Trim();
             gig.WasDriving = request.WasDriving;
+            gig.Type = request.Type;
             gig.Status = request.Status;
             gig.InvoicedAt = EndpointSupport.ResolveInvoicedAt(
                 requestedInvoiceId,

--- a/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigImportEndpoints.cs
@@ -123,6 +123,15 @@ internal static class GigImportEndpoints
             draft.AccommodationNotes = Normalize(request.AccommodationNotes);
             draft.TravelNotes = Normalize(request.TravelNotes);
             draft.SourceReference = Normalize(request.SourceReference);
+            if (request.GigType.HasValue)
+            {
+                if (!Enum.IsDefined(request.GigType.Value))
+                {
+                    return EndpointSupport.ValidationProblem("gigType", "Gig type is invalid.");
+                }
+
+                draft.ProposedGigType = request.GigType.Value;
+            }
             draft.Confidence = request.Confidence ?? draft.Confidence;
             draft.WarningsJson = JsonSerializer.Serialize(
                 PersistedWarnings(request.Warnings ?? ReadWarnings(draft.WarningsJson)),
@@ -365,6 +374,7 @@ internal static class GigImportEndpoints
             PassengerCount = null,
             Notes = BuildNotes(draft),
             WasDriving = false,
+            Type = draft.ProposedGigType,
             Status = GigStatus.Confirmed,
             SourceImportBatchId = batch.Id,
             SourceImportDraftId = draft.Id,
@@ -508,6 +518,7 @@ internal static class GigImportEndpoints
             draft.AccommodationNotes,
             draft.TravelNotes,
             draft.SourceReference,
+            draft.ProposedGigType.ToString(),
             draft.Confidence.ToString(),
             warnings,
             draft.Status.ToString(),
@@ -614,6 +625,7 @@ public sealed record GigImportDraftUpdateRequest(
     string? AccommodationNotes,
     string? TravelNotes,
     string? SourceReference,
+    GigType? GigType,
     GigImportDraftConfidence? Confidence,
     IReadOnlyList<string>? Warnings,
     string? Status);
@@ -660,6 +672,7 @@ public sealed record GigImportDraftDetailDto(
     string? AccommodationNotes,
     string? TravelNotes,
     string? SourceReference,
+    string GigType,
     string Confidence,
     IReadOnlyList<string> Warnings,
     string Status,

--- a/backend/Glovelly.Api/Endpoints/GigQuickCaptureSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/GigQuickCaptureSupport.cs
@@ -42,6 +42,7 @@ internal static class GigQuickCaptureSupport
                 gig.Title,
                 gig.Date,
                 gig.Venue,
+                gig.Type,
                 gig.Status,
                 Math.Abs(gig.Date.DayNumber - today.DayNumber)))
             .Where(candidate => candidate.DaysFromToday <= settings.AutoAttachWindowDays)
@@ -80,6 +81,7 @@ internal static class GigQuickCaptureSupport
             candidate.Title,
             candidate.Date,
             candidate.Venue,
+            candidate.Type,
             candidate.Status,
             candidate.DaysFromToday,
             IsSelected = candidate.Id == selectedGigId,
@@ -93,5 +95,6 @@ internal sealed record QuickGigCandidate(
     string Title,
     DateOnly Date,
     string Venue,
+    GigType Type,
     GigStatus Status,
     int DaysFromToday);

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -258,6 +258,41 @@ public static class InvoiceEndpoints
             return Results.Ok(invoice);
         });
 
+        group.MapPut("/{id:guid}/description", async (
+            Guid id,
+            InvoiceDescriptionUpdateRequest request,
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var invoice = await db.Invoices
+                .WhereVisibleTo(userId)
+                .Include(value => value.Lines)
+                .FirstOrDefaultAsync(value => value.Id == id);
+            if (invoice is null)
+            {
+                return Results.NotFound();
+            }
+
+            if (invoice.Status is not InvoiceStatus.Draft)
+            {
+                return EndpointSupport.ValidationProblem("status", "Only Draft invoices can have their description changed.");
+            }
+
+            var description = request.Description?.Trim();
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                return EndpointSupport.ValidationProblem("description", "Invoice description is required.");
+            }
+
+            invoice.Description = description;
+            EndpointSupport.StampUpdate(invoice, userId);
+            await db.SaveChangesAsync();
+
+            return Results.Ok(invoice);
+        });
+
         group.MapPost("/{id:guid}/reissue", async (
             Guid id,
             AppDbContext db,
@@ -464,5 +499,6 @@ public static class InvoiceEndpoints
     }
 
     private sealed record InvoiceStatusUpdateRequest(InvoiceStatus Status);
+    private sealed record InvoiceDescriptionUpdateRequest(string? Description);
     private sealed record InvoiceAdjustmentCreateRequest(decimal Amount, string Reason);
 }

--- a/backend/Glovelly.Api/Models/Gig.cs
+++ b/backend/Glovelly.Api/Models/Gig.cs
@@ -19,6 +19,7 @@ public sealed class Gig
     public int? PassengerCount { get; set; }
     public string? Notes { get; set; }
     public bool WasDriving { get; set; }
+    public GigType Type { get; set; } = GigType.Performance;
     public GigStatus Status { get; set; } = GigStatus.Draft;
     public DateTimeOffset? InvoicedAt { get; set; }
     public bool IsInvoiced => InvoiceId.HasValue;

--- a/backend/Glovelly.Api/Models/GigImportDraft.cs
+++ b/backend/Glovelly.Api/Models/GigImportDraft.cs
@@ -27,6 +27,7 @@ public sealed class GigImportDraft
     public string? AccommodationNotes { get; set; }
     public string? TravelNotes { get; set; }
     public string? SourceReference { get; set; }
+    public GigType ProposedGigType { get; set; } = GigType.Performance;
     public GigImportDraftConfidence Confidence { get; set; } = GigImportDraftConfidence.Medium;
     public string WarningsJson { get; set; } = "[]";
     public GigImportDraftStatus Status { get; set; } = GigImportDraftStatus.Pending;

--- a/backend/Glovelly.Api/Models/GigType.cs
+++ b/backend/Glovelly.Api/Models/GigType.cs
@@ -1,0 +1,11 @@
+namespace Glovelly.Api.Models;
+
+public enum GigType
+{
+    Performance,
+    Teaching,
+    Rehearsal,
+    Recording,
+    Admin,
+    Other,
+}

--- a/backend/Glovelly.Api/Services/GlovellyMcpContracts.cs
+++ b/backend/Glovelly.Api/Services/GlovellyMcpContracts.cs
@@ -44,7 +44,7 @@ public sealed record InvoiceLineDetail(Guid InvoiceLineId, string Description, d
 public sealed record ReceiptListRequest(DateOnly? FromDate, DateOnly? ToDate, string? Status);
 public sealed record ReceiptListResult(IReadOnlyList<ReceiptSummary> Receipts, int ReceiptCount, int UnmatchedReceiptCount, decimal TotalAmount, string Currency);
 public sealed record ReceiptSummary(Guid ReceiptId, Guid GigId, string GigTitle, DateOnly ReceiptDate, Guid? ContactId, string? ContactName, string Description, decimal Amount, string Status, int AttachmentCount, IReadOnlyList<string> AttachmentFileNames, string Currency);
-public sealed record GigListRequest(Guid? ContactId, string? ContactQuery, string? Status, DateOnly? FromDate, DateOnly? ToDate, string? InvoicingState);
+public sealed record GigListRequest(Guid? ContactId, string? ContactQuery, string? Status, DateOnly? FromDate, DateOnly? ToDate, string? InvoicingState, GigType? GigType);
 public sealed record GigListResult(bool Ambiguous, string? Message, IReadOnlyList<ContactMatch> Matches, IReadOnlyList<GigSummary> Gigs, decimal TotalFees, string Currency)
 {
     public static GigListResult Success(IReadOnlyList<GigSummary> gigs, decimal totalFees, string currency)
@@ -58,7 +58,7 @@ public sealed record GigListResult(bool Ambiguous, string? Message, IReadOnlyLis
     }
 }
 public sealed record GigGetResult(bool Found, GigDetail? Gig);
-public sealed record GigSummary(Guid GigId, string Title, DateOnly Date, string Venue, Guid ContactId, string ContactName, string Status, decimal Fee, bool IsInvoiced, Guid? InvoiceId, string Currency);
+public sealed record GigSummary(Guid GigId, string Title, DateOnly Date, string Venue, Guid ContactId, string ContactName, string Status, string GigType, decimal Fee, bool IsInvoiced, Guid? InvoiceId, string Currency);
 public sealed record GigDetail(
     Guid GigId,
     string Title,
@@ -67,6 +67,7 @@ public sealed record GigDetail(
     Guid ContactId,
     string ContactName,
     string Status,
+    string GigType,
     decimal Fee,
     decimal TravelMiles,
     int? PassengerCount,
@@ -129,6 +130,7 @@ public sealed record GigImportDraftAddRequest(
     string? AccommodationNotes,
     string? TravelNotes,
     string? SourceReference,
+    GigType? GigType,
     GigImportDraftConfidence? Confidence,
     IReadOnlyList<string>? Warnings);
 public sealed record GigImportDraftAddResult(bool BatchFound, bool Created, int Index, IReadOnlyList<string> ValidationErrors, IReadOnlyList<ContactMatch> ContactMatches, GigImportDraftDetail? Draft);
@@ -156,6 +158,7 @@ public sealed record GigImportDraftDetail(
     string? AccommodationNotes,
     string? TravelNotes,
     string? SourceReference,
+    string GigType,
     string Confidence,
     IReadOnlyList<string> Warnings,
     string Status);

--- a/backend/Glovelly.Api/Services/GlovellyMcpQueryService.cs
+++ b/backend/Glovelly.Api/Services/GlovellyMcpQueryService.cs
@@ -224,6 +224,10 @@ public sealed class GlovellyMcpQueryService(
         query = ApplyGigStatusFilter(query, request.Status);
         query = ApplyGigDateFilter(query, request.FromDate, request.ToDate);
         query = ApplyGigInvoicingFilter(query, forceUninvoiced ? "uninvoiced" : request.InvoicingState);
+        if (request.GigType.HasValue && Enum.IsDefined(request.GigType.Value))
+        {
+            query = query.Where(gig => gig.Type == request.GigType.Value);
+        }
 
         var gigs = await query
             .OrderBy(gig => gig.Date)
@@ -656,6 +660,7 @@ public sealed class GlovellyMcpQueryService(
             gig.ClientId,
             gig.Client?.Name ?? string.Empty,
             gig.Status.ToString().ToLowerInvariant(),
+            gig.Type.ToString(),
             gig.Fee,
             gig.IsInvoiced,
             gig.InvoiceId,
@@ -672,6 +677,7 @@ public sealed class GlovellyMcpQueryService(
             gig.ClientId,
             gig.Client?.Name ?? string.Empty,
             gig.Status.ToString().ToLowerInvariant(),
+            gig.Type.ToString(),
             gig.Fee,
             gig.TravelMiles,
             gig.PassengerCount,
@@ -954,6 +960,7 @@ public sealed class GlovellyMcpQueryService(
             AccommodationNotes = NormalizeForStorage(request.AccommodationNotes),
             TravelNotes = NormalizeForStorage(request.TravelNotes),
             SourceReference = NormalizeForStorage(request.SourceReference),
+            ProposedGigType = request.GigType ?? GigType.Performance,
             Confidence = request.Confidence ?? GigImportDraftConfidence.Medium,
             WarningsJson = JsonSerializer.Serialize(NormalizeWarnings(request.Warnings), JsonOptions),
             Status = GigImportDraftStatus.Pending,
@@ -979,6 +986,11 @@ public sealed class GlovellyMcpQueryService(
         ValidateLength(request.AccommodationNotes, "accommodationNotes", 4000, validationErrors);
         ValidateLength(request.TravelNotes, "travelNotes", 4000, validationErrors);
         ValidateLength(request.SourceReference, "sourceReference", 500, validationErrors);
+
+        if (request.GigType.HasValue && !Enum.IsDefined(request.GigType.Value))
+        {
+            validationErrors.Add("gigType is invalid.");
+        }
 
         if (request.Fee.HasValue && request.Fee.Value < 0)
         {
@@ -1047,6 +1059,7 @@ public sealed class GlovellyMcpQueryService(
             draft.AccommodationNotes,
             draft.TravelNotes,
             draft.SourceReference,
+            draft.ProposedGigType.ToString(),
             draft.Confidence.ToString().ToLowerInvariant(),
             ReadWarnings(draft.WarningsJson),
             draft.Status.ToString().ToLowerInvariant());

--- a/backend/Glovelly.Api/Services/GlovellyMcpSchemaFragments.cs
+++ b/backend/Glovelly.Api/Services/GlovellyMcpSchemaFragments.cs
@@ -24,6 +24,7 @@ public static class GlovellyMcpSchemaFragments
         ["invoicingState"] = McpSchema.Enum(
             ["all", "invoiced", "uninvoiced"],
             "Whether to return invoiced gigs, uninvoiced gigs, or all gigs."),
+        ["gigType"] = McpSchema.Enum<GigType>("Nature of the musician work."),
     };
 
     public static object Confidence => McpSchema.Enum<GigImportDraftConfidence>(

--- a/backend/Glovelly.Api/Services/GlovellyMcpToolCatalog.cs
+++ b/backend/Glovelly.Api/Services/GlovellyMcpToolCatalog.cs
@@ -47,7 +47,7 @@ public static class GlovellyMcpToolCatalog
         new(
             "glovelly_list_gigs",
             "List Gigs",
-            "List gigs by optional contact, status, date range, and invoicing state.",
+            "List gigs by optional contact, status, type, date range, and invoicing state.",
             McpSchema.Object(MergeProperties(
                 GlovellyMcpSchemaFragments.ContactSelector,
                 GlovellyMcpSchemaFragments.DateRange,
@@ -73,9 +73,10 @@ public static class GlovellyMcpToolCatalog
                 GlovellyMcpSchemaFragments.DateRange,
                 new Dictionary<string, object>
                 {
-                    ["status"] = McpSchema.Enum(
+                        ["status"] = McpSchema.Enum(
                         ["all", "draft", "confirmed", "planned", "completed", "cancelled", "canceled"],
-                        "Gig status filter. Use confirmed or planned for planned gigs."),
+                            "Gig status filter. Use confirmed or planned for planned gigs."),
+                    ["gigType"] = McpSchema.Enum<GigType>("Nature of the musician work."),
                 })),
             McpToolSafetyLevel.ReadOnly,
             OutputSchema: GigListOutputSchema()),
@@ -482,6 +483,7 @@ public static class GlovellyMcpToolCatalog
             contactId = UuidSchema(),
             contactName = new { type = "string" },
             status = McpSchema.Enum<GigStatus>("Gig lifecycle status."),
+            gigType = McpSchema.Enum<GigType>("Nature of the musician work."),
             fee = McpSchema.Money("Gig fee."),
             isInvoiced = new { type = "boolean" },
             invoiceId = UuidSchema(),
@@ -501,6 +503,7 @@ public static class GlovellyMcpToolCatalog
             contactId = UuidSchema(),
             contactName = new { type = "string" },
             status = McpSchema.Enum<GigStatus>("Gig lifecycle status."),
+            gigType = McpSchema.Enum<GigType>("Nature of the musician work."),
             fee = McpSchema.Money("Gig fee."),
             travelMiles = new { type = "number" },
             passengerCount = new { type = "integer" },
@@ -786,6 +789,7 @@ public static class GlovellyMcpToolCatalog
             accommodationNotes = new { type = "string" },
             travelNotes = new { type = "string" },
             sourceReference = new { type = "string" },
+            gigType = McpSchema.Enum<GigType>("Nature of the proposed musician work."),
             confidence = GlovellyMcpSchemaFragments.Confidence,
             warnings = StringArraySchema(),
             status = McpSchema.Enum<GigImportDraftStatus>("Draft review status."),
@@ -861,6 +865,7 @@ public static class GlovellyMcpToolCatalog
             ["accommodationNotes"] = McpSchema.String("Accommodation details or uncertainty.", maxLength: 4000),
             ["travelNotes"] = McpSchema.String("Travel details or uncertainty.", maxLength: 4000),
             ["sourceReference"] = McpSchema.String("Optional reference to the source row, page, message, or attachment.", maxLength: 500),
+            ["gigType"] = McpSchema.Enum<GigType>("Nature of the proposed musician work."),
             ["confidence"] = GlovellyMcpSchemaFragments.Confidence,
             ["warnings"] = StringArraySchema(),
         };

--- a/backend/Glovelly.Api/Services/InvoiceLineGenerationService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceLineGenerationService.cs
@@ -27,7 +27,7 @@ public sealed class InvoiceLineGenerationService(
                 userId,
                 nextSortOrder++,
                 InvoiceLineType.PerformanceFee,
-                $"Performance fee for {gig.Title} ({gig.Date:yyyy-MM-dd})",
+                $"{FeePrefixFor(gig.Type)} for {gig.Title} ({gig.Date:yyyy-MM-dd})",
                 1m,
                 gig.Fee));
         }
@@ -87,6 +87,19 @@ public sealed class InvoiceLineGenerationService(
         }
 
         return lines;
+    }
+
+    private static string FeePrefixFor(GigType type)
+    {
+        return type switch
+        {
+            GigType.Performance => "Performance fee",
+            GigType.Teaching => "Teaching fee",
+            GigType.Rehearsal => "Rehearsal fee",
+            GigType.Recording => "Recording fee",
+            GigType.Admin => "Admin fee",
+            _ => "Fee",
+        };
     }
 
     public async Task<bool> RemoveSystemGeneratedInvoiceLinesForGigAsync(

--- a/backend/Glovelly.Migrations/Migrations/20260719202048_AddTypedGigs.Designer.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260719202048_AddTypedGigs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Glovelly.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Glovelly.Migrations.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719202048_AddTypedGigs")]
+    partial class AddTypedGigs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Glovelly.Migrations/Migrations/20260719202048_AddTypedGigs.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260719202048_AddTypedGigs.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Glovelly.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTypedGigs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Type",
+                table: "Gigs",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "Performance");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProposedGigType",
+                table: "GigImportDrafts",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "Performance");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Gigs");
+
+            migrationBuilder.DropColumn(
+                name: "ProposedGigType",
+                table: "GigImportDrafts");
+        }
+    }
+}

--- a/docs/mcp-tools.json
+++ b/docs/mcp-tools.json
@@ -130,7 +130,7 @@
       "title": "Get Contact"
     },
     {
-      "description": "List gigs by optional contact, status, date range, and invoicing state.",
+      "description": "List gigs by optional contact, status, type, date range, and invoicing state.",
       "inputSchema": {
         "properties": {
           "contactId": {
@@ -145,6 +145,18 @@
           "fromDate": {
             "description": "Inclusive start date in YYYY-MM-DD format.",
             "format": "date",
+            "type": "string"
+          },
+          "gigType": {
+            "description": "Nature of the musician work.",
+            "enum": [
+              "performance",
+              "teaching",
+              "rehearsal",
+              "recording",
+              "admin",
+              "other"
+            ],
             "type": "string"
           },
           "invoicingState": {
@@ -210,6 +222,18 @@
                 },
                 "gigId": {
                   "format": "uuid",
+                  "type": "string"
+                },
+                "gigType": {
+                  "description": "Nature of the musician work.",
+                  "enum": [
+                    "performance",
+                    "teaching",
+                    "rehearsal",
+                    "recording",
+                    "admin",
+                    "other"
+                  ],
                   "type": "string"
                 },
                 "invoiceId": {
@@ -359,6 +383,18 @@
               },
               "gigId": {
                 "format": "uuid",
+                "type": "string"
+              },
+              "gigType": {
+                "description": "Nature of the musician work.",
+                "enum": [
+                  "performance",
+                  "teaching",
+                  "rehearsal",
+                  "recording",
+                  "admin",
+                  "other"
+                ],
                 "type": "string"
               },
               "invoice": {
@@ -554,6 +590,18 @@
             "format": "date",
             "type": "string"
           },
+          "gigType": {
+            "description": "Nature of the musician work.",
+            "enum": [
+              "performance",
+              "teaching",
+              "rehearsal",
+              "recording",
+              "admin",
+              "other"
+            ],
+            "type": "string"
+          },
           "status": {
             "description": "Gig status filter. Use confirmed or planned for planned gigs.",
             "enum": [
@@ -608,6 +656,18 @@
                 },
                 "gigId": {
                   "format": "uuid",
+                  "type": "string"
+                },
+                "gigType": {
+                  "description": "Nature of the musician work.",
+                  "enum": [
+                    "performance",
+                    "teaching",
+                    "rehearsal",
+                    "recording",
+                    "admin",
+                    "other"
+                  ],
                   "type": "string"
                 },
                 "invoiceId": {
@@ -1650,6 +1710,18 @@
             "minimum": 0,
             "type": "number"
           },
+          "gigType": {
+            "description": "Nature of the proposed musician work.",
+            "enum": [
+              "performance",
+              "teaching",
+              "rehearsal",
+              "recording",
+              "admin",
+              "other"
+            ],
+            "type": "string"
+          },
           "notes": {
             "description": "General notes from the source.",
             "maxLength": 4000,
@@ -1799,6 +1871,18 @@
                 "description": "Proposed gig fee.",
                 "type": "number"
               },
+              "gigType": {
+                "description": "Nature of the proposed musician work.",
+                "enum": [
+                  "performance",
+                  "teaching",
+                  "rehearsal",
+                  "recording",
+                  "admin",
+                  "other"
+                ],
+                "type": "string"
+              },
               "notes": {
                 "type": "string"
               },
@@ -1946,6 +2030,18 @@
                   "description": "Proposed gig fee.",
                   "minimum": 0,
                   "type": "number"
+                },
+                "gigType": {
+                  "description": "Nature of the proposed musician work.",
+                  "enum": [
+                    "performance",
+                    "teaching",
+                    "rehearsal",
+                    "recording",
+                    "admin",
+                    "other"
+                  ],
+                  "type": "string"
                 },
                 "notes": {
                   "description": "General notes from the source.",
@@ -2111,6 +2207,18 @@
                     "fee": {
                       "description": "Proposed gig fee.",
                       "type": "number"
+                    },
+                    "gigType": {
+                      "description": "Nature of the proposed musician work.",
+                      "enum": [
+                        "performance",
+                        "teaching",
+                        "rehearsal",
+                        "recording",
+                        "admin",
+                        "other"
+                      ],
+                      "type": "string"
                     },
                     "notes": {
                       "type": "string"
@@ -2338,6 +2446,18 @@
                     "fee": {
                       "description": "Proposed gig fee.",
                       "type": "number"
+                    },
+                    "gigType": {
+                      "description": "Nature of the proposed musician work.",
+                      "enum": [
+                        "performance",
+                        "teaching",
+                        "rehearsal",
+                        "recording",
+                        "admin",
+                        "other"
+                      ],
+                      "type": "string"
                     },
                     "notes": {
                       "type": "string"

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -182,7 +182,7 @@ Output schema:
 
 ## `glovelly_list_gigs`
 
-List gigs by optional contact, status, date range, and invoicing state.
+List gigs by optional contact, status, type, date range, and invoicing state.
 
 Title: List Gigs
 
@@ -194,6 +194,7 @@ Inputs:
 - `contactId` (optional): string (uuid). Exact Glovelly contact ID. Use this when a previous contact lookup returned an unambiguous match.
 - `contactQuery` (optional): string. Name or email text used to look up a contact when contactId is not known.
 - `fromDate` (optional): string (date). Inclusive start date in YYYY-MM-DD format.
+- `gigType` (optional): string = performance | teaching | rehearsal | recording | admin | other. Nature of the musician work.
 - `invoicingState` (optional): string = all | invoiced | uninvoiced. Whether to return invoiced gigs, uninvoiced gigs, or all gigs.
 - `status` (optional): string = all | draft | confirmed | planned | completed | cancelled | canceled. Gig status filter. Use confirmed or planned for planned gigs.
 - `toDate` (optional): string (date). Inclusive end date in YYYY-MM-DD format.
@@ -225,6 +226,18 @@ Input schema:
     "fromDate": {
       "description": "Inclusive start date in YYYY-MM-DD format.",
       "format": "date",
+      "type": "string"
+    },
+    "gigType": {
+      "description": "Nature of the musician work.",
+      "enum": [
+        "performance",
+        "teaching",
+        "rehearsal",
+        "recording",
+        "admin",
+        "other"
+      ],
       "type": "string"
     },
     "invoicingState": {
@@ -294,6 +307,18 @@ Output schema:
           },
           "gigId": {
             "format": "uuid",
+            "type": "string"
+          },
+          "gigType": {
+            "description": "Nature of the musician work.",
+            "enum": [
+              "performance",
+              "teaching",
+              "rehearsal",
+              "recording",
+              "admin",
+              "other"
+            ],
             "type": "string"
           },
           "invoiceId": {
@@ -467,6 +492,18 @@ Output schema:
         },
         "gigId": {
           "format": "uuid",
+          "type": "string"
+        },
+        "gigType": {
+          "description": "Nature of the musician work.",
+          "enum": [
+            "performance",
+            "teaching",
+            "rehearsal",
+            "recording",
+            "admin",
+            "other"
+          ],
           "type": "string"
         },
         "invoice": {
@@ -656,6 +693,7 @@ Inputs:
 - `contactId` (optional): string (uuid). Exact Glovelly contact ID. Use this when a previous contact lookup returned an unambiguous match.
 - `contactQuery` (optional): string. Name or email text used to look up a contact when contactId is not known.
 - `fromDate` (optional): string (date). Inclusive start date in YYYY-MM-DD format.
+- `gigType` (optional): string = performance | teaching | rehearsal | recording | admin | other. Nature of the musician work.
 - `status` (optional): string = all | draft | confirmed | planned | completed | cancelled | canceled. Gig status filter. Use confirmed or planned for planned gigs.
 - `toDate` (optional): string (date). Inclusive end date in YYYY-MM-DD format.
 
@@ -686,6 +724,18 @@ Input schema:
     "fromDate": {
       "description": "Inclusive start date in YYYY-MM-DD format.",
       "format": "date",
+      "type": "string"
+    },
+    "gigType": {
+      "description": "Nature of the musician work.",
+      "enum": [
+        "performance",
+        "teaching",
+        "rehearsal",
+        "recording",
+        "admin",
+        "other"
+      ],
       "type": "string"
     },
     "status": {
@@ -746,6 +796,18 @@ Output schema:
           },
           "gigId": {
             "format": "uuid",
+            "type": "string"
+          },
+          "gigType": {
+            "description": "Nature of the musician work.",
+            "enum": [
+              "performance",
+              "teaching",
+              "rehearsal",
+              "recording",
+              "admin",
+              "other"
+            ],
             "type": "string"
           },
           "invoiceId": {
@@ -1962,6 +2024,7 @@ Inputs:
 - `contactQuery` (optional): string. Name or email text to resolve the gig client/contact.
 - `date` (optional): string (date). ISO 8601 calendar date in YYYY-MM-DD format.
 - `fee` (optional): number. Proposed gig fee.
+- `gigType` (optional): string = performance | teaching | rehearsal | recording | admin | other. Nature of the proposed musician work.
 - `notes` (optional): string. General notes from the source.
 - `perDiem` (optional): number. Proposed per diem amount.
 - `postcode` (optional): string. Venue postcode.
@@ -2042,6 +2105,18 @@ Input schema:
       "description": "Proposed gig fee.",
       "minimum": 0,
       "type": "number"
+    },
+    "gigType": {
+      "description": "Nature of the proposed musician work.",
+      "enum": [
+        "performance",
+        "teaching",
+        "rehearsal",
+        "recording",
+        "admin",
+        "other"
+      ],
+      "type": "string"
     },
     "notes": {
       "description": "General notes from the source.",
@@ -2195,6 +2270,18 @@ Output schema:
         "fee": {
           "description": "Proposed gig fee.",
           "type": "number"
+        },
+        "gigType": {
+          "description": "Nature of the proposed musician work.",
+          "enum": [
+            "performance",
+            "teaching",
+            "rehearsal",
+            "recording",
+            "admin",
+            "other"
+          ],
+          "type": "string"
         },
         "notes": {
           "type": "string"
@@ -2372,6 +2459,18 @@ Input schema:
             "minimum": 0,
             "type": "number"
           },
+          "gigType": {
+            "description": "Nature of the proposed musician work.",
+            "enum": [
+              "performance",
+              "teaching",
+              "rehearsal",
+              "recording",
+              "admin",
+              "other"
+            ],
+            "type": "string"
+          },
           "notes": {
             "description": "General notes from the source.",
             "maxLength": 4000,
@@ -2540,6 +2639,18 @@ Output schema:
               "fee": {
                 "description": "Proposed gig fee.",
                 "type": "number"
+              },
+              "gigType": {
+                "description": "Nature of the proposed musician work.",
+                "enum": [
+                  "performance",
+                  "teaching",
+                  "rehearsal",
+                  "recording",
+                  "admin",
+                  "other"
+                ],
+                "type": "string"
               },
               "notes": {
                 "type": "string"
@@ -2814,6 +2925,18 @@ Output schema:
               "fee": {
                 "description": "Proposed gig fee.",
                 "type": "number"
+              },
+              "gigType": {
+                "description": "Nature of the proposed musician work.",
+                "enum": [
+                  "performance",
+                  "teaching",
+                  "rehearsal",
+                  "recording",
+                  "admin",
+                  "other"
+                ],
+                "type": "string"
               },
               "notes": {
                 "type": "string"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,6 +27,7 @@
 - Set lists
 - Richer financial reporting
 - More automation around tax prep
+- Invoice-native editing for draft line items, including clear regeneration behavior for generated lines
 
 ## Not Yet
 - AI chat agent

--- a/docs/uat/gig-imports.md
+++ b/docs/uat/gig-imports.md
@@ -50,7 +50,7 @@ The import review modal opens from the profile menu. Imported gigs are not a pri
 ### Steps
 
 1. Select the staged batch in the modal.
-2. Edit a missing or incorrect field, such as client, title, date, venue, fee, or source reference.
+2. Edit a missing or incorrect field, such as client, title, type, date, location, fee, or source reference.
 3. Wait briefly without clicking a save button.
 4. Close and reopen the import modal, or select another batch and return.
 5. Accept at least one valid row.
@@ -93,7 +93,7 @@ Duplicate rows show warning text in the review modal. Editing date, title, clien
 
 ### Expected Results
 
-Accepted rows become real gigs with source import linkage. Rejected rows are deleted from the import on commit. Pending rows remain staged. Previously rejected rows should not reappear or jump back into the review list on later passes.
+Accepted rows become real gigs with source import linkage and the reviewed gig type. Rejected rows are deleted from the import on commit. Pending rows remain staged. Previously rejected rows should not reappear or jump back into the review list on later passes.
 
 ## Validation And Multi-Pass Review
 

--- a/docs/uat/invoices.md
+++ b/docs/uat/invoices.md
@@ -191,6 +191,17 @@ The same invoice PDF can be previewed reactively from the invoice pane, download
 
 Expected result: redraft and re-issue update the PDF, preserve the expected invoice history rules, and show the latest PDF in the preview modal.
 
+### Draft Description Customization
+
+1. Open a draft invoice and open its Line items pane.
+2. Change the Description and save it.
+3. Confirm the invoice details show the saved description.
+4. Redraft the invoice and preview or download the PDF.
+5. Confirm the regenerated PDF uses the saved description.
+6. Open an issued invoice's Line items pane.
+
+Expected result: only draft invoices expose an editable Description and save action. Saving does not immediately regenerate the PDF; redrafting does. Non-draft invoice descriptions are read-only.
+
 ## Invoice Status And Delivery
 
 > **Automation:** Partially automated UAT: `Glovelly.Uat.Tests.InvoicePromptChoiceTests.IssuingLinkedDraftHonoursLinkedGigCompletionChoice` covers accepting and declining linked-gig completion after issuing; backend tests cover status and delivery rules, while configured email/Drive checks remain manual.

--- a/docs/uat/invoices.md
+++ b/docs/uat/invoices.md
@@ -18,11 +18,11 @@ Use these journeys when a change may affect invoice creation, generated invoice 
 ### Steps
 
 1. Create a client or choose an existing client.
-2. Create a gig with fee, date, venue, status `Planned`, and at least one claimable expense.
+2. Create a gig with a type, fee, date, location, status `Planned`, and at least one claimable expense.
 3. Save the gig.
 4. Generate an invoice from that gig.
 5. Open the invoice.
-6. Confirm invoice lines include the performance fee and chargeable expenses.
+6. Confirm invoice lines include the type-appropriate fee description and chargeable expenses.
 7. Download the PDF.
 8. Return to the gig.
 9. Confirm the gig shows as invoiced and links back to the invoice.

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -62,7 +62,7 @@ When changes touch Google Calendar, run the focused [Google Calendar](calendar.m
 
 ## Cross-Workspace Navigation Shortcuts
 
-> **Automation:** Automated UAT: `Glovelly.Uat.Tests.CrossWorkspaceNavigationTests.ClientAndInvoiceLineShortcutsOpenTargetsDespiteStaleFilters`
+> **Automation:** Automated UAT: `Glovelly.Uat.Tests.CrossWorkspaceNavigationTests.ClientAndInvoiceLineShortcutsOpenTargetsDespiteStaleFilters` and `InvoiceLineNavigationDoesNotReusePreviouslySavedGigEditorState`
 
 ### Steps
 
@@ -76,10 +76,12 @@ When changes touch Google Calendar, run the focused [Google Calendar](calendar.m
 8. Click a generated line-item title for a performance fee, mileage, passenger mileage, or expense line.
 9. Confirm the app opens Gigs with the corresponding gig selected.
 10. Confirm manual adjustment lines are not shown as gig links.
+11. For two gigs on one draft invoice, edit and regenerate the first gig, then use an invoice-line shortcut to open the second without refreshing the browser.
+12. Confirm the second gig editor shows only the second gig's saved fields and expenses before saving an intended second-gig change.
 
 ### Expected Results
 
-Cross-workspace shortcuts preserve the intended target record, clear stale search filters that would hide the target, and leave unrelated records unchanged.
+Cross-workspace shortcuts preserve the intended target record, clear stale search filters that would hide the target, hydrate an open gig editor from the target record, and leave unrelated records unchanged.
 
 ## Editor Navigation Regression Checks
 

--- a/frontend/glovelly-web/package-lock.json
+++ b/frontend/glovelly-web/package-lock.json
@@ -28,13 +28,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -53,21 +53,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -84,14 +84,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -101,14 +101,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -128,29 +128,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -190,27 +190,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -220,33 +220,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -254,35 +254,35 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -291,9 +291,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -430,25 +430,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -545,14 +559,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -564,9 +578,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -574,9 +588,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -591,9 +605,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -608,9 +622,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -625,9 +639,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -642,9 +656,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -659,9 +673,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -679,9 +693,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -699,9 +713,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -719,9 +733,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -739,9 +753,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -759,9 +773,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -779,9 +793,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -796,9 +810,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -806,18 +820,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -832,9 +846,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -856,9 +870,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -874,9 +888,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -888,19 +902,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
-      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -918,17 +932,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/type-utils": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -941,15 +955,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.1",
+        "@typescript-eslint/parser": "^8.64.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -957,16 +971,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -982,14 +996,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.1",
-        "@typescript-eslint/types": "^8.60.1",
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1004,14 +1018,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1"
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1022,9 +1036,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1039,15 +1053,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1064,9 +1078,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1078,16 +1092,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.1",
-        "@typescript-eslint/tsconfig-utils": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1106,9 +1120,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1119,16 +1133,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1"
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1143,13 +1157,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/types": "8.64.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1161,13 +1175,13 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
-      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "^1.0.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -1199,9 +1213,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1249,9 +1263,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
-      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1262,9 +1276,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1275,9 +1289,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -1295,10 +1309,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -1309,9 +1323,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -1394,9 +1408,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.335",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
-      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1424,11 +1438,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1500,9 +1517,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
-      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1762,9 +1779,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2062,6 +2079,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2083,6 +2103,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2104,6 +2127,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2125,6 +2151,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2230,9 +2259,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2276,11 +2305,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2360,9 +2392,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2373,9 +2405,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -2393,7 +2425,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2466,13 +2498,13 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2482,21 +2514,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/scheduler": {
@@ -2641,16 +2673,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
+      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.1",
-        "@typescript-eslint/parser": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1"
+        "@typescript-eslint/eslint-plugin": "8.64.0",
+        "@typescript-eslint/parser": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2665,9 +2697,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2732,16 +2764,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -2758,7 +2790,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -2852,9 +2884,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -2893,9 +2925,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -2423,6 +2423,10 @@ button.compact-record-row.selected {
   justify-self: start;
 }
 
+.invoice-description-form {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 @media (max-width: 1380px) {
   .invoice-adjustment-form {
     grid-template-columns: 1fr;

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1263,6 +1263,23 @@
   gap: 5px;
 }
 
+.gig-editor-metrics,
+.gig-detail-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.gig-detail-metrics article {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+  border-radius: 20px;
+  padding: 18px;
+  background: var(--surface-subtle);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 80%, transparent);
+}
+
 .gig-editor-panel input,
 .gig-editor-panel select {
   min-height: 40px;
@@ -2892,6 +2909,12 @@ button:disabled {
   .gig-expense-item {
     grid-template-columns: 1fr;
   }
+
+  .gig-editor-metrics,
+  .gig-detail-metrics {
+    grid-template-columns: 1fr;
+  }
+
 
   .panel-heading {
     flex-direction: column;

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -302,11 +302,13 @@ function App({ appMetadata }: AppProps) {
     handleDeleteInvoice,
     handleDownloadInvoicePdf,
     handleInvoiceReissue,
+    handleInvoiceDescriptionSave,
     handleInvoiceStatusChange,
     handlePublishInvoiceGoogleDrive,
     handleSendInvoiceEmail,
     invoices,
     invoiceQuickFilter,
+    invoiceDescription,
     invoiceSearchQuery,
     invoiceSort,
     invoiceStatus,
@@ -317,6 +319,7 @@ function App({ appMetadata }: AppProps) {
     selectedInvoice,
     setAdjustmentAmount,
     setAdjustmentReason,
+    setInvoiceDescription,
     setInvoices,
     setInvoiceStatus,
     setIsInvoiceLoading,
@@ -1752,6 +1755,7 @@ function App({ appMetadata }: AppProps) {
         filteredInvoices={filteredInvoices}
         isEditorOpen={isInvoiceEditorOpen}
         invoiceQuickFilter={invoiceQuickFilter}
+        invoiceDescription={invoiceDescription}
         invoiceSearchQuery={invoiceSearchQuery}
         invoiceSort={invoiceSort}
         invoiceStatus={invoiceStatus}
@@ -1770,6 +1774,8 @@ function App({ appMetadata }: AppProps) {
         onDeleteAdjustment={handleDeleteInvoiceAdjustment}
         onDeleteInvoice={handleDeleteInvoice}
         onDownloadPdf={handleDownloadInvoicePdf}
+        onInvoiceDescriptionChange={setInvoiceDescription}
+        onInvoiceDescriptionSave={handleInvoiceDescriptionSave}
         onInvoiceStatusChange={handleInvoiceStatusChangeWithGigPrompt}
         onOpenClient={openClientShortcut}
         onOpenGig={openInvoiceLineGig}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -204,6 +204,7 @@ function App({ appMetadata }: AppProps) {
     gigForm,
     gigMode,
     gigQuickFilter,
+    gigTypeFilter,
     gigSearchQuery,
     gigSort,
     gigStatus,
@@ -234,6 +235,7 @@ function App({ appMetadata }: AppProps) {
     selectGig,
     setGigs,
     setGigQuickFilter,
+    setGigTypeFilter,
     setGigSearchQuery,
     setGigSort,
     setGigStatus,
@@ -385,6 +387,7 @@ function App({ appMetadata }: AppProps) {
           title: gig.title,
           date: gig.date,
           venue: gig.venue,
+          type: gig.type,
           status: gig.status,
           daysFromToday,
           isSelected: false,
@@ -1693,6 +1696,7 @@ function App({ appMetadata }: AppProps) {
         isEditorOpen={isGigEditorOpen}
         gigMode={gigMode}
         gigQuickFilter={gigQuickFilter}
+        gigTypeFilter={gigTypeFilter}
         gigSearchQuery={gigSearchQuery}
         gigSort={gigSort}
         gigStatus={gigStatus}
@@ -1720,6 +1724,7 @@ function App({ appMetadata }: AppProps) {
         onDeleteExpenseAttachment={deleteExpenseAttachment}
         onResetForm={startGigCreate}
         onQuickFilterChange={setGigQuickFilter}
+        onGigTypeFilterChange={setGigTypeFilter}
         onSearchQueryChange={setGigSearchQuery}
         onSelectGig={selectGig}
         onSortChange={setGigSort}

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -954,7 +954,10 @@ function App({ appMetadata }: AppProps) {
   }
 
   const openInvoiceLineGig = (gigId: string) => {
-    setSelectedGigId(gigId)
+    if (!selectGig(gigId)) {
+      return
+    }
+
     setSelectedGigIds([])
     setGigSearchQuery('')
     closeInvoiceEditor()
@@ -1455,7 +1458,10 @@ function App({ appMetadata }: AppProps) {
       return
     }
 
-    setSelectedGigId(nextDashboardGig.id)
+    if (!selectGig(nextDashboardGig.id)) {
+      return
+    }
+
     setSelectedGigIds([])
     setGigSearchQuery('')
     setActiveSection('gigs')
@@ -1466,7 +1472,10 @@ function App({ appMetadata }: AppProps) {
       return
     }
 
-    setSelectedGigId(dashboardInvoiceCandidate.id)
+    if (!selectGig(dashboardInvoiceCandidate.id)) {
+      return
+    }
+
     setSelectedGigIds([])
     setGigSearchQuery('')
     setActiveSection('gigs')

--- a/frontend/glovelly-web/src/components/GigEditorPanel.tsx
+++ b/frontend/glovelly-web/src/components/GigEditorPanel.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from 'react'
-import type { Client, GigExpenseForm, GigForm, GigStatus } from '../types'
+import type { Client, GigExpenseForm, GigForm, GigStatus, GigType } from '../types'
 
 type GigEditorPanelProps = {
   clients: Client[]
@@ -65,14 +65,20 @@ export function GigEditorPanel({
         </label>
 
         <label>
-          <span>Date</span>
-          <input
-            data-testid="gig-date-input"
+          <span>Type</span>
+          <select
+            data-testid="gig-type-select"
             required
-            type="date"
-            value={gigForm.date}
-            onChange={(event) => onUpdateGigField('date', event.target.value)}
-          />
+            value={gigForm.type}
+            onChange={(event) => onUpdateGigField('type', event.target.value as GigType)}
+          >
+            <option value="Performance">Performance</option>
+            <option value="Teaching">Teaching</option>
+            <option value="Rehearsal">Rehearsal</option>
+            <option value="Recording">Recording</option>
+            <option value="Admin">Admin</option>
+            <option value="Other">Other work</option>
+          </select>
         </label>
 
         <label className="full-width">
@@ -87,7 +93,7 @@ export function GigEditorPanel({
         </label>
 
         <label className="full-width">
-          <span>Location / venue</span>
+          <span>Location</span>
           <input
             data-testid="gig-venue-input"
             required
@@ -97,33 +103,46 @@ export function GigEditorPanel({
           />
         </label>
 
-        <label>
-          <span>Fee</span>
-          <input
-            data-testid="gig-fee-input"
-            required
-            inputMode="decimal"
-            value={gigForm.fee}
-            onChange={(event) => onUpdateGigField('fee', event.target.value)}
-            placeholder="650"
-          />
-        </label>
+        <div className="gig-editor-metrics full-width">
+          <label>
+            <span>Date</span>
+            <input
+              data-testid="gig-date-input"
+              required
+              type="date"
+              value={gigForm.date}
+              onChange={(event) => onUpdateGigField('date', event.target.value)}
+            />
+          </label>
 
-        <label>
-          <span>Status</span>
-          <select
-            data-testid="gig-status-select"
-            value={gigForm.status}
-            onChange={(event) =>
-              onUpdateGigField('status', event.target.value as GigStatus)
-            }
-          >
-            <option value="Confirmed">Planned</option>
-            <option value="Completed">Completed</option>
-            <option value="Cancelled">Cancelled</option>
-            <option value="Draft">Draft</option>
-          </select>
-        </label>
+          <label>
+            <span>Fee</span>
+            <input
+              data-testid="gig-fee-input"
+              required
+              inputMode="decimal"
+              value={gigForm.fee}
+              onChange={(event) => onUpdateGigField('fee', event.target.value)}
+              placeholder="650"
+            />
+          </label>
+
+          <label>
+            <span>Status</span>
+            <select
+              data-testid="gig-status-select"
+              value={gigForm.status}
+              onChange={(event) =>
+                onUpdateGigField('status', event.target.value as GigStatus)
+              }
+            >
+              <option value="Confirmed">Planned</option>
+              <option value="Completed">Completed</option>
+              <option value="Cancelled">Cancelled</option>
+              <option value="Draft">Draft</option>
+            </select>
+          </label>
+        </div>
 
         <label className="checkbox-field full-width">
           <input

--- a/frontend/glovelly-web/src/components/GigImportsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigImportsSection.tsx
@@ -1,4 +1,4 @@
-import { formatCurrency, formatDate } from '../formatters'
+import { formatCurrency, formatDate, formatGigType } from '../formatters'
 import type { Client, GigImportBatchDetail, GigImportBatchSummary, GigImportDraft } from '../types'
 import type { GigImportDraftField } from '../hooks/useGigImportsWorkspace'
 
@@ -149,7 +149,7 @@ export function GigImportsModal({
                       <div>
                         <strong>{draft.title || draft.projectName || 'Untitled row'}</strong>
                         <span>
-                          {draft.date ? formatDate(draft.date) : 'Missing date'} · {draft.venueName || draft.venueAddress || 'Missing venue'}
+                          {formatGigType(draft.gigType)} · {draft.date ? formatDate(draft.date) : 'Missing date'} · {draft.venueName || draft.venueAddress || 'Missing location'}
                         </span>
                       </div>
                       <span className={`status-pill confidence-${draft.confidence.toLowerCase()}`}>
@@ -222,6 +222,24 @@ export function GigImportsModal({
                         />
                       </label>
                       <label>
+                        <span>Type</span>
+                        <select
+                          data-testid="gig-import-draft-type-select"
+                          value={draft.gigType}
+                          disabled={isCommitted}
+                          onChange={(event) =>
+                            onUpdateDraftField(draft.draftId, 'gigType', event.target.value)
+                          }
+                        >
+                          <option value="Performance">Performance</option>
+                          <option value="Teaching">Teaching</option>
+                          <option value="Rehearsal">Rehearsal</option>
+                          <option value="Recording">Recording</option>
+                          <option value="Admin">Admin</option>
+                          <option value="Other">Other work</option>
+                        </select>
+                      </label>
+                      <label>
                         <span>Fee</span>
                         <input
                           data-testid="gig-import-draft-fee-input"
@@ -260,7 +278,7 @@ export function GigImportsModal({
                         </select>
                       </label>
                       <label className="full-width">
-                        <span>Venue</span>
+                        <span>Location</span>
                         <input
                           data-testid="gig-import-draft-venue-input"
                           value={draft.venueName ?? ''}

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -5,7 +5,7 @@ import { GigAttachmentsPanel } from './GigAttachmentsPanel'
 import { GigEditorPanel } from './GigEditorPanel'
 import { GigExpensesPanel } from './GigExpensesPanel'
 import { TrashIcon } from './TrashIcon'
-import { formatCurrency, formatDate, formatGigStatus } from '../formatters'
+import { formatCurrency, formatDate, formatGigStatus, formatGigType } from '../formatters'
 import { useMeasuredBlockSize } from '../hooks/useMeasuredBlockSize'
 import type {
   Client,
@@ -19,6 +19,7 @@ import type {
   GigQuickFilter,
   GigSort,
   GigSortKey,
+  GigType,
 } from '../types'
 
 type GigsSectionProps = {
@@ -32,6 +33,7 @@ type GigsSectionProps = {
   isEditorOpen: boolean
   gigMode: 'create' | 'edit'
   gigQuickFilter: GigQuickFilter
+  gigTypeFilter: GigType | 'all'
   gigSearchQuery: string
   gigSort: GigSort
   gigStatus: string
@@ -65,6 +67,7 @@ type GigsSectionProps = {
   onDeleteExpenseAttachment: (expense: GigExpenseForm, attachmentId: string) => void
   onResetForm: () => void
   onQuickFilterChange: (filter: GigQuickFilter) => void
+  onGigTypeFilterChange: (filter: GigType | 'all') => void
   onSearchQueryChange: (value: string) => void
   onSelectGig: (gigId: string) => void
   onSortChange: (sort: GigSort) => void
@@ -107,6 +110,7 @@ export function GigsSection({
   isEditorOpen,
   gigMode,
   gigQuickFilter,
+  gigTypeFilter,
   gigSearchQuery,
   gigSort,
   gigStatus,
@@ -134,6 +138,7 @@ export function GigsSection({
   onDeleteExpenseAttachment,
   onResetForm,
   onQuickFilterChange,
+  onGigTypeFilterChange,
   onSearchQueryChange,
   onSelectGig,
   onSortChange,
@@ -224,10 +229,22 @@ export function GigsSection({
                 <input
                   data-testid="gig-search-input"
                   type="search"
-                  placeholder="Client, title, venue..."
+                  placeholder="Client, title, location, type..."
                   value={gigSearchQuery}
                   onChange={(event) => onSearchQueryChange(event.target.value)}
                 />
+              </label>
+              <label>
+                <span>Type</span>
+                <select value={gigTypeFilter} onChange={(event) => onGigTypeFilterChange(event.target.value as GigType | 'all')}>
+                  <option value="all">All types</option>
+                  <option value="Performance">Performance</option>
+                  <option value="Teaching">Teaching</option>
+                  <option value="Rehearsal">Rehearsal</option>
+                  <option value="Recording">Recording</option>
+                  <option value="Admin">Admin</option>
+                  <option value="Other">Other work</option>
+                </select>
               </label>
               <label>
                 <span>Sort by</span>
@@ -283,7 +300,7 @@ export function GigsSection({
               <span>Gig</span>
               <span>Client</span>
               <span>Date</span>
-              <span>Venue</span>
+              <span>Location</span>
               <span>Fee</span>
               <span>Status</span>
             </div>
@@ -323,7 +340,7 @@ export function GigsSection({
                   </label>
                   <div className="compact-primary-cell">
                     <strong>{gig.title}</strong>
-                    <span>{clientName}</span>
+                    <span>{formatGigType(gig.type)} · {clientName}</span>
                   </div>
                   <span>{clientName}</span>
                   <span>{formatDate(gig.date)}</span>
@@ -446,17 +463,23 @@ export function GigsSection({
                   </button>
                 </article>
                 <article>
-                  <p className="detail-label">Status</p>
-                  <strong data-testid="selected-gig-status">{formatGigStatus(selectedGig.status)}</strong>
+                  <p className="detail-label">Type</p>
+                  <strong>{formatGigType(selectedGig.type)}</strong>
                 </article>
-                <article>
-                  <p className="detail-label">Date</p>
-                  <strong>{formatDate(selectedGig.date)}</strong>
-                </article>
-                <article>
-                  <p className="detail-label">Fee</p>
-                  <strong>{formatCurrency(selectedGig.fee)}</strong>
-                </article>
+                <div className="gig-detail-metrics full-width">
+                  <article>
+                    <p className="detail-label">Date</p>
+                    <strong>{formatDate(selectedGig.date)}</strong>
+                  </article>
+                  <article>
+                    <p className="detail-label">Fee</p>
+                    <strong>{formatCurrency(selectedGig.fee)}</strong>
+                  </article>
+                  <article>
+                    <p className="detail-label">Status</p>
+                    <strong data-testid="selected-gig-status">{formatGigStatus(selectedGig.status)}</strong>
+                  </article>
+                </div>
                 <article className="full-width">
                   <p className="detail-label">Location</p>
                   <strong>{selectedGig.venue}</strong>

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -20,6 +20,7 @@ import type {
 type InvoicesSectionProps = {
   adjustmentAmount: string
   adjustmentReason: string
+  invoiceDescription: string
   clientNamesById: ReadonlyMap<string, string>
   draftInvoiceCount: number
   filteredInvoices: Invoice[]
@@ -41,6 +42,8 @@ type InvoicesSectionProps = {
   onDeleteAdjustment: (invoice: Invoice, line: InvoiceLine) => Promise<void>
   onDeleteInvoice: (invoice: Invoice) => Promise<void>
   onDownloadPdf: (invoice: Invoice) => Promise<void>
+  onInvoiceDescriptionChange: (value: string) => void
+  onInvoiceDescriptionSave: (invoice: Invoice) => Promise<void>
   onInvoiceStatusChange: (invoice: Invoice, status: InvoiceStatus) => Promise<Invoice | null>
   onOpenClient: (clientId: string) => void
   onOpenGig: (gigId: string) => void
@@ -61,6 +64,7 @@ type InvoicesSectionProps = {
 export function InvoicesSection({
   adjustmentAmount,
   adjustmentReason,
+  invoiceDescription,
   clientNamesById,
   draftInvoiceCount,
   filteredInvoices,
@@ -82,6 +86,8 @@ export function InvoicesSection({
   onDeleteAdjustment,
   onDeleteInvoice,
   onDownloadPdf,
+  onInvoiceDescriptionChange,
+  onInvoiceDescriptionSave,
   onInvoiceStatusChange,
   onOpenClient,
   onOpenGig,
@@ -500,6 +506,39 @@ export function InvoicesSection({
 
             {selectedInvoice ? (
               <div className="invoice-line-editor-content">
+                <div className="gig-timeline-note">
+                  <p className="detail-label">Description</p>
+                  {selectedInvoice.status === 'Draft' ? (
+                    <form
+                      className="invoice-adjustment-form invoice-description-form"
+                      onSubmit={(event) => {
+                        event.preventDefault()
+                        void onInvoiceDescriptionSave(selectedInvoice)
+                      }}
+                      >
+                      <label>
+                        <input
+                          aria-label="Description"
+                          data-testid="invoice-description-input"
+                          value={invoiceDescription}
+                          onChange={(event) => onInvoiceDescriptionChange(event.target.value)}
+                          disabled={isInvoiceLoading}
+                        />
+                      </label>
+                      <button
+                        className="ghost-button"
+                        data-testid="invoice-description-save-button"
+                        type="submit"
+                        disabled={isInvoiceLoading}
+                      >
+                        Save description
+                      </button>
+                    </form>
+                  ) : (
+                    <span>{selectedInvoice.description?.trim() || 'No description set.'}</span>
+                  )}
+                </div>
+
                 <div className="gig-timeline-note">
                   <p className="detail-label">Adjustments</p>
                   <span>

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -551,18 +551,7 @@ export function InvoicesSection({
                       return (
                         <div className="invoice-line-item" data-testid="invoice-line-item" key={line.id}>
                           <div className="invoice-line-content">
-                            {gigId ? (
-                              <button
-                                className="link-button invoice-line-link"
-                                data-testid="invoice-line-link"
-                                onClick={() => onOpenGig(gigId)}
-                                type="button"
-                              >
-                                <span data-testid="invoice-line-description">{line.description}</span>
-                              </button>
-                            ) : (
-                              <strong data-testid="invoice-line-description">{line.description}</strong>
-                            )}
+                            <strong data-testid="invoice-line-description">{line.description}</strong>
                             <span>
                               <span data-testid="invoice-line-type">{line.type}</span> · {line.quantity} x {formatCurrency(line.unitPrice)}
                             </span>
@@ -572,6 +561,16 @@ export function InvoicesSection({
                           </div>
                           <div className="invoice-line-end">
                             <strong>{formatCurrency(line.lineTotal)}</strong>
+                            {gigId ? (
+                              <button
+                                className="link-button invoice-line-link"
+                                data-testid="invoice-line-link"
+                                onClick={() => onOpenGig(gigId)}
+                                type="button"
+                              >
+                                View gig
+                              </button>
+                            ) : null}
                             {line.type === 'ManualAdjustment' ? (
                               <button
                                 aria-label={`Remove adjustment ${line.description}`}

--- a/frontend/glovelly-web/src/components/QuickAttachmentModal.tsx
+++ b/frontend/glovelly-web/src/components/QuickAttachmentModal.tsx
@@ -103,6 +103,7 @@ export function QuickAttachmentModal({
         title: draft.gig.title,
         date: draft.gig.date,
         venue: draft.gig.venue,
+        type: draft.gig.type,
         status: draft.gig.status,
         daysFromToday: getDaysFromToday(draft.gig.date),
         isSelected: true,

--- a/frontend/glovelly-web/src/components/QuickCaptureGigSelect.tsx
+++ b/frontend/glovelly-web/src/components/QuickCaptureGigSelect.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { formatDate } from '../formatters'
+import { formatDate, formatGigType } from '../formatters'
 import type { QuickGigCandidate } from '../types'
 
 type QuickCaptureGigSelectProps = {
@@ -53,7 +53,7 @@ export function QuickCaptureGigSelect({
       >
         {candidates.map((gig) => (
           <option key={gig.id} value={gig.id}>
-            {gig.title} · {formatDate(gig.date)} · {gig.venue} ·{' '}
+            {gig.title} · {formatGigType(gig.type)} · {formatDate(gig.date)} · {gig.venue} ·{' '}
             {clientNamesById.get(gig.clientId) ?? 'Unknown client'} ·{' '}
             {gig.daysFromToday === 0
               ? 'today'

--- a/frontend/glovelly-web/src/formatters.ts
+++ b/frontend/glovelly-web/src/formatters.ts
@@ -2,6 +2,7 @@ import type {
   GigExpense,
   GigExpenseForm,
   GigStatus,
+  GigType,
   InvoiceStatus,
 } from './types'
 
@@ -89,6 +90,10 @@ export function toGigExpenseForm(expense: GigExpense): GigExpenseForm {
 
 export function formatGigStatus(status: GigStatus) {
   return status === 'Confirmed' ? 'Planned' : status
+}
+
+export function formatGigType(type: GigType) {
+  return type === 'Other' ? 'Other work' : type
 }
 
 export function getAllowedInvoiceStatusTransitions(status: InvoiceStatus) {

--- a/frontend/glovelly-web/src/forms.ts
+++ b/frontend/glovelly-web/src/forms.ts
@@ -75,6 +75,7 @@ export const emptyGigForm = (): GigForm => ({
   passengerCount: '',
   notes: '',
   wasDriving: true,
+  type: 'Performance',
   status: 'Confirmed',
   expenses: [],
 })

--- a/frontend/glovelly-web/src/hooks/gigWorkspaceHelpers.ts
+++ b/frontend/glovelly-web/src/hooks/gigWorkspaceHelpers.ts
@@ -43,6 +43,7 @@ export function toEditableGigForm(gig: Gig): GigForm {
     passengerCount: formatEditableNumber(gig.passengerCount),
     notes: gig.notes ?? '',
     wasDriving: gig.wasDriving,
+    type: gig.type,
     status: gig.status,
     expenses: toEditableGigExpenses(gig),
   }
@@ -87,6 +88,7 @@ export function hasInvoiceRelevantGigChanges(
     fee: string
     notes: string
     wasDriving: boolean
+    type: Gig['type']
     travelMiles: string
     passengerCount: string
     status: Gig['status']
@@ -105,7 +107,8 @@ export function hasInvoiceRelevantGigChanges(
     (gig.passengerCount ?? 0) !==
       (payload.passengerCount ? Number(payload.passengerCount) : 0) ||
     (gig.notes ?? '') !== (payload.notes || '') ||
-    gig.wasDriving !== payload.wasDriving
+    gig.wasDriving !== payload.wasDriving ||
+    gig.type !== payload.type
   ) {
     return true
   }

--- a/frontend/glovelly-web/src/hooks/useGigImportsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigImportsWorkspace.ts
@@ -36,6 +36,7 @@ export type GigImportDraftField =
   | 'accommodationNotes'
   | 'travelNotes'
   | 'sourceReference'
+  | 'gigType'
   | 'confidence'
   | 'status'
 
@@ -66,6 +67,7 @@ function toDraftPayload(draft: GigImportDraft) {
     accommodationNotes: draft.accommodationNotes || null,
     travelNotes: draft.travelNotes || null,
     sourceReference: draft.sourceReference || null,
+    gigType: draft.gigType,
     confidence: draft.confidence,
     warnings: draft.warnings,
     status: draft.status,

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -31,6 +31,7 @@ import type {
   GigForm,
   GigQuickFilter,
   GigSort,
+  GigType,
   Invoice,
 } from '../types'
 import { useExpenseStatementWorkspace } from './useExpenseStatementWorkspace'
@@ -66,6 +67,7 @@ export function useGigsWorkspace({
   const [selectedGigIds, setSelectedGigIds] = useState<string[]>([])
   const [gigSearchQuery, setGigSearchQuery] = useState('')
   const [gigQuickFilter, setGigQuickFilter] = useState<GigQuickFilter>('all')
+  const [gigTypeFilter, setGigTypeFilter] = useState<GigType | 'all'>('all')
   const [gigSort, setGigSort] = useState<GigSort>({ key: 'priority', direction: 'asc' })
   const [isGigEditorOpen, setIsGigEditorOpen] = useState(false)
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
@@ -164,6 +166,9 @@ export function useGigsWorkspace({
       return left.id.localeCompare(right.id)
     })
     const quickFilteredGigs = sortedGigs.filter((gig) => {
+      if (gigTypeFilter !== 'all' && gig.type !== gigTypeFilter) {
+        return false
+      }
       switch (gigQuickFilter) {
         case 'completed':
           return gig.status === 'Completed'
@@ -186,12 +191,12 @@ export function useGigsWorkspace({
     return quickFilteredGigs.filter((gig) => {
       const clientName = clientNamesById.get(gig.clientId) ?? ''
 
-      return [gig.title, gig.venue, gig.date, gig.status, clientName]
+      return [gig.title, gig.venue, gig.date, gig.status, gig.type, clientName]
         .join(' ')
         .toLowerCase()
         .includes(query)
     })
-  }, [clientNamesById, deferredGigSearchQuery, gigQuickFilter, gigSort, gigs])
+  }, [clientNamesById, deferredGigSearchQuery, gigQuickFilter, gigSort, gigTypeFilter, gigs])
 
   const selectedGig = gigsById.get(selectedGigId) ?? filteredGigs[0] ?? null
 
@@ -686,6 +691,7 @@ export function useGigsWorkspace({
           passengerCount: selectedGig.passengerCount,
           notes: selectedGig.notes,
           wasDriving: selectedGig.wasDriving,
+          type: selectedGig.type,
           status: selectedGig.status,
           invoiceId: null,
           expenses: includeExpenses
@@ -1227,6 +1233,7 @@ export function useGigsWorkspace({
       wasDriving: gigForm.wasDriving,
       travelMiles: gigForm.travelMiles.trim(),
       passengerCount: gigForm.passengerCount.trim(),
+      type: gigForm.type,
       status: gigForm.status,
       expenses: expensesOverride ?? gigForm.expenses,
     }
@@ -1301,6 +1308,7 @@ export function useGigsWorkspace({
           fee,
           travelMiles,
           passengerCount: passengerCount === 0 ? null : passengerCount,
+          type: payload.type,
           notes: payload.notes || null,
           wasDriving: payload.wasDriving,
           status: payload.status,
@@ -1500,6 +1508,7 @@ export function useGigsWorkspace({
     gigForm,
     gigMode,
     gigQuickFilter,
+    gigTypeFilter,
     gigSearchQuery,
     gigSort,
     gigStatus,
@@ -1526,6 +1535,7 @@ export function useGigsWorkspace({
     selectGig,
     setGigs,
     setGigQuickFilter,
+    setGigTypeFilter,
     setGigSearchQuery,
     setGigSort,
     setGigStatus,

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -742,12 +742,12 @@ export function useGigsWorkspace({
 
   const selectGig = (gigId: string) => {
     if (gigId === selectedGig?.id) {
-      return
+      return true
     }
 
     const nextGig = gigsById.get(gigId)
     if (!nextGig) {
-      return
+      return false
     }
 
     if (isGigEditorOpen) {
@@ -755,7 +755,7 @@ export function useGigsWorkspace({
         hasUnsavedGigEditorChanges() &&
         !window.confirm('Discard unsaved gig changes and edit the selected gig?')
       ) {
-        return
+        return false
       }
 
       setGigMode('edit')
@@ -766,6 +766,7 @@ export function useGigsWorkspace({
     cancelExternalResourceEdit()
 
     setSelectedGigId(gigId)
+    return true
   }
 
   const closeGigEditor = () => {

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useMemo, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
 import {
   buildApiUrl,
   downloadResponseBlob,
@@ -48,6 +48,7 @@ export function useInvoicesWorkspace({
   const [isInvoiceLoading, setIsInvoiceLoading] = useState(false)
   const [adjustmentAmount, setAdjustmentAmount] = useState('')
   const [adjustmentReason, setAdjustmentReason] = useState('')
+  const [invoiceDescription, setInvoiceDescription] = useState('')
   const deferredInvoiceSearchQuery = useDeferredValue(invoiceSearchQuery)
 
   const invoicesById = useMemo(
@@ -166,6 +167,10 @@ export function useInvoicesWorkspace({
     ? invoicesById.get(selectedInvoiceId) ?? null
     : filteredInvoices[0] ?? null
 
+  useEffect(() => {
+    setInvoiceDescription(selectedInvoice?.description ?? '')
+  }, [selectedInvoice?.description, selectedInvoice?.id])
+
   const applyInvoices = useCallback((nextInvoices: Invoice[]) => {
     setInvoices(nextInvoices)
     setSelectedInvoiceId(nextInvoices[0]?.id ?? '')
@@ -183,6 +188,7 @@ export function useInvoicesWorkspace({
     setIsInvoiceLoading(false)
     setAdjustmentAmount('')
     setAdjustmentReason('')
+    setInvoiceDescription('')
   }, [])
 
   const startInvoiceEdit = () => {
@@ -195,8 +201,10 @@ export function useInvoicesWorkspace({
 
   const closeInvoiceEditor = () => {
     if (
-      (adjustmentAmount.trim().length > 0 || adjustmentReason.trim().length > 0) &&
-      !window.confirm('Discard unsaved invoice adjustment and close line items?')
+      (adjustmentAmount.trim().length > 0 ||
+        adjustmentReason.trim().length > 0 ||
+        invoiceDescription !== (selectedInvoice?.description ?? '')) &&
+      !window.confirm('Discard unsaved invoice changes and close line items?')
     ) {
       return
     }
@@ -204,6 +212,7 @@ export function useInvoicesWorkspace({
     setIsInvoiceEditorOpen(false)
     setAdjustmentAmount('')
     setAdjustmentReason('')
+    setInvoiceDescription(selectedInvoice?.description ?? '')
   }
 
   const handleDownloadInvoicePdf = async (invoice: Invoice) => {
@@ -485,6 +494,40 @@ export function useInvoicesWorkspace({
     }
   }
 
+  const handleInvoiceDescriptionSave = async (invoice: Invoice) => {
+    setIsInvoiceLoading(true)
+    setInvoiceStatus(`Saving description for ${invoice.invoiceNumber}...`)
+
+    try {
+      const response = await fetchWithSession(
+        buildApiUrl(`/invoices/${invoice.id}/description`),
+        jsonRequestInit('PUT', { description: invoiceDescription })
+      )
+
+      if (!response.ok) {
+        const problem = await parseProblemDetails(response)
+        const descriptionError = problem?.errors?.description?.[0]
+        const statusError = problem?.errors?.status?.[0]
+        throw new Error(
+          descriptionError ??
+            statusError ??
+            getProblemDetailsMessage(problem, 'Unable to save invoice description.')
+        )
+      }
+
+      const updatedInvoice = (await response.json()) as Invoice
+      setInvoices((current) =>
+        current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
+      )
+      setInvoiceDescription(updatedInvoice.description ?? '')
+      setInvoiceStatus(`Description saved for ${updatedInvoice.invoiceNumber}. Redraft the invoice to update its PDF.`)
+    } catch (error) {
+      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to save invoice description.')
+    } finally {
+      setIsInvoiceLoading(false)
+    }
+  }
+
   const handleDeleteInvoiceAdjustment = async (invoice: Invoice, line: InvoiceLine) => {
     if (line.type !== 'ManualAdjustment') {
       setInvoiceStatus('Only manual adjustments can be removed from here.')
@@ -571,6 +614,7 @@ export function useInvoicesWorkspace({
   return {
     adjustmentAmount,
     adjustmentReason,
+    invoiceDescription,
     applyInvoices,
     closeInvoiceEditor,
     draftInvoiceCount: invoices.filter((invoice) => invoice.status === 'Draft').length,
@@ -581,6 +625,7 @@ export function useInvoicesWorkspace({
     handleDeleteInvoice,
     handleDownloadInvoicePdf,
     handleInvoiceReissue,
+    handleInvoiceDescriptionSave,
     handleInvoiceStatusChange,
     handlePublishInvoiceGoogleDrive,
     handleSendInvoiceEmail,
@@ -597,6 +642,7 @@ export function useInvoicesWorkspace({
     selectedInvoice,
     setAdjustmentAmount,
     setAdjustmentReason,
+    setInvoiceDescription,
     setInvoices,
     setInvoiceStatus,
     setIsInvoiceLoading,

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -204,6 +204,7 @@ export type SellerProfileForm = {
 }
 
 export type GigStatus = 'Draft' | 'Confirmed' | 'Completed' | 'Cancelled'
+export type GigType = 'Performance' | 'Teaching' | 'Rehearsal' | 'Recording' | 'Admin' | 'Other'
 export type GigExternalResourceType =
   | 'GoogleSheet'
   | 'GoogleDoc'
@@ -438,6 +439,7 @@ export type Gig = {
   passengerCount: number | null
   notes: string | null
   wasDriving: boolean
+  type: GigType
   status: GigStatus
   invoicedAt: string | null
   isInvoiced: boolean
@@ -497,6 +499,7 @@ export type GigImportDraft = {
   accommodationNotes: string | null
   travelNotes: string | null
   sourceReference: string | null
+  gigType: GigType
   confidence: GigImportDraftConfidence
   warnings: string[]
   status: GigImportDraftStatus
@@ -516,7 +519,7 @@ export type GigImportCommitResult = {
 
 export type QuickGigCandidate = Pick<
   Gig,
-  'id' | 'clientId' | 'title' | 'date' | 'venue' | 'status'
+  'id' | 'clientId' | 'title' | 'date' | 'venue' | 'type' | 'status'
 > & {
   daysFromToday: number
   isSelected: boolean
@@ -626,6 +629,7 @@ export type GigForm = {
   passengerCount: string
   notes: string
   wasDriving: boolean
+  type: GigType
   status: GigStatus
   expenses: GigExpenseForm[]
 }

--- a/openspec/changes/archive/2026-07-19-support-typed-gigs/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-support-typed-gigs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/archive/2026-07-19-support-typed-gigs/design.md
+++ b/openspec/changes/archive/2026-07-19-support-typed-gigs/design.md
@@ -1,0 +1,115 @@
+## Context
+
+Glovelly currently uses `Gig` as the core entity for a discrete musician work item, but the stored model and user-facing workflows still assume live-performance language in several places. The existing `Gig` entity already carries the shared data needed by performances, teaching, rehearsals, recording sessions, admin work, and other work: client, title, date, venue/location, fee, status, invoice linkage, expenses, mileage, notes, and external resources.
+
+The repository now has EF Core migration bundle infrastructure and an `InitialBaseline` migration registered for existing PostgreSQL databases. This change should therefore be implemented as the first ordinary post-baseline EF migration, not through startup schema mutation or manual SQL. Existing set-list workflows are allowed to remain available to all gig types because "set list" can reasonably apply to rehearsals and recording contexts as well as performances.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep `Gig` as the single domain entity and user-facing umbrella term.
+- Add required type classification for gigs and import drafts with an explicit initial enum.
+- Preserve existing performance behavior by backfilling/defaulting existing and inferred gigs to `Performance`.
+- Make type visible and editable in the web UI, import review UI, REST API, and MCP contracts.
+- Let users filter gigs by type in the web UI and MCP listing tools.
+- Generate type-aware invoice fee descriptions.
+- Use the established EF migrations project and migration bundle pipeline for schema changes.
+
+**Non-Goals:**
+
+- Rename `Gig` to `WorkItem`, `Engagement`, `Activity`, or another abstraction.
+- Introduce inheritance, separate gig tables, or type-specific workflow subclasses.
+- Add recurring gigs, teaching/student records, lesson plans, attendance, type-specific fields, custom gig types, or configurable metadata schemas.
+- Restrict set-list resources/imports to performance gigs.
+- Change Google Calendar event title/description behavior for this slice.
+- Rename the persisted `Venue` property or overhaul API field names solely for wording cleanup.
+
+## Decisions
+
+### Add string-backed `GigType` enum values to `Gig` and import drafts
+
+Add a backend enum with `Performance`, `Teaching`, `Rehearsal`, `Recording`, `Admin`, and `Other`. Store it with EF string conversion and a bounded length on both `Gig` and `GigImportDraft` (`ProposedGigType` or equivalent). Existing records and nullable/legacy creation paths default to `Performance`.
+
+Rationale: string-backed enum columns match existing status storage, are readable in PostgreSQL, and avoid adding a parallel entity hierarchy.
+
+Alternative considered: separate `PerformanceGig`/`TeachingGig` subclasses or a generic `WorkItem` rename. This is larger than the product need and would force invoice, expense, import, and MCP refactors without proven type-specific data requirements.
+
+### Use a normal post-baseline EF migration
+
+Generate a migration in `backend/Glovelly.Migrations` that adds the required columns, backfills existing rows to `Performance`, and updates the model snapshot. The web app must not apply this migration during startup.
+
+Rationale: issues #197 and #198 established EF migrations as the schema history and deployment path; #196 is explicitly the first ordinary post-baseline schema change.
+
+Alternative considered: manual SQL or startup backfill. That would bypass the new migration ledger and reintroduce the drift risk the migration work removed.
+
+### Keep `Venue` as storage/API field, present it as location in generic UI
+
+Continue using `Venue`/`venue` in persisted models and current API contracts, but update generic labels, placeholders, empty states, and search wording to prefer `Location` where not performance-specific.
+
+Rationale: this solves the user-facing language problem without combining a type feature with a broad persisted-property rename.
+
+Alternative considered: rename `Venue` to `Location` throughout the model/API. That would create unnecessary migration and compatibility churn for a copy-level concern.
+
+### Add editable gig type to import drafts from the outset
+
+Import drafts should carry the proposed type through REST DTOs, frontend review forms, MCP draft-add contracts, and commit mapping. If an importer or MCP client omits type, default the draft to `Performance`.
+
+Rationale: import review is where users correct source interpretation before creating real gigs; forcing type correction after commit would make typed imports immediately incomplete.
+
+Alternative considered: default all imports to `Performance` and edit after commit. That is smaller but likely creates a follow-up task immediately and weakens the import review workflow.
+
+### Generate type-aware fee descriptions
+
+Invoice line generation derives the fee description from gig type, title, and date.
+
+Default generated descriptions:
+
+- `Performance fee for {Title} ({Date})`
+- `Teaching fee for {Title} ({Date})`
+- `Rehearsal fee for {Title} ({Date})`
+- `Recording fee for {Title} ({Date})`
+- `Admin fee for {Title} ({Date})`
+- `Fee for {Title} ({Date})` for `Other`
+
+Rationale: type-aware descriptions cover the immediate terminology need without introducing partial invoice-line editing. Invoice-native editing is deferred to a separate roadmap item so its regeneration semantics can be designed coherently.
+
+### Do not restrict set-list workflows by gig type
+
+Leave `GigExternalResourcePurpose.SetList`, set-list import endpoints, set-list chart matching, and set-list export available for every type.
+
+Rationale: rehearsals and recording sessions can have set lists in ordinary musician workflows, and the user explicitly prefers keeping the behavior available.
+
+Alternative considered: show/allow set-list only for `Performance`. This is simpler conceptually but incorrectly narrows the workflow.
+
+### Extend MCP read and staged-import contracts
+
+Expose type in MCP gig summary/detail responses, add optional type filtering to gig listing and uninvoiced gig listing, and allow staged gig import drafts created through MCP to include type. Preserve the existing MCP visibility model and staged-write safety posture.
+
+Rationale: MCP consumers need the same type information as the UI, and import tools should not require an immediate follow-up to correct type.
+
+Alternative considered: limit this change to REST/web and defer MCP. That would make typed gigs incomplete for existing agent-assisted workflows.
+
+### Leave calendar output unchanged
+
+Do not add type to Google Calendar event titles or descriptions in this slice.
+
+Rationale: gig names are expected to be descriptive enough, and calendar changes are not needed to solve the issue.
+
+Alternative considered: add `Type: ...` to calendar descriptions. This adds visible calendar churn without a clear user benefit.
+
+## Risks / Trade-offs
+
+- Existing API clients may omit gig type on direct create/update requests → default only known legacy/inferred paths where practical, validate normal user-facing requests, and cover behavior with tests.
+- Type and status may be confused in UI copy → label type as nature of work and status as lifecycle, and keep `Confirmed` displayed as planned where already established.
+- Generated invoice line descriptions could change existing performance expectations → preserve the performance default wording and add regression tests for invoice generation.
+- Import/MCP contract changes touch several layers → update schemas, snapshots/docs, DTOs, and integration tests together.
+- Adding non-null columns to live databases can fail without defaults/backfill → implement the EF migration with safe defaults/backfill and validate through the migration chain CI.
+
+## Migration Plan
+
+1. Add enum/model/configuration changes and generate a normal EF migration in `backend/Glovelly.Migrations` after `InitialBaseline`.
+2. Migration adds gig type columns to gigs and import drafts, backfills gig and draft type values to `Performance`, and enforces non-null where required.
+3. CI validates pending model changes, applies the migration chain to a fresh PostgreSQL database, and verifies no-op reruns through the existing migration checks.
+4. Deployment runs the packaged migration bundle against staging before service deployment, then against production after staging UAT and production approval.
+5. Rollback follows the established database posture: restore from backup or deploy a forward-fix migration rather than running automatic `Down()` migrations.

--- a/openspec/changes/archive/2026-07-19-support-typed-gigs/proposal.md
+++ b/openspec/changes/archive/2026-07-19-support-typed-gigs/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Early musician feedback shows that Glovelly currently presents every gig as though it were a live performance, which makes teaching, rehearsal, recording, preparation, and admin work feel awkward or disguised. The existing `Gig` model already supports the shared workflow shape, so this change adds explicit gig typing without renaming or refactoring the core domain entity.
+
+## What Changes
+
+- Add a required gig type to the existing `Gig` entity with initial values `Performance`, `Teaching`, `Rehearsal`, `Recording`, `Admin`, and `Other`.
+- Add a post-baseline EF Core migration that stores gig type for gigs and import drafts, backfilling existing gigs and staged drafts to `Performance`.
+- Let users choose and edit gig type in normal gig forms and gig import draft review before commit.
+- Default calendar/import/quick-capture/MCP-created draft paths to `Performance` when no explicit type is available.
+- Show gig type in gig lists, detail panels, import drafts, and MCP gig/draft responses.
+- Add gig type filtering to the main gigs UI and MCP gig listing tools.
+- Keep all gig types on the same fee, invoice, expense, mileage, notes, external-resource, tax-summary, and receipt flows.
+- Generate type-aware invoice fee line descriptions.
+- Keep set-list resource and import functionality available for all gig types; do not restrict set-list workflows to performances.
+- Review generic gig-related UI copy so it no longer implies that all gigs are performances, while preserving performance-specific language where the feature is genuinely performance-oriented.
+
+## Capabilities
+
+### New Capabilities
+
+- `typed-gigs`: Required gig type classification, type-aware gig UI/API behavior, import draft typing, and type-aware invoice fee descriptions.
+
+### Modified Capabilities
+
+- `mcp-read-tools`: MCP gig listing/detail responses and filters include gig type while preserving existing visibility boundaries.
+
+## Impact
+
+- Backend domain/model: `Gig`, `GigImportDraft`, validation, EF configuration, seed data, and a normal post-`InitialBaseline` EF migration under `backend/Glovelly.Migrations`.
+- Backend workflows: gig CRUD, gig import commit/review, quick capture candidates, invoice line generation, tax/expense/invoice regression coverage, and MCP query/tool contracts.
+- Frontend: gig and import draft types/forms, gig editor, import review UI, gig list/detail presentation, search/filter behavior, copy updates, and TypeScript API shapes.
+- API compatibility: existing records are backfilled to `Performance`; existing creation paths that omit a type continue where practical by defaulting only on known legacy/import/quick-capture/MCP paths, while normal user-facing gig creation requires a type.
+- No change to calendar event title/description behavior and no set-list restriction by gig type.

--- a/openspec/changes/archive/2026-07-19-support-typed-gigs/specs/mcp-read-tools/spec.md
+++ b/openspec/changes/archive/2026-07-19-support-typed-gigs/specs/mcp-read-tools/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+### Requirement: MCP shall expose read-only gig listing
+The system SHALL provide an authenticated read-only MCP tool named `glovelly_list_gigs` that lists gigs visible to the MCP user and supports filtering by contact, status, date range, invoicing state, and gig type.
+
+#### Scenario: List visible gigs by date range
+- **WHEN** an authenticated MCP user calls `glovelly_list_gigs` with `fromDate` and `toDate`
+- **THEN** the response includes only visible gigs whose dates fall within the inclusive range, ordered predictably, with gig ID, title, date, venue, contact summary, status, type, fee, invoice state, and currency
+
+#### Scenario: Filter visible gigs by type
+- **WHEN** an authenticated MCP user calls `glovelly_list_gigs` with a supported gig type filter
+- **THEN** the response includes only visible gigs whose type matches the requested type
+
+#### Scenario: Ambiguous contact query does not guess
+- **WHEN** an authenticated MCP user calls `glovelly_list_gigs` with a `contactQuery` that matches multiple visible contacts
+- **THEN** the response is marked ambiguous, includes the matching contacts, and does not return guessed gig results
+
+#### Scenario: Unmatched contact query returns no gigs
+- **WHEN** an authenticated MCP user calls `glovelly_list_gigs` with a `contactQuery` that matches no visible contacts
+- **THEN** the response is not ambiguous and contains an empty gig list
+
+### Requirement: MCP shall expose read-only gig detail
+The system SHALL provide an authenticated read-only MCP tool named `glovelly_get_gig` that fetches details for one visible gig without modifying the gig or related records.
+
+#### Scenario: Fetch visible gig detail
+- **WHEN** an authenticated MCP user calls `glovelly_get_gig` with the ID of a visible gig
+- **THEN** the response has `found` set to true and includes gig details, type, contact summary, invoice summary when linked, expense summaries, resource summaries, and currency
+
+#### Scenario: Hidden or missing gig is not returned
+- **WHEN** an authenticated MCP user calls `glovelly_get_gig` with a missing gig ID or a gig ID outside their visible scope
+- **THEN** the response has `found` set to false and does not include gig details
+
+### Requirement: MCP shall expose read-only uninvoiced gig listing
+The system SHALL provide an authenticated read-only MCP tool named `glovelly_list_uninvoiced_gigs` that lists visible gigs that are not linked to an invoice and supports the same gig type filter as `glovelly_list_gigs`.
+
+#### Scenario: List uninvoiced gigs
+- **WHEN** an authenticated MCP user calls `glovelly_list_uninvoiced_gigs`
+- **THEN** the response includes only visible gigs without an invoice link and includes gig type, total uninvoiced fees, and currency
+
+#### Scenario: Filter uninvoiced gigs by contact and date
+- **WHEN** an authenticated MCP user calls `glovelly_list_uninvoiced_gigs` with contact and date filters
+- **THEN** the response applies the filters before returning gig summaries and totals
+
+#### Scenario: Filter uninvoiced gigs by type
+- **WHEN** an authenticated MCP user calls `glovelly_list_uninvoiced_gigs` with a supported gig type filter
+- **THEN** the response includes only visible uninvoiced gigs whose type matches the requested type
+
+## ADDED Requirements
+
+### Requirement: MCP staged gig import drafts shall include gig type
+The system SHALL allow MCP staged gig import draft tools to accept, store, and return a proposed gig type while preserving staged-write behavior.
+
+#### Scenario: Add typed gig import draft through MCP
+- **WHEN** an authenticated MCP user calls `glovelly_add_gig_import_draft` with a supported gig type
+- **THEN** the created draft stores and returns that type without creating a real gig
+
+#### Scenario: Add bulk typed gig import drafts through MCP
+- **WHEN** an authenticated MCP user calls `glovelly_add_gig_import_drafts` with draft rows that include supported gig types
+- **THEN** each created draft stores and returns its requested type in the per-row result
+
+#### Scenario: MCP draft type defaults
+- **WHEN** an MCP staged gig import draft request omits gig type
+- **THEN** the created draft stores and returns `Performance` as the proposed gig type
+
+#### Scenario: MCP draft rejects invalid type
+- **WHEN** an MCP staged gig import draft request supplies an unsupported gig type
+- **THEN** the draft is not created and the result includes validation feedback for the type field

--- a/openspec/changes/archive/2026-07-19-support-typed-gigs/specs/typed-gigs/spec.md
+++ b/openspec/changes/archive/2026-07-19-support-typed-gigs/specs/typed-gigs/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+### Requirement: Gigs have a required type
+The system SHALL assign every gig one of the supported gig types: `Performance`, `Teaching`, `Rehearsal`, `Recording`, `Admin`, or `Other`.
+
+#### Scenario: Existing gigs are backfilled
+- **WHEN** the post-baseline database migration is applied to a database with existing gigs
+- **THEN** every existing gig has type `Performance`
+
+#### Scenario: New gig type is validated
+- **WHEN** a user-facing gig create or update request supplies an unsupported type
+- **THEN** the system rejects the request with validation feedback for the type field
+
+#### Scenario: Type remains separate from lifecycle status
+- **WHEN** a gig is created or edited
+- **THEN** the system stores the gig type independently from the gig status values `Draft`, `Confirmed`, `Completed`, and `Cancelled`
+
+### Requirement: Users can create and edit typed gigs
+The system SHALL let users choose and edit gig type through the primary gig creation and editing workflow.
+
+#### Scenario: Create typed gig
+- **WHEN** a user creates a gig for teaching, rehearsal, recording, admin, performance, or other work
+- **THEN** the saved gig uses the selected type and remains available in the normal gig workspace
+
+#### Scenario: Edit gig type
+- **WHEN** a user edits an existing gig and changes its type
+- **THEN** the saved gig reflects the new type without changing its status, invoice link, expenses, mileage, notes, or external resources
+
+#### Scenario: Legacy inferred creation defaults type
+- **WHEN** a quick-capture, calendar/import, MCP draft, seed, or other inferred creation path cannot determine a type explicitly
+- **THEN** the system assigns `Performance` as the default type
+
+### Requirement: Gig presentation and filtering are type-aware
+The system SHALL display gig type in gig lists, gig details, and relevant selection surfaces, and SHALL let users filter gigs by type.
+
+#### Scenario: Gig list shows type
+- **WHEN** a user views the gig workspace list
+- **THEN** each gig row or card clearly shows its type alongside the existing gig summary information
+
+#### Scenario: Gig detail shows type
+- **WHEN** a user selects a gig in the gig workspace
+- **THEN** the detail panel clearly shows the gig type
+
+#### Scenario: User filters by type
+- **WHEN** a user applies a gig type filter
+- **THEN** the gig list includes only gigs matching the selected type while preserving existing search, status filter, and sort behavior
+
+#### Scenario: Search includes type
+- **WHEN** a user searches the gig list by a type label such as `teaching` or `recording`
+- **THEN** matching gigs of that type are included in the search results
+
+### Requirement: Generic gig language is neutral
+The system SHALL avoid generic UI wording that implies every gig is a performance while keeping `Gig` as the primary entity name.
+
+#### Scenario: Generic location labels are neutral
+- **WHEN** a user creates, edits, imports, or views a generic gig
+- **THEN** the UI uses neutral location wording rather than requiring the work to be a venue-based performance
+
+#### Scenario: Performance-specific language remains contextual
+- **WHEN** the UI describes a feature that genuinely applies to set lists, shows, or performance-specific material
+- **THEN** the UI may use performance-specific language in that context
+
+### Requirement: Import drafts carry editable gig type
+The system SHALL store, display, and commit an editable proposed gig type for each staged gig import draft.
+
+#### Scenario: Review imported draft type
+- **WHEN** a user reviews a staged gig import draft
+- **THEN** the draft shows an editable type field with one of the supported gig type values
+
+#### Scenario: Commit imported draft type
+- **WHEN** a user commits an accepted import draft
+- **THEN** the created gig has the draft's selected type
+
+#### Scenario: Imported draft defaults type
+- **WHEN** an import draft is created without an explicit type
+- **THEN** the draft type defaults to `Performance`
+
+#### Scenario: Invalid draft type is rejected
+- **WHEN** a user or MCP client updates or creates an import draft with an unsupported type
+- **THEN** the system rejects the draft change with validation feedback
+
+### Requirement: All gig types use shared financial workflows
+The system SHALL allow every gig type to use existing fee, invoice, expense, mileage, receipt, tax-summary, notes, and external-resource behavior.
+
+#### Scenario: Teaching gig is invoiced
+- **WHEN** a teaching gig has a fee and a user generates an invoice from it
+- **THEN** the system creates an invoice through the existing invoice workflow and links it to the teaching gig
+
+#### Scenario: Admin gig expenses are counted
+- **WHEN** an admin gig has expenses included in existing expense or tax-summary flows
+- **THEN** the system includes those expenses according to the same rules used for performance gigs
+
+#### Scenario: Non-chargeable gig remains supported
+- **WHEN** any gig type has a zero fee
+- **THEN** the gig can still be saved and can still carry expenses, mileage, notes, and resources
+
+### Requirement: Invoice fee descriptions are type-aware
+The system SHALL generate fee line descriptions from gig type, title, and date.
+
+#### Scenario: Generate performance fee description
+- **WHEN** a performance gig with a non-zero fee generates invoice lines
+- **THEN** the fee line description uses the existing performance wording pattern
+
+#### Scenario: Generate teaching fee description
+- **WHEN** a teaching gig with a non-zero fee generates invoice lines
+- **THEN** the fee line description describes a teaching fee for that gig
+
+### Requirement: Set-list workflows remain available across gig types
+The system SHALL keep set-list resources, set-list imports, chart matching, and set-list exports available regardless of gig type.
+
+#### Scenario: Rehearsal gig uses set-list resource
+- **WHEN** a rehearsal gig has a Google Sheet external resource with purpose `SetList`
+- **THEN** the user can manage the set-list import through the existing set-list workflow
+
+#### Scenario: Recording gig set-list is not rejected by type
+- **WHEN** a recording gig calls an existing set-list import endpoint with otherwise valid input
+- **THEN** the system does not reject the request solely because the gig type is not `Performance`
+
+### Requirement: Calendar output remains unchanged by type
+The system SHALL NOT add gig type to Google Calendar event titles or descriptions as part of typed gigs.
+
+#### Scenario: Calendar event maps existing fields
+- **WHEN** a typed gig is mapped to a Google Calendar event
+- **THEN** the event title and description follow the existing calendar mapping without adding a type label
+
+### Requirement: Typed gig schema changes use EF migrations
+The system SHALL introduce gig type persistence through a checked-in EF Core migration in the migrations project.
+
+#### Scenario: Migration is checked in
+- **WHEN** the gig type model changes are implemented
+- **THEN** the corresponding migration and model snapshot changes are stored under the EF migrations project
+
+#### Scenario: PostgreSQL deployment applies migration through bundle
+- **WHEN** the typed gig change is deployed to PostgreSQL environments
+- **THEN** the existing migration bundle and Cloud Run Job workflow applies the migration before the application service revision is deployed

--- a/openspec/changes/archive/2026-07-19-support-typed-gigs/tasks.md
+++ b/openspec/changes/archive/2026-07-19-support-typed-gigs/tasks.md
@@ -1,0 +1,45 @@
+## 1. Backend Domain And Migration
+
+- [x] 1.1 Add `GigType` enum and add required type fields to `Gig`.
+- [x] 1.2 Add proposed gig type to `GigImportDraft` and configure gig/import draft EF string conversions, lengths, and nullability.
+- [x] 1.3 Generate a post-`InitialBaseline` EF migration in `backend/Glovelly.Migrations` that backfills existing gigs and import drafts to `Performance` and updates the model snapshot.
+- [x] 1.4 Update development, UAT, and test seed data so created gigs and import drafts have explicit or defaulted types.
+
+## 2. Backend API Workflows
+
+- [x] 2.1 Update gig create/update validation, normalization, responses, and invoice-relevant change detection to include gig type.
+- [x] 2.2 Update gig import draft REST update/detail DTOs, validation, missing-field handling, and commit mapping so draft type is editable and committed to created gigs.
+- [x] 2.3 Update quick capture gig candidate responses and any other inferred gig creation paths to return or default gig type consistently.
+- [x] 2.4 Update invoice line generation to use type-aware fee descriptions.
+- [x] 2.5 Confirm set-list endpoints and resource flows remain unrestricted by gig type and calendar event mapping remains unchanged.
+
+## 3. MCP Contracts
+
+- [x] 3.1 Add gig type to MCP gig summary/detail contracts and output schemas.
+- [x] 3.2 Add optional gig type filtering to `glovelly_list_gigs` and `glovelly_list_uninvoiced_gigs` while preserving contact/status/date/invoicing filters.
+- [x] 3.3 Add gig type to MCP staged gig import draft input, validation, persistence, output contracts, and tool schemas.
+- [x] 3.4 Update MCP tool snapshots, generated MCP documentation, and capability manifest artifacts affected by schema changes.
+
+## 4. Frontend Types And Gig Workspace
+
+- [x] 4.1 Add frontend `GigType` types, formatters, form fields, payload mapping, and default values.
+- [x] 4.2 Add required type selection to the gig editor.
+- [x] 4.3 Show gig type in gig lists, selected gig details, and quick candidate surfaces where gig summaries are displayed.
+- [x] 4.4 Add gig type filtering and type-aware search to the gig workspace without regressing existing quick filters and sorting.
+- [x] 4.5 Replace generic performance/venue/show copy with neutral gig/location wording while keeping contextual set-list language.
+- [x] 4.6 Retain a clear linked-gig navigation action for invoice lines.
+
+## 5. Frontend Import Review
+
+- [x] 5.1 Add proposed gig type to frontend import draft types, payloads, autosave/update handling, and status rendering.
+- [x] 5.2 Add editable type selection to the gig import draft review UI and display type in draft summaries.
+- [x] 5.3 Ensure committed/imported gigs returned to the frontend preserve and display the selected type.
+
+## 6. Tests And Verification
+
+- [x] 6.1 Add backend tests for gig type validation, create/edit/read behavior, defaults, migration-backed model changes, and existing performance workflow preservation.
+- [x] 6.2 Add backend tests for import draft type editing/defaulting/commit behavior through REST and MCP paths.
+- [x] 6.3 Add backend tests for type-aware invoice fee descriptions and generated-line behavior.
+- [x] 6.4 Add MCP tests for type in gig list/detail responses, type filtering, and staged import draft validation/defaults.
+- [x] 6.5 Add or update frontend checks for gig type form behavior, list/detail display, filtering/search, and import draft editing.
+- [x] 6.6 Run `dotnet test glovelly.sln -m:1`, `npm --prefix frontend/glovelly-web run lint`, and `npm --prefix frontend/glovelly-web run build`.

--- a/openspec/changes/archive/2026-07-20-customize-invoice-description/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-20-customize-invoice-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/archive/2026-07-20-customize-invoice-description/design.md
+++ b/openspec/changes/archive/2026-07-20-customize-invoice-description/design.md
@@ -1,0 +1,46 @@
+## Context
+
+Invoices already persist a document-level `Description`, which is displayed as "In respect of" in the invoice detail and rendered in the PDF's Description block. The Line items pane currently supports manual adjustments but has no control for that document-level value. The broad invoice update endpoint accepts a complete invoice payload, making it unsuitable for a narrowly scoped editor.
+
+PDF redraft and reissue operations render the saved invoice entity and its saved lines. They do not rebuild the invoice description from linked gigs, so persistence is sufficient for regeneration to retain a custom description.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let an authenticated owner edit a Draft invoice's non-empty document-level description from the Line items pane.
+- Persist only the description through a focused API operation and return the refreshed invoice for client state replacement.
+- Keep a saved description when the Draft invoice is redrafted and its PDF is regenerated.
+- Prevent mutations to a non-Draft invoice's description.
+
+**Non-Goals:**
+- Editing individual generated or adjustment line descriptions.
+- Automatically regenerating a PDF when the description is saved.
+- Changing an issued PDF or permitting post-issue document-content changes.
+- Changing the generated default description or gig data.
+
+## Decisions
+
+### Use an invoice-level, description-only endpoint
+
+Add a dedicated update route beneath the invoice resource that accepts a small request containing `description`. The handler will load the invoice through the existing user-visibility scope, reject anything other than `Draft`, trim and validate a non-empty value, stamp the update, save, and return the invoice with lines.
+
+This avoids exposing a broad full-invoice update from a small inline field and keeps status and document-integrity rules at the API boundary.
+
+Alternative considered: reuse `PUT /invoices/{id}`. Rejected because the frontend would have to submit and maintain unrelated invoice fields, increasing the risk of overwriting dates, client, number, or status.
+
+### Put the editor in the existing Line items pane
+
+The pane will display a labelled text field initialized from the selected invoice description and a deliberate Save action. It will be editable only while the selected invoice is Draft; all other statuses present the description as read-only in that pane. The existing invoice detail display remains unchanged.
+
+Alternative considered: place editing in the invoice detail summary. Rejected for now because the Line items pane is the established location for draft-level invoice adjustments and the requested discovery point.
+
+### Do not regenerate on save
+
+Saving changes only the persistent invoice description. The normal Redraft action generates a replacement draft PDF using that saved value. This separates text editing from document generation and retains the existing user-confirmed regeneration workflow.
+
+## Risks / Trade-offs
+
+- [A user may expect an existing PDF download to update immediately] -> The UI will communicate a successful save without claiming regeneration; the existing Redraft action remains the explicit document refresh.
+- [Client state can show stale input after selecting another invoice] -> The editor state will be synchronized when the selected invoice changes and replaced from the successful API response.
+- [A non-Draft client can attempt the route directly] -> The backend independently enforces the Draft-only constraint and returns a validation response.
+- [Blank descriptions could produce a poor document] -> The API rejects blank or whitespace-only values after trimming.

--- a/openspec/changes/archive/2026-07-20-customize-invoice-description/proposal.md
+++ b/openspec/changes/archive/2026-07-20-customize-invoice-description/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Generated invoices receive a default description, but users cannot correct or tailor that wording for a particular invoice. Giving draft invoices a focused description editor lets users produce an accurate document without changing gig data or rebuilding the invoice.
+
+## What Changes
+
+- Add a draft-only API operation to update an invoice's description independently of other invoice fields.
+- Add an editable Description field to the invoice Line items pane and retain the existing read-only display in invoice details.
+- Preserve a saved custom description when a draft invoice PDF is regenerated.
+- Reject description changes once an invoice is no longer Draft, preserving issued document history.
+
+## Capabilities
+
+### New Capabilities
+- `invoice-description-customization`: Allows users to edit a draft invoice's document-level description and retain it through PDF regeneration.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Backend invoice endpoint mapping and integration tests.
+- React invoice workspace state and Line items pane.
+- Existing invoice PDF regeneration behavior will use the saved description; no schema or dependency changes are required.

--- a/openspec/changes/archive/2026-07-20-customize-invoice-description/specs/invoice-description-customization/spec.md
+++ b/openspec/changes/archive/2026-07-20-customize-invoice-description/specs/invoice-description-customization/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Draft invoice description can be updated independently
+The system SHALL provide an authenticated, owner-scoped API operation that updates only the document-level description of a Draft invoice. The operation MUST trim the submitted value, reject blank descriptions, persist the updated description, and return the updated invoice including its line items.
+
+#### Scenario: Draft description is saved
+- **WHEN** an authenticated user submits a non-empty description for an invoice they can access that is in Draft status
+- **THEN** the system persists the trimmed description and returns the updated invoice with its line items
+
+#### Scenario: Blank description is rejected
+- **WHEN** an authenticated user submits a description containing only whitespace
+- **THEN** the system returns a validation error and does not alter the invoice description
+
+#### Scenario: Non-draft description update is rejected
+- **WHEN** an authenticated user attempts to update the description of an invoice whose status is not Draft
+- **THEN** the system returns a validation error and does not alter the invoice description
+
+#### Scenario: Inaccessible invoice cannot be updated
+- **WHEN** an authenticated user submits a description update for an invoice outside their visibility scope
+- **THEN** the system does not disclose or alter that invoice
+
+### Requirement: Line items pane supports draft description editing
+The Line items pane SHALL show the selected invoice's document-level description in an editable labelled field when the invoice is Draft. The user MUST be able to save the field through the dedicated description operation, and the UI MUST replace the selected invoice with the returned invoice on success.
+
+#### Scenario: User saves a draft description
+- **WHEN** a user edits the Description field in the Line items pane for a Draft invoice and saves it
+- **THEN** the UI sends only the description update, displays the saved description, and reports a successful save
+
+#### Scenario: Non-draft description is read-only
+- **WHEN** a user opens the Line items pane for an invoice that is not Draft
+- **THEN** the document-level description is shown without an editable field or save action
+
+### Requirement: Regenerated draft PDF retains custom description
+The system SHALL render a Draft invoice's persisted document-level description when redrafting its PDF.
+
+#### Scenario: Redraft after description customization
+- **WHEN** a user saves a custom description on a Draft invoice and redrafts that invoice
+- **THEN** the regenerated PDF uses the saved custom description

--- a/openspec/changes/archive/2026-07-20-customize-invoice-description/tasks.md
+++ b/openspec/changes/archive/2026-07-20-customize-invoice-description/tasks.md
@@ -1,0 +1,17 @@
+## 1. Draft Description API
+
+- [x] 1.1 Add an owner-scoped invoice description update endpoint with a focused request contract, trimming and rejecting blank values.
+- [x] 1.2 Enforce Draft-only updates, stamp the invoice update, and return the invoice with its line items.
+- [x] 1.3 Add integration coverage for successful trimmed updates, blank validation, non-Draft rejection, and user visibility.
+
+## 2. Invoice Workspace
+
+- [x] 2.1 Add Line items pane state and a save handler that calls the dedicated description endpoint and replaces the updated invoice in workspace state.
+- [x] 2.2 Render a Description editor and Save action for Draft invoices, and a read-only description for non-Draft invoices.
+- [x] 2.3 Synchronize the editor value on invoice selection and report saving and validation outcomes through the existing invoice status feedback.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Extend invoice redraft coverage to verify that a saved custom description is retained in the regenerated PDF.
+- [x] 3.2 Update the relevant invoice user-acceptance scenario to cover changing a Draft invoice description and redrafting it.
+- [x] 3.3 Run the targeted backend invoice tests, frontend lint, and frontend build.

--- a/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/design.md
+++ b/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/design.md
@@ -1,0 +1,56 @@
+## Context
+
+Gig selection and gig editor state are managed together in `useGigsWorkspace`. The normal `selectGig` operation updates the selected gig and, when the editor is open, replaces the form with the target gig's persisted values after handling unsaved-change confirmation. Some cross-workspace callbacks in `App.tsx` bypass that operation by setting the selected gig ID directly.
+
+Saving an expense keeps the gig editor open. If the user then follows an invoice-line shortcut to a different gig, the selected gig changes while the editable form remains associated with the previous gig. The next save sends the full stale form to the newly selected gig's `PUT /gigs/{id}` endpoint. That endpoint intentionally replaces editable gig fields and normalizes the full expense collection, making the client-side mismatch destructive.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep selected-gig identity and editable gig form state aligned for every cross-workspace navigation path.
+- Retain the established explicit confirmation before discarding genuinely unsaved gig edits.
+- Prove the invoice-line navigation circuit does not leak the first gig's fields or expenses into the second gig and cannot overwrite either record.
+
+**Non-Goals:**
+- Change the gig API's full-update semantics or introduce optimistic concurrency tokens.
+- Redesign the gig editor or invoice-line user experience.
+- Cover unrelated multi-browser or multi-user concurrent editing conflicts.
+
+## Decisions
+
+### Use the workspace's canonical gig-selection operation for navigation
+
+Cross-workspace navigation that opens a gig will use the workspace-level selection behavior rather than calling the raw selected-ID state setter. This centralizes selection, editor hydration, external-resource editor cleanup, and unsaved-change handling in one path.
+
+The invoice-line callback is the confirmed incident path. Dashboard shortcuts using raw gig selection will be reviewed and routed through the same behavior where they open a gig workspace, preventing the same state mismatch through a different entry point.
+
+Alternative considered: update the form from an effect whenever `selectedGig` changes. This would erase unsaved edits before the existing confirmation logic can decide whether navigation is allowed, and would split selection policy across the hook and a reactive side effect.
+
+### Preserve the existing discard guard
+
+Navigation to a different gig with unsaved edits will continue to require explicit user confirmation. After a successful save, the form is rehydrated from the saved gig and is no longer dirty; navigation can therefore safely hydrate the target form without a prompt.
+
+Alternative considered: close the editor whenever the user leaves Gigs. This is broader behavior change, loses the current editing continuity, and does not establish one safe selection path.
+
+### Test persisted state, not only visible selection
+
+The regression UAT will create two distinguishable, invoice-linked gigs, edit an expense on the first while retaining the open editor, regenerate the draft invoice, then follow an invoice line to the second gig. It will assert both target editor hydration and final persisted values after a save, so it detects both the misleading UI state and the previous data-loss outcome.
+
+The existing cross-workspace navigation UAT is the natural suite because it already exercises invoice-line gig shortcuts. The UAT documentation will name the expanded test and describe the state-isolation guarantee.
+
+## Risks / Trade-offs
+
+- [A navigation helper can trigger an unexpected discard dialog] -> Reuse the established `selectGig` behavior and cover both saved-form navigation and existing dirty-form guard tests.
+- [Target gig data held in the local workspace could be stale] -> This change prevents cross-record form leakage; it does not claim multi-session conflict protection. A future concurrency change can independently address stale remote data.
+- [A direct selected-ID setter remains available for future callers] -> Limit cross-workspace use of raw setters and review current App-level entry points as part of implementation.
+
+## Migration Plan
+
+1. Ship the frontend selection-path correction and browser UAT regression together.
+2. Run the focused UAT suite plus frontend lint/build and the normal verification suite before deployment.
+3. No data migration is required. The correction prevents future bad writes; it cannot reconstruct data already overwritten, so any historical recovery remains an operational database-restoration concern.
+4. If a regression is found, revert the frontend change; no persisted schema or API changes require rollback work.
+
+## Open Questions
+
+- None for the incident fix. Optimistic concurrency for gig updates remains a separate defense-in-depth decision.

--- a/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/proposal.md
+++ b/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Issue #206 exposed a production data-loss path: navigating from a generated invoice line to a second gig after editing a first gig can leave the second gig's editor populated with the first gig's saved form. Saving then overwrites the second gig's details and expenses, requiring a database rollback to recover.
+
+## What Changes
+
+- Route every cross-workspace gig navigation through gig-selection behavior that keeps the selected record and editable form state aligned.
+- Preserve the existing explicit-discard behavior when a user has unsaved gig edits before navigating to another gig.
+- Add browser UAT coverage for editing one gig, regenerating its linked draft invoice, navigating to a different linked gig from invoice lines in the same browser session, and verifying neither record is overwritten.
+- Update the corresponding UAT documentation to describe the automated regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `uat-browser-automation`: Cross-workspace invoice-line navigation must verify the selected gig editor is hydrated from the target record and cannot persist data from a previously edited gig.
+
+## Impact
+
+- Frontend gig workspace selection and cross-workspace navigation callbacks, principally `App.tsx` and `useGigsWorkspace.ts`.
+- Playwright UAT tests, likely the cross-workspace navigation suite and its shared invoice helpers.
+- `docs/uat` cross-workspace navigation guidance.
+- No API contract, database schema, or external-service dependency changes are expected.

--- a/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/specs/uat-browser-automation/spec.md
+++ b/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/specs/uat-browser-automation/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-workspace browser navigation is automated
+The UAT browser suite SHALL verify that cross-workspace shortcuts open the intended workspace and selected record without stale filters hiding the target, and SHALL verify that opening a gig from a generated invoice line hydrates an open gig editor from that target gig rather than a previously edited gig.
+
+#### Scenario: User follows gig and invoice client shortcuts
+- **WHEN** an authenticated UAT browser test opens a gig or invoice with a known client and activates the client shortcut
+- **THEN** the Clients workspace SHALL open with that client selected and visible even if previous search filters would otherwise hide it
+
+#### Scenario: User follows generated invoice line shortcuts
+- **WHEN** an authenticated UAT browser test opens generated invoice lines linked to gigs and activates a line shortcut
+- **THEN** the Gigs workspace SHALL open with the corresponding gig selected and visible
+
+#### Scenario: Invoice-line shortcut replaces an open saved gig editor with the target gig
+- **WHEN** an authenticated UAT browser test saves an invoice-relevant edit to one gig, regenerates its linked draft invoice, and follows a generated invoice line shortcut to a different linked gig without refreshing the browser
+- **THEN** the second gig SHALL be selected and its editor fields and expenses SHALL reflect the second gig's persisted values rather than values from the first gig
+- **AND THEN** saving an intended change to the second gig SHALL NOT alter the first gig or replace the second gig's unrelated fields and expenses with values from the first gig
+
+#### Scenario: Manual adjustment lines are not gig shortcuts
+- **WHEN** an authenticated UAT browser test opens invoice lines containing manual adjustments
+- **THEN** manual adjustment lines SHALL NOT expose a gig navigation shortcut

--- a/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/tasks.md
+++ b/openspec/changes/archive/2026-07-20-fix-invoice-gig-navigation-state/tasks.md
@@ -1,0 +1,16 @@
+## 1. Safe Gig Navigation
+
+- [x] 1.1 Route invoice-line and other App-level gig-opening shortcuts through the canonical gig workspace selection behavior rather than directly setting the selected gig ID.
+- [x] 1.2 Confirm navigating after a saved gig or expense edit rehydrates the target gig form while navigation with unsaved edits retains the existing discard-confirmation behavior.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Extend the cross-workspace Playwright UAT journey with two distinct, combined-invoice gigs and the saved-edit, regenerate, invoice-line-to-second-gig circuit from issue #206.
+- [x] 2.2 Assert the second gig editor displays its own persisted fields and expenses, then save a deliberate second-gig change and verify neither gig is overwritten by the other.
+- [x] 2.3 Update the cross-workspace UAT documentation to name the expanded automated regression coverage and its state-isolation guarantee.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused cross-workspace UAT test and confirm the regression journey passes.
+- [x] 3.2 Run frontend lint and build checks.
+- [x] 3.3 Run `./verify.sh` before handover.

--- a/openspec/specs/invoice-description-customization/spec.md
+++ b/openspec/specs/invoice-description-customization/spec.md
@@ -1,0 +1,42 @@
+## Purpose
+
+Support authenticated owners in customizing a Draft invoice's document-level description.
+
+## Requirements
+
+### Requirement: Draft invoice description can be updated independently
+The system SHALL provide an authenticated, owner-scoped API operation that updates only the document-level description of a Draft invoice. The operation MUST trim the submitted value, reject blank descriptions, persist the updated description, and return the updated invoice including its line items.
+
+#### Scenario: Draft description is saved
+- **WHEN** an authenticated user submits a non-empty description for an invoice they can access that is in Draft status
+- **THEN** the system persists the trimmed description and returns the updated invoice with its line items
+
+#### Scenario: Blank description is rejected
+- **WHEN** an authenticated user submits a description containing only whitespace
+- **THEN** the system returns a validation error and does not alter the invoice description
+
+#### Scenario: Non-draft description update is rejected
+- **WHEN** an authenticated user attempts to update the description of an invoice whose status is not Draft
+- **THEN** the system returns a validation error and does not alter the invoice description
+
+#### Scenario: Inaccessible invoice cannot be updated
+- **WHEN** an authenticated user submits a description update for an invoice outside their visibility scope
+- **THEN** the system does not disclose or alter that invoice
+
+### Requirement: Line items pane supports draft description editing
+The Line items pane SHALL show the selected invoice's document-level description in an editable labelled field when the invoice is Draft. The user MUST be able to save the field through the dedicated description operation, and the UI MUST replace the selected invoice with the returned invoice on success.
+
+#### Scenario: User saves a draft description
+- **WHEN** a user edits the Description field in the Line items pane for a Draft invoice and saves it
+- **THEN** the UI sends only the description update, displays the saved description, and reports a successful save
+
+#### Scenario: Non-draft description is read-only
+- **WHEN** a user opens the Line items pane for an invoice that is not Draft
+- **THEN** the document-level description is shown without an editable field or save action
+
+### Requirement: Regenerated draft PDF retains custom description
+The system SHALL render a Draft invoice's persisted document-level description when redrafting its PDF.
+
+#### Scenario: Redraft after description customization
+- **WHEN** a user saves a custom description on a Draft invoice and redrafts that invoice
+- **THEN** the regenerated PDF uses the saved custom description

--- a/openspec/specs/mcp-read-tools/spec.md
+++ b/openspec/specs/mcp-read-tools/spec.md
@@ -7,11 +7,15 @@ Define the authenticated read-only MCP tools that expose Glovelly business data 
 ## Requirements
 
 ### Requirement: MCP shall expose read-only gig listing
-The system SHALL provide an authenticated read-only MCP tool named `glovelly_list_gigs` that lists gigs visible to the MCP user and supports filtering by contact, status, date range, and invoicing state.
+The system SHALL provide an authenticated read-only MCP tool named `glovelly_list_gigs` that lists gigs visible to the MCP user and supports filtering by contact, status, date range, invoicing state, and gig type.
 
 #### Scenario: List visible gigs by date range
 - **WHEN** an authenticated MCP user calls `glovelly_list_gigs` with `fromDate` and `toDate`
-- **THEN** the response includes only visible gigs whose dates fall within the inclusive range, ordered predictably, with gig ID, title, date, venue, contact summary, status, fee, invoice state, and currency
+- **THEN** the response includes only visible gigs whose dates fall within the inclusive range, ordered predictably, with gig ID, title, date, venue, contact summary, status, type, fee, invoice state, and currency
+
+#### Scenario: Filter visible gigs by type
+- **WHEN** an authenticated MCP user calls `glovelly_list_gigs` with a supported gig type filter
+- **THEN** the response includes only visible gigs whose type matches the requested type
 
 #### Scenario: Ambiguous contact query does not guess
 - **WHEN** an authenticated MCP user calls `glovelly_list_gigs` with a `contactQuery` that matches multiple visible contacts
@@ -26,22 +30,45 @@ The system SHALL provide an authenticated read-only MCP tool named `glovelly_get
 
 #### Scenario: Fetch visible gig detail
 - **WHEN** an authenticated MCP user calls `glovelly_get_gig` with the ID of a visible gig
-- **THEN** the response has `found` set to true and includes gig details, contact summary, invoice summary when linked, expense summaries, resource summaries, and currency
+- **THEN** the response has `found` set to true and includes gig details, type, contact summary, invoice summary when linked, expense summaries, resource summaries, and currency
 
 #### Scenario: Hidden or missing gig is not returned
 - **WHEN** an authenticated MCP user calls `glovelly_get_gig` with a missing gig ID or a gig ID outside their visible scope
 - **THEN** the response has `found` set to false and does not include gig details
 
 ### Requirement: MCP shall expose read-only uninvoiced gig listing
-The system SHALL provide an authenticated read-only MCP tool named `glovelly_list_uninvoiced_gigs` that lists visible gigs that are not linked to an invoice.
+The system SHALL provide an authenticated read-only MCP tool named `glovelly_list_uninvoiced_gigs` that lists visible gigs that are not linked to an invoice and supports the same gig type filter as `glovelly_list_gigs`.
 
 #### Scenario: List uninvoiced gigs
 - **WHEN** an authenticated MCP user calls `glovelly_list_uninvoiced_gigs`
-- **THEN** the response includes only visible gigs without an invoice link and includes total uninvoiced fees and currency
+- **THEN** the response includes only visible gigs without an invoice link and includes gig type, total uninvoiced fees, and currency
 
 #### Scenario: Filter uninvoiced gigs by contact and date
 - **WHEN** an authenticated MCP user calls `glovelly_list_uninvoiced_gigs` with contact and date filters
 - **THEN** the response applies the filters before returning gig summaries and totals
+
+#### Scenario: Filter uninvoiced gigs by type
+- **WHEN** an authenticated MCP user calls `glovelly_list_uninvoiced_gigs` with a supported gig type filter
+- **THEN** the response includes only visible uninvoiced gigs whose type matches the requested type
+
+### Requirement: MCP staged gig import drafts shall include gig type
+The system SHALL allow MCP staged gig import draft tools to accept, store, and return a proposed gig type while preserving staged-write behavior.
+
+#### Scenario: Add typed gig import draft through MCP
+- **WHEN** an authenticated MCP user calls `glovelly_add_gig_import_draft` with a supported gig type
+- **THEN** the created draft stores and returns that type without creating a real gig
+
+#### Scenario: Add bulk typed gig import drafts through MCP
+- **WHEN** an authenticated MCP user calls `glovelly_add_gig_import_drafts` with draft rows that include supported gig types
+- **THEN** each created draft stores and returns its requested type in the per-row result
+
+#### Scenario: MCP draft type defaults
+- **WHEN** an MCP staged gig import draft request omits gig type
+- **THEN** the created draft stores and returns `Performance` as the proposed gig type
+
+#### Scenario: MCP draft rejects invalid type
+- **WHEN** an MCP staged gig import draft request supplies an unsupported gig type
+- **THEN** the draft is not created and the result includes validation feedback for the type field
 
 ### Requirement: MCP shall expose read-only contact detail
 The system SHALL provide an authenticated read-only MCP tool named `glovelly_get_contact` that fetches details for one visible contact.

--- a/openspec/specs/typed-gigs/spec.md
+++ b/openspec/specs/typed-gigs/spec.md
@@ -1,0 +1,141 @@
+# Typed Gigs
+
+## Purpose
+
+Define typed gig behavior across gig management, financial workflows, imports, calendar output, and persistence.
+
+## Requirements
+
+### Requirement: Gigs have a required type
+The system SHALL assign every gig one of the supported gig types: `Performance`, `Teaching`, `Rehearsal`, `Recording`, `Admin`, or `Other`.
+
+#### Scenario: Existing gigs are backfilled
+- **WHEN** the post-baseline database migration is applied to a database with existing gigs
+- **THEN** every existing gig has type `Performance`
+
+#### Scenario: New gig type is validated
+- **WHEN** a user-facing gig create or update request supplies an unsupported type
+- **THEN** the system rejects the request with validation feedback for the type field
+
+#### Scenario: Type remains separate from lifecycle status
+- **WHEN** a gig is created or edited
+- **THEN** the system stores the gig type independently from the gig status values `Draft`, `Confirmed`, `Completed`, and `Cancelled`
+
+### Requirement: Users can create and edit typed gigs
+The system SHALL let users choose and edit gig type through the primary gig creation and editing workflow.
+
+#### Scenario: Create typed gig
+- **WHEN** a user creates a gig for teaching, rehearsal, recording, admin, performance, or other work
+- **THEN** the saved gig uses the selected type and remains available in the normal gig workspace
+
+#### Scenario: Edit gig type
+- **WHEN** a user edits an existing gig and changes its type
+- **THEN** the saved gig reflects the new type without changing its status, invoice link, expenses, mileage, notes, or external resources
+
+#### Scenario: Legacy inferred creation defaults type
+- **WHEN** a quick-capture, calendar/import, MCP draft, seed, or other inferred creation path cannot determine a type explicitly
+- **THEN** the system assigns `Performance` as the default type
+
+### Requirement: Gig presentation and filtering are type-aware
+The system SHALL display gig type in gig lists, gig details, and relevant selection surfaces, and SHALL let users filter gigs by type.
+
+#### Scenario: Gig list shows type
+- **WHEN** a user views the gig workspace list
+- **THEN** each gig row or card clearly shows its type alongside the existing gig summary information
+
+#### Scenario: Gig detail shows type
+- **WHEN** a user selects a gig in the gig workspace
+- **THEN** the detail panel clearly shows the gig type
+
+#### Scenario: User filters by type
+- **WHEN** a user applies a gig type filter
+- **THEN** the gig list includes only gigs matching the selected type while preserving existing search, status filter, and sort behavior
+
+#### Scenario: Search includes type
+- **WHEN** a user searches the gig list by a type label such as `teaching` or `recording`
+- **THEN** matching gigs of that type are included in the search results
+
+### Requirement: Generic gig language is neutral
+The system SHALL avoid generic UI wording that implies every gig is a performance while keeping `Gig` as the primary entity name.
+
+#### Scenario: Generic location labels are neutral
+- **WHEN** a user creates, edits, imports, or views a generic gig
+- **THEN** the UI uses neutral location wording rather than requiring the work to be a venue-based performance
+
+#### Scenario: Performance-specific language remains contextual
+- **WHEN** the UI describes a feature that genuinely applies to set lists, shows, or performance-specific material
+- **THEN** the UI may use performance-specific language in that context
+
+### Requirement: Import drafts carry editable gig type
+The system SHALL store, display, and commit an editable proposed gig type for each staged gig import draft.
+
+#### Scenario: Review imported draft type
+- **WHEN** a user reviews a staged gig import draft
+- **THEN** the draft shows an editable type field with one of the supported gig type values
+
+#### Scenario: Commit imported draft type
+- **WHEN** a user commits an accepted import draft
+- **THEN** the created gig has the draft's selected type
+
+#### Scenario: Imported draft defaults type
+- **WHEN** an import draft is created without an explicit type
+- **THEN** the draft type defaults to `Performance`
+
+#### Scenario: Invalid draft type is rejected
+- **WHEN** a user or MCP client updates or creates an import draft with an unsupported type
+- **THEN** the system rejects the draft change with validation feedback
+
+### Requirement: All gig types use shared financial workflows
+The system SHALL allow every gig type to use existing fee, invoice, expense, mileage, receipt, tax-summary, notes, and external-resource behavior.
+
+#### Scenario: Teaching gig is invoiced
+- **WHEN** a teaching gig has a fee and a user generates an invoice from it
+- **THEN** the system creates an invoice through the existing invoice workflow and links it to the teaching gig
+
+#### Scenario: Admin gig expenses are counted
+- **WHEN** an admin gig has expenses included in existing expense or tax-summary flows
+- **THEN** the system includes those expenses according to the same rules used for performance gigs
+
+#### Scenario: Non-chargeable gig remains supported
+- **WHEN** any gig type has a zero fee
+- **THEN** the gig can still be saved and can still carry expenses, mileage, notes, and resources
+
+### Requirement: Invoice fee descriptions are type-aware
+The system SHALL generate fee line descriptions from gig type, title, and date.
+
+#### Scenario: Generate performance fee description
+- **WHEN** a performance gig with a non-zero fee generates invoice lines
+- **THEN** the fee line description uses the existing performance wording pattern
+
+#### Scenario: Generate teaching fee description
+- **WHEN** a teaching gig with a non-zero fee generates invoice lines
+- **THEN** the fee line description describes a teaching fee for that gig
+
+### Requirement: Set-list workflows remain available across gig types
+The system SHALL keep set-list resources, set-list imports, chart matching, and set-list exports available regardless of gig type.
+
+#### Scenario: Rehearsal gig uses set-list resource
+- **WHEN** a rehearsal gig has a Google Sheet external resource with purpose `SetList`
+- **THEN** the user can manage the set-list import through the existing set-list workflow
+
+#### Scenario: Recording gig set-list is not rejected by type
+- **WHEN** a recording gig calls an existing set-list import endpoint with otherwise valid input
+- **THEN** the system does not reject the request solely because the gig type is not `Performance`
+
+### Requirement: Calendar output remains unchanged by type
+The system SHALL NOT add gig type to Google Calendar event titles or descriptions as part of typed gigs.
+
+#### Scenario: Calendar event maps existing fields
+- **WHEN** a typed gig is mapped to a Google Calendar event
+- **THEN** the event title and description follow the existing calendar mapping without adding a type label
+
+### Requirement: Typed gig schema changes use EF migrations
+The system SHALL introduce gig type persistence through a checked-in EF Core migration in the migrations project.
+
+#### Scenario: Migration is checked in
+- **WHEN** the gig type model changes are implemented
+- **THEN** the corresponding migration and model snapshot changes are stored under the EF migrations project
+
+#### Scenario: PostgreSQL deployment applies migration through bundle
+- **WHEN** the typed gig change is deployed to PostgreSQL environments
+- **THEN** the existing migration bundle and Cloud Run Job workflow applies the migration before the application service revision is deployed

--- a/openspec/specs/uat-browser-automation/spec.md
+++ b/openspec/specs/uat-browser-automation/spec.md
@@ -6,7 +6,7 @@ Define the browser-level UAT automation coverage for high-value authenticated Gl
 ## Requirements
 
 ### Requirement: Cross-workspace browser navigation is automated
-The UAT browser suite SHALL verify that cross-workspace shortcuts open the intended workspace and selected record without stale filters hiding the target.
+The UAT browser suite SHALL verify that cross-workspace shortcuts open the intended workspace and selected record without stale filters hiding the target, and SHALL verify that opening a gig from a generated invoice line hydrates an open gig editor from that target gig rather than a previously edited gig.
 
 #### Scenario: User follows gig and invoice client shortcuts
 - **WHEN** an authenticated UAT browser test opens a gig or invoice with a known client and activates the client shortcut
@@ -15,6 +15,11 @@ The UAT browser suite SHALL verify that cross-workspace shortcuts open the inten
 #### Scenario: User follows generated invoice line shortcuts
 - **WHEN** an authenticated UAT browser test opens generated invoice lines linked to gigs and activates a line shortcut
 - **THEN** the Gigs workspace SHALL open with the corresponding gig selected and visible
+
+#### Scenario: Invoice-line shortcut replaces an open saved gig editor with the target gig
+- **WHEN** an authenticated UAT browser test saves an invoice-relevant edit to one gig, regenerates its linked draft invoice, and follows a generated invoice line shortcut to a different linked gig without refreshing the browser
+- **THEN** the second gig SHALL be selected and its editor fields and expenses SHALL reflect the second gig's persisted values rather than values from the first gig
+- **AND THEN** saving an intended change to the second gig SHALL NOT alter the first gig or replace the second gig's unrelated fields and expenses with values from the first gig
 
 #### Scenario: Manual adjustment lines are not gig shortcuts
 - **WHEN** an authenticated UAT browser test opens invoice lines containing manual adjustments

--- a/tests/Glovelly.Uat.Tests/CrossWorkspaceNavigationTests.cs
+++ b/tests/Glovelly.Uat.Tests/CrossWorkspaceNavigationTests.cs
@@ -63,4 +63,141 @@ public sealed class CrossWorkspaceNavigationTests : InvoiceUatTestBase
                 HasText = adjustmentReason,
             }).GetByTestId("invoice-line-link")).ToHaveCountAsync(0);
         });
+
+    [Fact]
+    public Task InvoiceLineNavigationDoesNotReusePreviouslySavedGigEditorState() => RunWithDiagnosticsAsync(
+        nameof(InvoiceLineNavigationDoesNotReusePreviouslySavedGigEditorState),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} State Isolation Client";
+            var firstGigTitle = $"{runId} State Isolation Gig A";
+            var secondGigTitle = $"{runId} State Isolation Gig B";
+            var firstGigVenue = "First gig venue";
+            var firstGigUpdatedExpense = $"{runId} Updated first expense";
+            var secondGigVenue = "Second gig venue";
+            var secondGigUpdatedVenue = "Second gig updated venue";
+            var firstGigExpense = $"{runId} First expense";
+            var secondGigExpense = $"{runId} Second expense";
+            var gigDate = DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-dd");
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(
+                clientName,
+                firstGigTitle,
+                gigDate,
+                venue: firstGigVenue,
+                expenses: [new GigExpense(firstGigExpense, "11.00")]);
+            await CreateGigAsync(
+                clientName,
+                secondGigTitle,
+                DateTime.UtcNow.AddDays(31).ToString("yyyy-MM-dd"),
+                venue: secondGigVenue,
+                expenses: [new GigExpense(secondGigExpense, "22.00")]);
+
+            await SelectGigForBatchInvoiceAsync(firstGigTitle);
+            await SelectGigForBatchInvoiceAsync(secondGigTitle);
+            await GenerateInvoiceAndWaitForPreviewAsync();
+            await OpenPreviewedInvoiceAsync();
+            await OpenInvoiceLinesAsync();
+
+            await OpenGigFromInvoiceLineAsync(firstGigTitle);
+            await EnsureGigEditorOpenAsync();
+            await UpdateExpenseAndAcceptLinkedRedraftAsync(firstGigExpense, firstGigUpdatedExpense);
+
+            await OpenLinkedInvoiceFromGigAsync();
+            await OpenInvoiceLinesAsync();
+            await OpenGigFromInvoiceLineAsync(secondGigTitle);
+
+            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = secondGigTitle })).ToBeVisibleAsync();
+            await Assertions.Expect(Page.GetByTestId("gig-title-input")).ToHaveValueAsync(secondGigTitle);
+            await Assertions.Expect(Page.GetByTestId("gig-venue-input")).ToHaveValueAsync(secondGigVenue);
+            await Assertions.Expect(ExpenseRow(secondGigExpense)).ToBeVisibleAsync();
+            await Assertions.Expect(ExpenseRow(firstGigUpdatedExpense)).ToHaveCountAsync(0);
+
+            await Page.GetByTestId("gig-venue-input").FillAsync(secondGigUpdatedVenue);
+            await SaveGigAndAcceptLinkedRedraftAsync();
+
+            await OpenLinkedInvoiceFromGigAsync();
+            await OpenInvoiceLinesAsync();
+            await OpenGigFromInvoiceLineAsync(firstGigTitle);
+            await EnsureGigEditorOpenAsync();
+            await Assertions.Expect(Page.GetByTestId("gig-venue-input")).ToHaveValueAsync(firstGigVenue);
+            await Assertions.Expect(ExpenseRow(firstGigUpdatedExpense)).ToBeVisibleAsync();
+            await Assertions.Expect(ExpenseRow(secondGigExpense)).ToHaveCountAsync(0);
+
+            await OpenLinkedInvoiceFromGigAsync();
+            await OpenInvoiceLinesAsync();
+            await OpenGigFromInvoiceLineAsync(secondGigTitle);
+            await EnsureGigEditorOpenAsync();
+            await Assertions.Expect(Page.GetByTestId("gig-venue-input")).ToHaveValueAsync(secondGigUpdatedVenue);
+            await Assertions.Expect(ExpenseRow(secondGigExpense)).ToBeVisibleAsync();
+        });
+
+    private async Task SelectGigForBatchInvoiceAsync(string gigTitle)
+    {
+        await Page.GetByTestId("nav-gigs").ClickAsync();
+        await Page.GetByTestId("gig-search-input").FillAsync(string.Empty);
+        await GigCard(gigTitle).Locator("input[type=checkbox]").CheckAsync();
+    }
+
+    private async Task UpdateExpenseAndAcceptLinkedRedraftAsync(string currentDescription, string nextDescription)
+    {
+        var expense = ExpenseRow(currentDescription);
+        await expense.Locator(".associated-item-summary").ClickAsync();
+        await expense.GetByRole(AriaRole.Button, new() { Name = "Edit" }).ClickAsync();
+        await Page.GetByTestId("gig-expense-description-input").FillAsync(nextDescription);
+
+        Page.Dialog += AcceptLinkedRedraftDialog;
+        try
+        {
+            var redraftResponse = await Page.RunAndWaitForResponseAsync(
+                async () => await Page.GetByTestId("add-gig-expense-button").ClickAsync(),
+                IsInvoiceRedraftResponse,
+                new PageRunAndWaitForResponseOptions { Timeout = 30_000 });
+            Assert.True(redraftResponse.Ok, $"Expected invoice redraft to succeed, got HTTP {redraftResponse.Status} for {redraftResponse.Url}.");
+        }
+        finally
+        {
+            Page.Dialog -= AcceptLinkedRedraftDialog;
+        }
+
+        await Assertions.Expect(ExpenseRow(nextDescription)).ToBeVisibleAsync();
+    }
+
+    private async Task SaveGigAndAcceptLinkedRedraftAsync()
+    {
+        Page.Dialog += AcceptLinkedRedraftDialog;
+        try
+        {
+            var redraftResponse = await Page.RunAndWaitForResponseAsync(
+                async () => await Page.GetByTestId("gig-save-close-button").ClickAsync(),
+                IsInvoiceRedraftResponse,
+                new PageRunAndWaitForResponseOptions { Timeout = 30_000 });
+            Assert.True(redraftResponse.Ok, $"Expected invoice redraft to succeed, got HTTP {redraftResponse.Status} for {redraftResponse.Url}.");
+        }
+        finally
+        {
+            Page.Dialog -= AcceptLinkedRedraftDialog;
+        }
+    }
+
+    private ILocator ExpenseRow(string description) => Page.GetByTestId("gig-expense-item").Filter(new LocatorFilterOptions
+    {
+        HasText = description,
+    });
+
+    private static bool IsInvoiceRedraftResponse(IResponse response)
+    {
+        var path = new Uri(response.Url).AbsolutePath;
+        return response.Request.Method == "POST" &&
+            path.StartsWith("/invoices/", StringComparison.Ordinal) &&
+            path.EndsWith("/redraft", StringComparison.Ordinal);
+    }
+
+    private static void AcceptLinkedRedraftDialog(object? _, IDialog dialog)
+    {
+        _ = dialog.Type == "confirm" ? dialog.AcceptAsync() : dialog.DismissAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- add required gig types across gig CRUD, import review, quick capture, MCP, and the frontend workspace
- add the post-baseline EF migration that defaults existing gigs and import drafts to Performance
- use type-aware generated invoice fee descriptions and preserve linked gig navigation from invoice lines
- correct development seed invoice-to-gig line linkages and document future invoice-native line editing separately

## Verification
- dotnet test glovelly.sln -m:1
- npm --prefix frontend/glovelly-web run lint
- npm --prefix frontend/glovelly-web run build
- dotnet tool run dotnet-ef migrations has-pending-model-changes --project backend/Glovelly.Migrations --startup-project backend/Glovelly.Migrations