### PR TITLE
Hide past gigs by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Restore frontend dependencies
         run: npm --prefix frontend/glovelly-web ci
 
+      - name: Run frontend tests
+        run: npm --prefix frontend/glovelly-web run test
+
       - name: Run frontend lint
         run: npm --prefix frontend/glovelly-web run lint
 

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -127,6 +127,17 @@ Expected result: clients cannot be deleted silently. Deletion is only available 
 
 Expected result: unsaved gig edits and unsaved expense draft fields are never discarded without confirmation. Accepted navigation switches the editor to the selected gig or a blank new-gig form.
 
+### Gig History And Selection
+
+1. Create a future planned gig and a past completed or cancelled gig.
+2. Confirm the past completed or cancelled gig is hidden by default, while a past draft remains visible.
+3. Enable `Show past gigs` and confirm the historical gig appears without clearing search, type, quick-filter, or sort controls.
+4. Select a gig, then change filters or sort order while it remains visible; confirm it stays selected.
+5. Hide or delete the selected gig and confirm the first remaining visible gig is selected, or the empty state is shown.
+6. Follow an invoice-line link to a historical gig while it is hidden; confirm the workspace shows past gigs, clears incompatible filters, and explains the changed view.
+
+Expected result: the selected gig always belongs to the rendered list. Explicit navigation reveals its target, while passive list changes preserve a visible selection or select the first visible fallback.
+
 ### Admin
 
 1. Open Admin as an administrator, select a user, and click `Edit access`.

--- a/frontend/glovelly-web/package-lock.json
+++ b/frontend/glovelly-web/package-lock.json
@@ -24,7 +24,8 @@
         "globals": "^17.6.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.60.1",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.0.16"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -869,6 +870,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -879,6 +887,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1200,6 +1226,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1250,6 +1389,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -1343,6 +1492,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1413,6 +1572,13 @@
       "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1612,6 +1778,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1636,6 +1812,16 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2235,6 +2421,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2314,6 +2510,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2383,6 +2593,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2576,6 +2793,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2584,6 +2808,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2601,6 +2856,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tough-cookie": {
@@ -2841,6 +3106,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -2871,6 +3226,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/glovelly-web/package.json
+++ b/frontend/glovelly-web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@microsoft/signalr": "^10.0.0",
@@ -26,6 +27,7 @@
     "globals": "^17.6.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.60.1",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.0.16"
   }
 }

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -232,6 +232,7 @@ function App({ appMetadata }: AppProps) {
     selectedGig,
     selectedGigIds,
     selectedGigs,
+    showPastGigs,
     selectGig,
     setGigs,
     setGigQuickFilter,
@@ -241,8 +242,8 @@ function App({ appMetadata }: AppProps) {
     setGigStatus,
     setIncludeStatementReceiptAppendix,
     setIncludeStatementReceiptAttachments,
-    setSelectedGigId,
     setSelectedGigIds,
+    setShowPastGigs,
     startExternalResourceCreate,
     startExternalResourceEdit,
     startGigCreate,
@@ -367,7 +368,7 @@ function App({ appMetadata }: AppProps) {
     getGigById: (gigId) => gigsById.get(gigId),
     onMergeSavedGig: (gig) => mergeSavedGig(gig),
     onOpenReceiptDraft: (gig) => openGigReceiptDraft(gig),
-    onSelectGig: setSelectedGigId,
+    onSelectGig: selectGig,
     onSessionExpired: expireSession,
     setGigStatus,
   })
@@ -446,7 +447,7 @@ function App({ appMetadata }: AppProps) {
     getQuickCaptureCandidates,
     onMergeSavedGig: (gig) => mergeSavedGig(gig),
     onOpenAttachmentDraft: (gig) => openGigReceiptDraft(gig),
-    onSelectGig: setSelectedGigId,
+    onSelectGig: selectGig,
     onSessionExpired: expireSession,
     setGigStatus,
   })
@@ -1739,6 +1740,7 @@ function App({ appMetadata }: AppProps) {
         onGigTypeFilterChange={setGigTypeFilter}
         onSearchQueryChange={setGigSearchQuery}
         onSelectGig={selectGig}
+        onShowPastGigsChange={setShowPastGigs}
         onSortChange={setGigSort}
         onToggleGigSelection={handleToggleGigSelection}
         onStartEditing={startGigEdit}
@@ -1754,6 +1756,7 @@ function App({ appMetadata }: AppProps) {
         selectedGig={selectedGig}
         selectedGigIds={selectedGigIds}
         selectedGigs={selectedGigs}
+        showPastGigs={showPastGigs}
       />
     ) : (
       <InvoicesSection

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -70,6 +70,7 @@ type GigsSectionProps = {
   onGigTypeFilterChange: (filter: GigType | 'all') => void
   onSearchQueryChange: (value: string) => void
   onSelectGig: (gigId: string) => void
+  onShowPastGigsChange: (showPastGigs: boolean) => void
   onSortChange: (sort: GigSort) => void
   onToggleGigSelection: (gigId: string) => void
   onStartEditing: () => void
@@ -97,6 +98,7 @@ type GigsSectionProps = {
   selectedGig: Gig | null
   selectedGigIds: string[]
   selectedGigs: Gig[]
+  showPastGigs: boolean
 }
 
 export function GigsSection({
@@ -141,6 +143,7 @@ export function GigsSection({
   onGigTypeFilterChange,
   onSearchQueryChange,
   onSelectGig,
+  onShowPastGigsChange,
   onSortChange,
   onToggleGigSelection,
   onStartEditing,
@@ -156,6 +159,7 @@ export function GigsSection({
   selectedGig,
   selectedGigIds,
   selectedGigs,
+  showPastGigs,
 }: GigsSectionProps) {
   const editorSlotRef = useRef<HTMLDivElement | null>(null)
   const { ref: detailPanelRef, blockSize: detailPanelBlockSize } = useMeasuredBlockSize<HTMLDivElement>()
@@ -281,6 +285,15 @@ export function GigsSection({
               </button>
             </div>
             <div className="compact-filter-chips" aria-label="Gig filters">
+              <button
+                aria-pressed={showPastGigs}
+                className={`compact-filter-chip ${showPastGigs ? 'selected' : ''}`}
+                data-testid="show-past-gigs-button"
+                onClick={() => onShowPastGigsChange(!showPastGigs)}
+                type="button"
+              >
+                Show past gigs
+              </button>
               {gigFilterOptions.map((option) => (
                 <button
                   key={option.value}

--- a/frontend/glovelly-web/src/hooks/gigListState.test.ts
+++ b/frontend/glovelly-web/src/hooks/gigListState.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { Gig, GigSort } from '../types'
+import {
+  type GigListFilters,
+  getGigReveal,
+  getLocalDate,
+  getVisibleGigs,
+  reconcileSelectedGigId,
+} from './gigListState'
+
+const sort: GigSort = { key: 'date', direction: 'asc' }
+const filters = (overrides: Partial<GigListFilters> = {}): GigListFilters => ({
+  searchQuery: '', quickFilter: 'all', showPastGigs: false, sort, typeFilter: 'all', ...overrides,
+})
+const gig = (id: string, date: string, status: Gig['status'], title = id): Gig => ({
+  id, clientId: 'client', invoiceId: null, sourceImportBatchId: null, sourceImportDraftId: null,
+  title, date, venue: 'Venue', fee: 0, travelMiles: 0, passengerCount: null, notes: null,
+  wasDriving: false, type: 'Performance', status, invoicedAt: null, isInvoiced: false,
+  expenses: [], externalResources: [],
+})
+const names = new Map([['client', 'Client']])
+const today = '2026-07-24'
+
+describe('getVisibleGigs', () => {
+  it('formats the local calendar date without UTC conversion', () => {
+    expect(getLocalDate(new Date(2026, 6, 24, 0, 30))).toBe('2026-07-24')
+  })
+
+  it('hides only past completed and cancelled gigs by default', () => {
+    const gigs = [
+      gig('completed', '2026-07-23', 'Completed'), gig('cancelled', '2026-07-23', 'Cancelled'),
+      gig('draft', '2026-07-23', 'Draft'), gig('confirmed', '2026-07-23', 'Confirmed'),
+      gig('today', today, 'Completed'),
+    ]
+    expect(getVisibleGigs(gigs, names, filters(), today).map((value) => value.id))
+      .toEqual(['confirmed', 'draft', 'today'])
+  })
+
+  it('includes historical gigs without discarding active filters or sorting', () => {
+    const gigs = [
+      gig('older', '2026-07-01', 'Completed', 'Match'),
+      gig('newer', '2026-07-02', 'Completed', 'Match'),
+      gig('other', '2026-07-03', 'Completed', 'Other'),
+    ]
+    expect(getVisibleGigs(gigs, names, filters({ showPastGigs: true, searchQuery: 'match' }), today)
+      .map((value) => value.id)).toEqual(['older', 'newer'])
+  })
+})
+
+describe('gig selection state', () => {
+  const visible = [gig('first', '2026-07-25', 'Confirmed'), gig('second', '2026-07-26', 'Confirmed')]
+
+  it('uses the first visible gig initially and retains a visible selected gig', () => {
+    expect(reconcileSelectedGigId('', visible)).toBe('first')
+    expect(reconcileSelectedGigId('second', visible)).toBe('second')
+  })
+
+  it('falls back to the first visible gig or clears selection', () => {
+    expect(reconcileSelectedGigId('hidden', visible)).toBe('first')
+    expect(reconcileSelectedGigId('hidden', [])).toBe('')
+  })
+
+  it('requests filter clearing and historical visibility for a hidden target', () => {
+    const historical = gig('past', '2026-07-01', 'Completed')
+    expect(getGigReveal(historical, visible, today)).toEqual({ clearFilters: true, showPastGigs: true })
+    expect(getGigReveal(visible[0], visible, today)).toEqual({ clearFilters: false, showPastGigs: false })
+  })
+
+  it('clears filters without showing history for a non-historical hidden target', () => {
+    const target = gig('future', '2026-07-25', 'Confirmed')
+    expect(getGigReveal(target, [], today)).toEqual({ clearFilters: true, showPastGigs: false })
+  })
+})

--- a/frontend/glovelly-web/src/hooks/gigListState.ts
+++ b/frontend/glovelly-web/src/hooks/gigListState.ts
@@ -1,0 +1,102 @@
+import type { Gig, GigQuickFilter, GigSort, GigType } from '../types'
+
+export type GigListFilters = {
+  searchQuery: string
+  quickFilter: GigQuickFilter
+  showPastGigs: boolean
+  sort: GigSort
+  typeFilter: GigType | 'all'
+}
+
+export function getLocalDate(date = new Date()) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function isNormallyHiddenPastGig(gig: Gig, today: string) {
+  return gig.date < today && (gig.status === 'Completed' || gig.status === 'Cancelled')
+}
+
+export function getVisibleGigs(
+  gigs: Gig[],
+  clientNamesById: ReadonlyMap<string, string>,
+  filters: GigListFilters,
+  today: string
+) {
+  const query = filters.searchQuery.trim().toLowerCase()
+  const sortDirection = filters.sort.direction === 'asc' ? 1 : -1
+  const compareText = (left: string, right: string) => left.localeCompare(right)
+  const compareNumber = (left: number, right: number) => left - right
+  const getClientName = (gig: Gig) => clientNamesById.get(gig.clientId) ?? ''
+  const getPriorityBucket = (gig: Gig) => {
+    if (gig.status === 'Cancelled') return 5
+    if (gig.status === 'Confirmed' && gig.date >= today) return 0
+    if (gig.status === 'Completed' && !gig.isInvoiced && gig.date <= today) return 1
+    if (gig.status === 'Confirmed' && !gig.isInvoiced && gig.date < today) return 2
+    if (gig.status === 'Draft') return 3
+    return 4
+  }
+  const comparePriority = (left: Gig, right: Gig) => {
+    const bucketComparison = getPriorityBucket(left) - getPriorityBucket(right)
+    if (bucketComparison !== 0) return bucketComparison
+    return getPriorityBucket(left) === 0
+      ? compareText(left.date, right.date)
+      : compareText(right.date, left.date)
+  }
+  const compareByKey = (left: Gig, right: Gig) => {
+    switch (filters.sort.key) {
+      case 'client': return compareText(getClientName(left), getClientName(right))
+      case 'fee': return compareNumber(left.fee, right.fee)
+      case 'status': return compareText(left.status, right.status)
+      case 'title': return compareText(left.title, right.title)
+      case 'venue': return compareText(left.venue, right.venue)
+      case 'priority': return comparePriority(left, right)
+      case 'date':
+      default: return compareText(left.date, right.date)
+    }
+  }
+
+  return gigs
+    .filter((gig) => filters.showPastGigs || !isNormallyHiddenPastGig(gig, today))
+    .filter((gig) => filters.typeFilter === 'all' || gig.type === filters.typeFilter)
+    .filter((gig) => {
+      switch (filters.quickFilter) {
+        case 'completed': return gig.status === 'Completed'
+        case 'drafts': return gig.status === 'Draft'
+        case 'uninvoiced': return !gig.isInvoiced && gig.status !== 'Cancelled'
+        case 'upcoming': return gig.status !== 'Cancelled' && gig.date >= today
+        case 'all':
+        default: return true
+      }
+    })
+    .filter((gig) => !query || [gig.title, gig.venue, gig.date, gig.status, gig.type, getClientName(gig)]
+      .join(' ')
+      .toLowerCase()
+      .includes(query))
+    .sort((left, right) => {
+      const primaryComparison = compareByKey(left, right)
+      if (primaryComparison !== 0) return primaryComparison * sortDirection
+      return left.date.localeCompare(right.date)
+        || left.title.localeCompare(right.title)
+        || left.id.localeCompare(right.id)
+    })
+}
+
+export function reconcileSelectedGigId(selectedGigId: string, visibleGigs: Gig[]) {
+  return visibleGigs.some((gig) => gig.id === selectedGigId)
+    ? selectedGigId
+    : (visibleGigs[0]?.id ?? '')
+}
+
+export function getGigReveal(target: Gig, visibleGigs: Gig[], today: string) {
+  if (visibleGigs.some((gig) => gig.id === target.id)) {
+    return { clearFilters: false, showPastGigs: false }
+  }
+
+  return {
+    clearFilters: true,
+    showPastGigs: isNormallyHiddenPastGig(target, today),
+  }
+}

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { FormEvent } from 'react'
 import {
   buildApiUrl,
@@ -20,6 +20,12 @@ import {
   toEditableGigForm,
 } from './gigWorkspaceHelpers'
 import type { NormalizedGigExpensePayload } from './gigWorkspaceHelpers'
+import {
+  getGigReveal,
+  getLocalDate,
+  getVisibleGigs,
+  reconcileSelectedGigId,
+} from './gigListState'
 import type {
   Client,
   Gig,
@@ -68,6 +74,7 @@ export function useGigsWorkspace({
   const [gigSearchQuery, setGigSearchQuery] = useState('')
   const [gigQuickFilter, setGigQuickFilter] = useState<GigQuickFilter>('all')
   const [gigTypeFilter, setGigTypeFilter] = useState<GigType | 'all'>('all')
+  const [showPastGigs, setShowPastGigs] = useState(false)
   const [gigSort, setGigSort] = useState<GigSort>({ key: 'priority', direction: 'asc' })
   const [isGigEditorOpen, setIsGigEditorOpen] = useState(false)
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
@@ -81,124 +88,20 @@ export function useGigsWorkspace({
   const [externalResourceForm, setExternalResourceForm] = useState<GigExternalResourceForm>(
     emptyGigExternalResourceForm()
   )
-  const deferredGigSearchQuery = useDeferredValue(gigSearchQuery)
-
   const gigsById = useMemo(() => new Map(gigs.map((gig) => [gig.id, gig])), [gigs])
 
-  const filteredGigs = useMemo(() => {
-    const query = deferredGigSearchQuery.trim().toLowerCase()
-    const today = new Date().toISOString().slice(0, 10)
-    const sortDirection = gigSort.direction === 'asc' ? 1 : -1
-    const compareText = (left: string, right: string) => left.localeCompare(right)
-    const compareNumber = (left: number, right: number) => left - right
-    const getClientName = (gig: Gig) => clientNamesById.get(gig.clientId) ?? ''
-    const getPriorityBucket = (gig: Gig) => {
-      if (gig.status === 'Cancelled') {
-        return 5
-      }
-
-      if (gig.status === 'Confirmed' && gig.date >= today) {
-        return 0
-      }
-
-      if (gig.status === 'Completed' && !gig.isInvoiced && gig.date <= today) {
-        return 1
-      }
-
-      if (gig.status === 'Confirmed' && !gig.isInvoiced && gig.date < today) {
-        return 2
-      }
-
-      if (gig.status === 'Draft') {
-        return 3
-      }
-
-      return 4
-    }
-    const comparePriority = (left: Gig, right: Gig) => {
-      const bucketComparison = getPriorityBucket(left) - getPriorityBucket(right)
-      if (bucketComparison !== 0) {
-        return bucketComparison
-      }
-
-      const bucket = getPriorityBucket(left)
-      if (bucket === 0) {
-        return compareText(left.date, right.date)
-      }
-
-      return compareText(right.date, left.date)
-    }
-    const compareByKey = (left: Gig, right: Gig) => {
-      switch (gigSort.key) {
-        case 'client':
-          return compareText(getClientName(left), getClientName(right))
-        case 'fee':
-          return compareNumber(left.fee, right.fee)
-        case 'status':
-          return compareText(left.status, right.status)
-        case 'title':
-          return compareText(left.title, right.title)
-        case 'venue':
-          return compareText(left.venue, right.venue)
-        case 'priority':
-          return comparePriority(left, right)
-        case 'date':
-        default:
-          return compareText(left.date, right.date)
-      }
-    }
-    const sortedGigs = [...gigs].sort((left, right) => {
-      const primaryComparison = compareByKey(left, right)
-      if (primaryComparison !== 0) {
-        return primaryComparison * sortDirection
-      }
-
-      const dateComparison = left.date.localeCompare(right.date)
-      if (dateComparison !== 0) {
-        return dateComparison
-      }
-
-      const titleComparison = left.title.localeCompare(right.title)
-      if (titleComparison !== 0) {
-        return titleComparison
-      }
-
-      return left.id.localeCompare(right.id)
-    })
-    const quickFilteredGigs = sortedGigs.filter((gig) => {
-      if (gigTypeFilter !== 'all' && gig.type !== gigTypeFilter) {
-        return false
-      }
-      switch (gigQuickFilter) {
-        case 'completed':
-          return gig.status === 'Completed'
-        case 'drafts':
-          return gig.status === 'Draft'
-        case 'uninvoiced':
-          return !gig.isInvoiced && gig.status !== 'Cancelled'
-        case 'upcoming':
-          return gig.status !== 'Cancelled' && gig.date >= today
-        case 'all':
-        default:
-          return true
-      }
-    })
-
-    if (!query) {
-      return quickFilteredGigs
-    }
-
-    return quickFilteredGigs.filter((gig) => {
-      const clientName = clientNamesById.get(gig.clientId) ?? ''
-
-      return [gig.title, gig.venue, gig.date, gig.status, gig.type, clientName]
-        .join(' ')
-        .toLowerCase()
-        .includes(query)
-    })
-  }, [clientNamesById, deferredGigSearchQuery, gigQuickFilter, gigSort, gigTypeFilter, gigs])
-
-  const selectedGig = gigsById.get(selectedGigId) ?? filteredGigs[0] ?? null
+  const today = getLocalDate()
+  const filteredGigs = useMemo(() => getVisibleGigs(gigs, clientNamesById, {
+    searchQuery: gigSearchQuery,
+    quickFilter: gigQuickFilter,
+    showPastGigs,
+    sort: gigSort,
+    typeFilter: gigTypeFilter,
+  }, today), [clientNamesById, gigQuickFilter, gigSearchQuery, gigSort, gigTypeFilter, gigs, showPastGigs, today])
+  const reconciledSelectedGigId = reconcileSelectedGigId(selectedGigId, filteredGigs)
+  const selectedGig = isGigEditorOpen
+    ? (gigsById.get(selectedGigId) ?? null)
+    : (filteredGigs.find((gig) => gig.id === reconciledSelectedGigId) ?? null)
 
   const selectedGigs = useMemo(() => {
     const selectedGigIdSet = new Set(selectedGigIds)
@@ -258,6 +161,16 @@ export function useGigsWorkspace({
   }, [gigs])
 
   useEffect(() => {
+    if (isGigEditorOpen) {
+      return
+    }
+
+    if (reconciledSelectedGigId !== selectedGigId) {
+      setSelectedGigId(reconciledSelectedGigId)
+    }
+  }, [isGigEditorOpen, reconciledSelectedGigId, selectedGigId])
+
+  useEffect(() => {
     if (gigForm.clientId || clients.length === 0) {
       return
     }
@@ -279,7 +192,6 @@ export function useGigsWorkspace({
 
   const applyGigs = useCallback((nextGigs: Gig[]) => {
     setGigs(nextGigs)
-    setSelectedGigId(nextGigs[0]?.id ?? '')
   }, [])
 
   const resetGigsWorkspace = useCallback(() => {
@@ -288,6 +200,7 @@ export function useGigsWorkspace({
     setSelectedGigIds([])
     setGigSearchQuery('')
     setGigQuickFilter('all')
+    setShowPastGigs(false)
     setGigSort({ key: 'priority', direction: 'asc' })
     setIsGigEditorOpen(false)
     setGigMode('create')
@@ -314,7 +227,6 @@ export function useGigsWorkspace({
 
   const replaceSavedGig = useCallback((savedGig: Gig) => {
     setGigs((current) => current.map((gig) => (gig.id === savedGig.id ? savedGig : gig)))
-    setSelectedGigId(savedGig.id)
   }, [])
 
   const startExternalResourceCreate = () => {
@@ -723,21 +635,49 @@ export function useGigsWorkspace({
       }
 
       const savedGig = (await response.json()) as Gig
-      setGigs((current) => [
+      const nextGigs = [
         savedGig,
-        ...current.filter((gig) => gig.id !== savedGig.id),
-      ])
-      setSelectedGigId(savedGig.id)
+        ...gigs.filter((gig) => gig.id !== savedGig.id),
+      ]
+      setGigs(nextGigs)
       setSelectedGigIds([])
       setGigMode('edit')
       setGigForm(toEditableGigForm(savedGig))
       setGigStatus('Gig cloned. Update any details before saving.')
+      revealGig(savedGig, nextGigs)
       setIsGigEditorOpen(true)
     } catch (error) {
       setGigStatus(error instanceof Error ? error.message : 'Unable to clone gig.')
     } finally {
       setIsGigLoading(false)
     }
+  }
+
+  const revealGig = (nextGig: Gig, candidateGigs = gigs) => {
+    const visibleGigs = getVisibleGigs(candidateGigs, clientNamesById, {
+      searchQuery: gigSearchQuery,
+      quickFilter: gigQuickFilter,
+      showPastGigs,
+      sort: gigSort,
+      typeFilter: gigTypeFilter,
+    }, today)
+    const reveal = getGigReveal(nextGig, visibleGigs, today)
+
+    if (reveal.clearFilters) {
+      setGigSearchQuery('')
+      setGigQuickFilter('all')
+      setGigTypeFilter('all')
+      if (reveal.showPastGigs) {
+        setShowPastGigs(true)
+      }
+      setGigStatus(
+        reveal.showPastGigs
+          ? `Cleared filters and showed past gigs to open ${nextGig.title}.`
+          : `Cleared filters to open ${nextGig.title}.`
+      )
+    }
+
+    setSelectedGigId(nextGig.id)
   }
 
   const selectGig = (gigId: string) => {
@@ -765,7 +705,7 @@ export function useGigsWorkspace({
 
     cancelExternalResourceEdit()
 
-    setSelectedGigId(gigId)
+    revealGig(nextGig)
     return true
   }
 
@@ -1016,7 +956,6 @@ export function useGigsWorkspace({
 
       const nextGigs = gigs.filter((gig) => gig.id !== selectedGig.id)
       setGigs(nextGigs)
-      setSelectedGigId(nextGigs[0]?.id ?? '')
       setSelectedGigIds((current) => current.filter((gigId) => gigId !== selectedGig.id))
       setIsGigEditorOpen(false)
       setGigMode('create')
@@ -1112,7 +1051,7 @@ export function useGigsWorkspace({
 
   const openGigReceiptDraft = (savedGig: Gig) => {
     mergeSavedGig(savedGig)
-    setSelectedGigId(savedGig.id)
+    revealGig(savedGig, [savedGig, ...gigs.filter((gig) => gig.id !== savedGig.id)])
     onOpenSection('gigs')
     setGigMode('edit')
     setGigForm(toEditableGigForm(savedGig))
@@ -1335,22 +1274,15 @@ export function useGigsWorkspace({
 
       const savedGig = (await response.json()) as Gig
 
-      setGigs((current) => {
-        if (isEdit) {
-          return current.map((gig) => (gig.id === savedGig.id ? savedGig : gig))
-        }
-
-        return [
-          savedGig,
-          ...current.filter((gig) => gig.id !== savedGig.id),
-        ]
-      })
-
-      setSelectedGigId(savedGig.id)
+      const nextGigs = isEdit
+        ? gigs.map((gig) => (gig.id === savedGig.id ? savedGig : gig))
+        : [savedGig, ...gigs.filter((gig) => gig.id !== savedGig.id)]
+      setGigs(nextGigs)
       setGigMode('edit')
       setGigForm(toEditableGigForm(savedGig))
       setGigStatus(successMessage ?? (isEdit ? 'Gig updated.' : 'Gig created.'))
       setIsGigEditorOpen(!closeAfterSave)
+      revealGig(savedGig, nextGigs)
       if (previousGig) {
         await handleLinkedInvoiceAfterGigSave(
           previousGig,
@@ -1533,6 +1465,7 @@ export function useGigsWorkspace({
     selectedGig,
     selectedGigIds,
     selectedGigs,
+    showPastGigs,
     selectGig,
     setGigs,
     setGigQuickFilter,
@@ -1540,9 +1473,9 @@ export function useGigsWorkspace({
     setGigSearchQuery,
     setGigSort,
     setGigStatus,
+    setShowPastGigs,
     setIncludeStatementReceiptAppendix,
     setIncludeStatementReceiptAttachments,
-    setSelectedGigId,
     setSelectedGigIds,
     saveExpenseDraft,
     startGigCreate,
@@ -1551,7 +1484,7 @@ export function useGigsWorkspace({
     startExternalResourceEdit,
     submitExternalResource,
     uninvoicedGigCount: gigs.filter((gig) => !gig.isInvoiced && gig.status !== 'Cancelled').length,
-    upcomingGigCount: gigs.filter((gig) => gig.date >= new Date().toISOString().slice(0, 10)).length,
+    upcomingGigCount: gigs.filter((gig) => gig.date >= today).length,
     updateExternalResourceField,
     updateGigField,
     updateExpenseReimbursement,

--- a/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/design.md
+++ b/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The gig workspace currently sorts and filters the full gig collection in `useGigsWorkspace`, but initial load and deletion select the first API-order entry. The selected gig is resolved from all loaded gigs before the rendered list, so the detail panel can display a gig that is absent from the list. Date comparisons use UTC date strings even though the intended list behavior is based on the user's local calendar date.
+
+The change affects the hook that owns gig state, the gig-list controls, and callers that request selection, including invoice-line navigation. The API already supplies required date-only values and needs no change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make one ordered visible collection authoritative for both the gig list and normal selection behavior.
+- Default the workspace to active work while retaining an obvious, session-only historical visibility control.
+- Let explicit navigation reveal its requested target consistently, rather than creating separate exceptions for deep links and saved gigs.
+- Add deterministic frontend coverage for local-date and state-transition rules.
+
+**Non-Goals:**
+
+- Persisting list filters or `Show past gigs` between sessions.
+- Allowing undated gigs or changing backend gig validation.
+- Changing API filtering, database schema, lifecycle rules, or the existing sort options.
+- Retaining hidden selections after a passive list-state change.
+
+## Decisions
+
+### Use a pure gig-list state module
+
+Extract local-date formatting, historical inclusion, sorting/filtering, selection reconciliation, and target-reveal calculation from the React hook into a small pure frontend module. The hook remains responsible for React state, unsaved-editor confirmation, requests, and rendering inputs.
+
+This gives tests a supplied local `today` value rather than relying on browser timezone or clock behavior. Keeping the logic embedded in the hook would be a smaller code movement, but would require component-level test infrastructure to cover the same state matrix.
+
+### Apply one visibility pipeline before selection
+
+The pipeline is: historical inclusion, type and quick filters, text search, then the configured stable sort. The final ordered result is the list rendered by `GigsSection` and the only normal source for selected-gig resolution.
+
+The selected ID is retained only while it appears in that result. Otherwise the hook uses the first visible ID, or an empty ID for an empty list. This prevents detail/list disagreement during filter changes, edits, deletion, initial load, and server refreshes.
+
+### Treat explicit selection as intent to reveal
+
+All explicit selection paths route through `selectGig`. If the requested gig is not visible, the action clears the search, type, and quick filters; enables `Show past gigs` when the target is a normally hidden past `Completed` or `Cancelled` gig; and then selects the target. Sorting remains unchanged. A workspace status message states whether filters were cleared and/or past gigs were shown.
+
+This central rule covers row-adjacent programmatic navigation, invoice-line deep links, and newly saved gigs without separate per-caller behavior. Passive state changes do not reveal a hidden selection; they reconcile to the current list instead.
+
+### Keep historical visibility session-scoped
+
+`Show past gigs` is local React workspace state and resets with the rest of the workspace. Existing list controls are also session-scoped, and persistence would require a user-preference contract that is outside this change.
+
+### Add focused Vitest coverage plus targeted UAT
+
+Add the minimal Vitest setup needed to test the pure module. Unit tests cover visibility, local-date boundaries, sorting, reconciliation, and reveal instructions. Playwright UAT tests remain responsible for proving the control and invoice-line navigation wire those rules into the actual UI.
+
+## Risks / Trade-offs
+
+- [Extracted functions duplicate existing list logic during transition] -> Move the existing logic rather than retaining parallel implementations, and make the hook consume only the extracted result.
+- [React updates can temporarily combine stale selected IDs with new filters] -> Derive the rendered selected gig from the visible collection and reconcile the stored ID whenever list inputs change.
+- [Clearing filters on explicit navigation changes the user's view] -> Limit resets to an explicit request for a target that is not visible, preserve sort order, and display an explanatory status message.
+- [Local date tests can be timezone-sensitive] -> Pass a `YYYY-MM-DD` local date into pure functions rather than constructing dates from UTC timestamps in assertions.
+
+## Migration Plan
+
+The change is frontend-only and deploys with the existing application build. No data migration, API versioning, or rollback procedure is needed; reverting the frontend release restores the previous list behavior.
+
+## Open Questions
+
+None. The selected behavior is session-scoped history visibility and automatic target reveal for explicit selection.

--- a/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/proposal.md
+++ b/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Past completed and cancelled gigs crowd the default workspace even though upcoming and actionable work is more useful. The current selection is computed separately from the rendered list, so users can be shown an irrelevant or hidden gig detail.
+
+## What Changes
+
+- Hide past `Completed` and `Cancelled` gigs by default while retaining a clear session-scoped `Show past gigs` control.
+- Use the user's local calendar date for gig visibility and related list calculations.
+- Make the rendered, filtered, sorted gig collection the source of truth for the selected gig.
+- Preserve a valid selection, fall back to the first visible gig when it is removed from the view, and clear selection for an empty result set.
+- Make explicit gig navigation reveal a target by clearing incompatible list filters and enabling historical visibility when required, with a workspace message explaining the changed view.
+- Add focused frontend tests for visibility, sorting, selection reconciliation, and explicit target reveal, with UAT coverage for the rendered controls and navigation.
+
+## Capabilities
+
+### New Capabilities
+- `gig-list-visibility`: Defines historical gig visibility, list-derived selection, and explicit navigation behavior in the gig workspace.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects `frontend/glovelly-web/src/hooks/useGigsWorkspace.ts`, `frontend/glovelly-web/src/components/GigsSection.tsx`, and gig navigation in `frontend/glovelly-web/src/App.tsx`.
+- Adds a minimal frontend test runner and focused test files; existing Playwright UAT coverage and gig regression documentation will be extended.
+- No API, database, or persisted-preference change. Gig dates remain required by the existing backend contract.

--- a/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/specs/gig-list-visibility/spec.md
+++ b/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/specs/gig-list-visibility/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Default gig visibility prioritizes active work
+The system SHALL exclude a gig from the default gig workspace list only when its date is before the user's local calendar date and its status is `Completed` or `Cancelled`. Gigs dated today or later, and past `Draft` or `Confirmed` gigs, SHALL remain visible. Gig date comparisons SHALL use the local `YYYY-MM-DD` calendar date.
+
+#### Scenario: Past completed and cancelled gigs are hidden
+- **WHEN** the gig workspace opens with `Show past gigs` disabled
+- **THEN** past `Completed` and `Cancelled` gigs are excluded while other gigs remain eligible for the list
+
+#### Scenario: Past actionable gigs remain visible
+- **WHEN** the gig workspace contains past `Draft` or `Confirmed` gigs
+- **THEN** those gigs remain visible with `Show past gigs` disabled
+
+#### Scenario: A gig dated today remains visible
+- **WHEN** a gig's date equals the user's local calendar date
+- **THEN** the gig is not treated as historical for default visibility
+
+### Requirement: Users can include historical gigs
+The system SHALL provide a visually apparent `Show past gigs` control in the gig workspace. Enabling the control SHALL include otherwise hidden historical gigs while preserving the active search, type filter, quick filter, and sort order. The control state SHALL apply only to the current workspace session.
+
+#### Scenario: Historical visibility is enabled
+- **WHEN** a user enables `Show past gigs`
+- **THEN** normally hidden past `Completed` and `Cancelled` gigs participate in the current filtered and sorted list
+
+#### Scenario: Existing filters remain active
+- **WHEN** a user enables `Show past gigs` while search, type, or quick filters are active
+- **THEN** the historical gigs are evaluated by those active filters rather than replacing them
+
+### Requirement: Gig selection follows the visible ordered list
+The system SHALL derive initial and fallback gig selection from the same filtered and sorted collection rendered in the gig list. A selected gig SHALL remain selected while it remains visible, regardless of list reordering. If the selected gig is no longer visible, the system SHALL select the first visible gig, or clear selection when no gigs are visible.
+
+#### Scenario: Initial selection uses the first rendered gig
+- **WHEN** gig data is first loaded into the workspace
+- **THEN** the selected gig is the first gig after active visibility, filtering, and sorting are applied
+
+#### Scenario: Existing visible selection is retained
+- **WHEN** sorting or a non-excluding list change occurs while the selected gig remains visible
+- **THEN** the system keeps that gig selected instead of selecting the new first row
+
+#### Scenario: Hidden or deleted selection falls back
+- **WHEN** a selected gig is removed from the visible list by a filter, update, deletion, or refresh
+- **THEN** the system selects the first remaining visible gig or clears selection if the result is empty
+
+### Requirement: Explicit gig navigation reveals its target
+The system SHALL treat an explicit request to select a gig that is not in the visible list as intent to reveal that gig. It SHALL clear active search, type, and quick filters; SHALL enable `Show past gigs` when the target is a normally hidden historical gig; SHALL preserve sort order; and SHALL display a workspace message explaining the changed view.
+
+#### Scenario: Invoice-line navigation opens a hidden historical gig
+- **WHEN** a user follows an invoice-line link to a past `Completed` or `Cancelled` gig hidden by the current view
+- **THEN** the workspace enables `Show past gigs`, clears incompatible filters, selects the target, and displays an explanation
+
+#### Scenario: Saved gig is hidden by active filters
+- **WHEN** a newly saved gig is intentionally selected but is excluded by the current list filters
+- **THEN** the workspace clears incompatible filters, reveals and selects the saved gig, and displays an explanation
+
+#### Scenario: Explicit selection preserves sort order
+- **WHEN** explicit navigation reveals a gig that was hidden by filters
+- **THEN** the target is shown at its position in the existing sort order

--- a/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/tasks.md
+++ b/openspec/changes/archive/2026-07-25-improve-gig-list-visibility/tasks.md
@@ -1,0 +1,26 @@
+## 1. List-State Foundation
+
+- [x] 1.1 Add the minimal Vitest configuration and scripts required for frontend unit tests.
+- [x] 1.2 Extract pure local-date, historical visibility, filtering, sorting, selection reconciliation, and target-reveal functions for the gig workspace.
+- [x] 1.3 Add unit tests for default historical visibility, past Draft/Confirmed visibility, today boundary behavior, composed filters, and sort order.
+- [x] 1.4 Add unit tests for initial selection, preserved visible selection, fallback selection, empty results, and explicit target reveal instructions.
+
+## 2. Gig Workspace Behavior
+
+- [x] 2.1 Add session-scoped `Show past gigs` state and integrate the pure list-state result into `useGigsWorkspace`.
+- [x] 2.2 Reconcile stored and rendered selection against the final visible ordered gig list for load, refresh, filtering, editing, and deletion.
+- [x] 2.3 Route saved-gig and deep-link selection through the explicit target-reveal behavior, clearing incompatible filters and enabling historical visibility as needed.
+- [x] 2.4 Replace list-specific UTC date comparisons with the local calendar-date helper, including upcoming and summary calculations.
+
+## 3. Gig Workspace UI
+
+- [x] 3.1 Add an accessible, visually active `Show past gigs` control to the gig list controls.
+- [x] 3.2 Render the reconciled selection and appropriate empty-detail state when no gigs are visible.
+- [x] 3.3 Display a clear workspace status message when explicit navigation changes filters or historical visibility to reveal a gig.
+
+## 4. Regression Coverage
+
+- [x] 4.1 Extend Playwright UAT coverage for historical visibility, the `Show past gigs` control, and list-derived initial/fallback selection.
+- [x] 4.2 Extend invoice-line navigation UAT coverage for opening a historical gig hidden by the active view.
+- [x] 4.3 Update the gig section of `docs/uat/pre-merge-regression.md` with the historical visibility and target-reveal journey.
+- [x] 4.4 Run frontend unit tests, frontend lint/build, and the affected UAT suite.

--- a/openspec/specs/gig-list-visibility/spec.md
+++ b/openspec/specs/gig-list-visibility/spec.md
@@ -1,0 +1,63 @@
+# Gig List Visibility Specification
+
+## Purpose
+
+Define how the gig workspace prioritizes active work, includes historical gigs on demand, and maintains selection during list changes and explicit navigation.
+
+## Requirements
+
+### Requirement: Default gig visibility prioritizes active work
+The system SHALL exclude a gig from the default gig workspace list only when its date is before the user's local calendar date and its status is `Completed` or `Cancelled`. Gigs dated today or later, and past `Draft` or `Confirmed` gigs, SHALL remain visible. Gig date comparisons SHALL use the local `YYYY-MM-DD` calendar date.
+
+#### Scenario: Past completed and cancelled gigs are hidden
+- **WHEN** the gig workspace opens with `Show past gigs` disabled
+- **THEN** past `Completed` and `Cancelled` gigs are excluded while other gigs remain eligible for the list
+
+#### Scenario: Past actionable gigs remain visible
+- **WHEN** the gig workspace contains past `Draft` or `Confirmed` gigs
+- **THEN** those gigs remain visible with `Show past gigs` disabled
+
+#### Scenario: A gig dated today remains visible
+- **WHEN** a gig's date equals the user's local calendar date
+- **THEN** the gig is not treated as historical for default visibility
+
+### Requirement: Users can include historical gigs
+The system SHALL provide a visually apparent `Show past gigs` control in the gig workspace. Enabling the control SHALL include otherwise hidden historical gigs while preserving the active search, type filter, quick filter, and sort order. The control state SHALL apply only to the current workspace session.
+
+#### Scenario: Historical visibility is enabled
+- **WHEN** a user enables `Show past gigs`
+- **THEN** normally hidden past `Completed` and `Cancelled` gigs participate in the current filtered and sorted list
+
+#### Scenario: Existing filters remain active
+- **WHEN** a user enables `Show past gigs` while search, type, or quick filters are active
+- **THEN** the historical gigs are evaluated by those active filters rather than replacing them
+
+### Requirement: Gig selection follows the visible ordered list
+The system SHALL derive initial and fallback gig selection from the same filtered and sorted collection rendered in the gig list. A selected gig SHALL remain selected while it remains visible, regardless of list reordering. If the selected gig is no longer visible, the system SHALL select the first visible gig, or clear selection when no gigs are visible.
+
+#### Scenario: Initial selection uses the first rendered gig
+- **WHEN** gig data is first loaded into the workspace
+- **THEN** the selected gig is the first gig after active visibility, filtering, and sorting are applied
+
+#### Scenario: Existing visible selection is retained
+- **WHEN** sorting or a non-excluding list change occurs while the selected gig remains visible
+- **THEN** the system keeps that gig selected instead of selecting the new first row
+
+#### Scenario: Hidden or deleted selection falls back
+- **WHEN** a selected gig is removed from the visible list by a filter, update, deletion, or refresh
+- **THEN** the system selects the first remaining visible gig or clears selection if the result is empty
+
+### Requirement: Explicit gig navigation reveals its target
+The system SHALL treat an explicit request to select a gig that is not in the visible list as intent to reveal that gig. It SHALL clear active search, type, and quick filters; SHALL enable `Show past gigs` when the target is a normally hidden historical gig; SHALL preserve sort order; and SHALL display a workspace message explaining the changed view.
+
+#### Scenario: Invoice-line navigation opens a hidden historical gig
+- **WHEN** a user follows an invoice-line link to a past `Completed` or `Cancelled` gig hidden by the current view
+- **THEN** the workspace enables `Show past gigs`, clears incompatible filters, selects the target, and displays an explanation
+
+#### Scenario: Saved gig is hidden by active filters
+- **WHEN** a newly saved gig is intentionally selected but is excluded by the current list filters
+- **THEN** the workspace clears incompatible filters, reveals and selects the saved gig, and displays an explanation
+
+#### Scenario: Explicit selection preserves sort order
+- **WHEN** explicit navigation reveals a gig that was hidden by filters
+- **THEN** the target is shown at its position in the existing sort order

--- a/tests/Glovelly.Uat.Tests/GigListVisibilityTests.cs
+++ b/tests/Glovelly.Uat.Tests/GigListVisibilityTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public sealed class GigListVisibilityTests : InvoiceUatTestBase
+{
+    [Fact]
+    public Task InvoiceLineNavigationRevealsHistoricalGig() => RunWithDiagnosticsAsync(
+        nameof(InvoiceLineNavigationRevealsHistoricalGig),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Historical Link Client";
+            var gigTitle = $"{runId} Historical Link Gig";
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(
+                clientName,
+                gigTitle,
+                DateTime.UtcNow.AddDays(-14).ToString("yyyy-MM-dd"),
+                status: "Completed");
+            await GenerateInvoiceAndWaitForPreviewAsync();
+            await OpenPreviewedInvoiceAsync();
+
+            await Page.GetByTestId("nav-gigs").ClickAsync();
+            await Page.GetByTestId("show-past-gigs-button").ClickAsync();
+            await Assertions.Expect(GigCard(gigTitle)).ToHaveCountAsync(0);
+
+            await Page.GetByTestId("nav-invoices").ClickAsync();
+            await OpenInvoiceLinesAsync();
+            await OpenGigFromInvoiceLineAsync(gigTitle);
+
+            await Assertions.Expect(Page.GetByTestId("show-past-gigs-button")).ToHaveAttributeAsync("aria-pressed", "true");
+            await Assertions.Expect(GigCard(gigTitle)).ToBeVisibleAsync();
+            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = gigTitle })).ToBeVisibleAsync();
+        });
+
+    [Fact]
+    public Task HistoricalVisibilityReconcilesSelection() => RunWithDiagnosticsAsync(
+        nameof(HistoricalVisibilityReconcilesSelection),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Visibility Client";
+            var activeGig = $"{runId} Active Gig";
+            var historicalGig = $"{runId} Historical Gig";
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(clientName, activeGig, DateTime.UtcNow.AddDays(14).ToString("yyyy-MM-dd"));
+            await CreateGigAsync(
+                clientName,
+                historicalGig,
+                DateTime.UtcNow.AddDays(-14).ToString("yyyy-MM-dd"),
+                status: "Draft");
+
+            await EnsureGigEditorOpenAsync();
+            await Page.GetByTestId("gig-status-select").SelectOptionAsync("Completed");
+            await SaveGigAndWaitForResponseAsync();
+
+            var showPastGigs = Page.GetByTestId("show-past-gigs-button");
+            await Assertions.Expect(showPastGigs).ToHaveAttributeAsync("aria-pressed", "true");
+            await Assertions.Expect(GigCard(historicalGig)).ToBeVisibleAsync();
+
+            await Page.GetByTestId("gig-search-input").FillAsync(runId);
+
+            await showPastGigs.ClickAsync();
+            await Assertions.Expect(GigCard(historicalGig)).ToHaveCountAsync(0);
+            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = activeGig })).ToBeVisibleAsync();
+
+            await showPastGigs.ClickAsync();
+            await Assertions.Expect(GigCard(historicalGig)).ToBeVisibleAsync();
+            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = activeGig })).ToBeVisibleAsync();
+        });
+}

--- a/verify.sh
+++ b/verify.sh
@@ -8,6 +8,10 @@ echo "Running backend tests..."
 dotnet test "$ROOT_DIR/glovelly.sln" -m:1
 
 echo
+echo "Running frontend tests..."
+npm --prefix "$ROOT_DIR/frontend/glovelly-web" run test
+
+echo
 echo "Running frontend lint..."
 npm --prefix "$ROOT_DIR/frontend/glovelly-web" run lint
 


### PR DESCRIPTION
## Summary
- hide past completed and cancelled gigs by default, with a session-scoped Show past gigs control
- derive gig selection from the visible sorted list and reveal explicit navigation targets by resetting incompatible filters
- add Vitest coverage, Playwright UAT scenarios, regression documentation, and frontend test execution in local/CI verification

Closes #186
Closes #212

## Verification
- `./verify.sh`
- Focused browser UATs were compiled but not executed locally because `GLOVELLY_UAT_BASE_URL` is not configured.