### PR TITLE
Make dashboard cards context aware

### DIFF
--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -54,6 +54,7 @@ jobs:
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gcp_location: 'global'
           gcp_project_id: '${{ vars.GCP_PROJECT_ID }}'

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -98,6 +98,7 @@ jobs:
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gcp_location: 'global'
           gcp_project_id: '${{ vars.GCP_PROJECT_ID }}'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -65,6 +65,7 @@ jobs:
           ISSUE_TITLE: '${{ github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.issue.body }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gcp_location: 'global'
           gcp_project_id: '${{ vars.GCP_PROJECT_ID }}'

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -32,6 +32,7 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
         Assert.Equal("Paid", updatedInvoice.GetProperty("status").GetString());
         Assert.Equal(TestAuthContext.UserId, updatedInvoice.GetProperty("updatedByUserId").GetGuid());
         Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("statusUpdatedUtc").ValueKind);
+        Assert.Equal("2026-01-01", updatedInvoice.GetProperty("paidOn").GetString());
     }
 
     [Fact]
@@ -195,6 +196,7 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
 
         var updatedInvoice = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
         Assert.Equal("Draft", updatedInvoice.GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.Null, updatedInvoice.GetProperty("paidOn").ValueKind);
         Assert.Equal(JsonValueKind.String, updatedInvoice.GetProperty("statusUpdatedUtc").ValueKind);
         Assert.Equal(expectedInvoiceDate.ToString("yyyy-MM-dd"), updatedInvoice.GetProperty("invoiceDate").GetString());
         Assert.Equal(expectedInvoiceDate.AddDays(14).ToString("yyyy-MM-dd"), updatedInvoice.GetProperty("dueDate").GetString());

--- a/backend/Glovelly.Api.Tests/PaidIncomeSummaryEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/PaidIncomeSummaryEndpointsTests.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
+using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class PaidIncomeSummaryEndpointsTests : IClassFixture<GlovellyApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly GlovellyApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public PaidIncomeSummaryEndpointsTests(GlovellyApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Theory]
+    [InlineData(2026, 4, 6, 2026, 4, 6, 2027, 4, 5)]
+    [InlineData(2027, 4, 5, 2026, 4, 6, 2027, 4, 5)]
+    public void FinancialYear_UsesInclusiveSixthAprilToFifthAprilBoundaries(
+        int year,
+        int month,
+        int day,
+        int expectedStartYear,
+        int expectedStartMonth,
+        int expectedStartDay,
+        int expectedEndYear,
+        int expectedEndMonth,
+        int expectedEndDay)
+    {
+        var period = UkFinancialYear.ForDate(new DateOnly(year, month, day));
+
+        Assert.Equal(new DateOnly(expectedStartYear, expectedStartMonth, expectedStartDay), period.Start);
+        Assert.Equal(new DateOnly(expectedEndYear, expectedEndMonth, expectedEndDay), period.End);
+    }
+
+    [Fact]
+    public void FinancialYear_UsesTheEuropeLondonLocalDate()
+    {
+        var period = UkFinancialYear.Current(
+            new FixedTimeProvider(new DateTimeOffset(2026, 4, 5, 23, 30, 0, TimeSpan.Zero)));
+
+        Assert.Equal(new DateOnly(2026, 4, 6), period.Start);
+        Assert.Equal(new DateOnly(2027, 4, 5), period.End);
+    }
+
+    [Fact]
+    public async Task GetPaidIncomeSummary_IncludesOnlyVisiblePaidInvoicesWithinTheFinancialYear()
+    {
+        var includedInvoiceId = Guid.NewGuid();
+        var secondIncludedInvoiceId = Guid.NewGuid();
+        var excludedPaidDateInvoiceId = Guid.NewGuid();
+        var excludedStatusInvoiceId = Guid.NewGuid();
+        var missingPaidDateInvoiceId = Guid.NewGuid();
+        var alternateUserInvoiceId = Guid.NewGuid();
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            AddInvoice(db, includedInvoiceId, InvoiceStatus.Paid, new DateOnly(2025, 4, 6), 125m, TestAuthContext.UserId);
+            AddInvoice(db, secondIncludedInvoiceId, InvoiceStatus.Paid, new DateOnly(2026, 4, 5), 75m, TestAuthContext.UserId);
+            AddInvoice(db, excludedPaidDateInvoiceId, InvoiceStatus.Paid, new DateOnly(2025, 4, 5), 250m, TestAuthContext.UserId);
+            AddInvoice(db, excludedStatusInvoiceId, InvoiceStatus.Issued, new DateOnly(2026, 1, 1), 375m, TestAuthContext.UserId);
+            AddInvoice(db, missingPaidDateInvoiceId, InvoiceStatus.Paid, null, 425m, TestAuthContext.UserId);
+            AddInvoice(db, alternateUserInvoiceId, InvoiceStatus.Paid, new DateOnly(2026, 1, 1), 500m, TestAuthContext.AlternateUserId);
+            db.SaveChanges();
+        }
+
+        var response = await _client.GetAsync("/invoices/paid-income-summary", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var summary = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("2025-04-06", summary.GetProperty("financialYearStart").GetString());
+        Assert.Equal("2026-04-05", summary.GetProperty("financialYearEnd").GetString());
+        Assert.Equal(200m, summary.GetProperty("total").GetDecimal());
+
+        var invoiceIds = summary.GetProperty("invoiceIds").EnumerateArray().Select(value => value.GetGuid()).ToList();
+        Assert.Equal(2, invoiceIds.Count);
+        Assert.Contains(includedInvoiceId, invoiceIds);
+        Assert.Contains(secondIncludedInvoiceId, invoiceIds);
+        Assert.Equal(125m + 75m, summary.GetProperty("total").GetDecimal());
+        Assert.DoesNotContain(excludedPaidDateInvoiceId, invoiceIds);
+        Assert.DoesNotContain(excludedStatusInvoiceId, invoiceIds);
+        Assert.DoesNotContain(missingPaidDateInvoiceId, invoiceIds);
+        Assert.DoesNotContain(alternateUserInvoiceId, invoiceIds);
+    }
+
+    [Fact]
+    public async Task GetPaidIncomeSummary_IncludesPaidInvoicesWithoutLinesAsZeroIncome()
+    {
+        var zeroLineInvoiceId = Guid.NewGuid();
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            AddInvoice(
+                db,
+                zeroLineInvoiceId,
+                InvoiceStatus.Paid,
+                new DateOnly(2026, 1, 1),
+                0m,
+                TestAuthContext.UserId,
+                includeLine: false);
+            db.SaveChanges();
+        }
+
+        var response = await _client.GetAsync("/invoices/paid-income-summary", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var summary = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(0m, summary.GetProperty("total").GetDecimal());
+        Assert.Contains(
+            zeroLineInvoiceId,
+            summary.GetProperty("invoiceIds").EnumerateArray().Select(value => value.GetGuid()));
+    }
+
+    private static void AddInvoice(
+        AppDbContext db,
+        Guid invoiceId,
+        InvoiceStatus status,
+        DateOnly? paidOn,
+        decimal total,
+        Guid ownerId,
+        bool includeLine = true)
+    {
+        db.Invoices.Add(new Invoice
+        {
+            Id = invoiceId,
+            InvoiceNumber = $"TEST-{invoiceId:N}",
+            ClientId = TestData.FoxAndFinchId,
+            InvoiceDate = new DateOnly(2026, 1, 1),
+            DueDate = new DateOnly(2026, 1, 15),
+            Status = status,
+            PaidOn = paidOn,
+            CreatedByUserId = ownerId,
+            UpdatedByUserId = ownerId,
+            Lines = includeLine
+                ?
+                [
+                    new InvoiceLine
+                    {
+                        Id = Guid.NewGuid(),
+                        InvoiceId = invoiceId,
+                        CreatedByUserId = ownerId,
+                        CreatedUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                        SortOrder = 1,
+                        Type = InvoiceLineType.PerformanceFee,
+                        Description = "Test income",
+                        Quantity = 1,
+                        UnitPrice = total,
+                    },
+                ]
+                : [],
+        });
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/backend/Glovelly.Api/Data/Configuration/InvoiceConfiguration.cs
+++ b/backend/Glovelly.Api/Data/Configuration/InvoiceConfiguration.cs
@@ -14,6 +14,8 @@ internal sealed class InvoiceConfiguration : IEntityTypeConfiguration<Invoice>
         entity.Property(invoice => invoice.Status)
             .HasConversion<string>()
             .HasMaxLength(50);
+        entity.Property(invoice => invoice.PaidOn)
+            .HasColumnType("date");
         entity.Property(invoice => invoice.ReissueCount)
             .HasDefaultValue(0);
         entity.Property(invoice => invoice.DeliveryCount)

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpointSupport.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpointSupport.cs
@@ -1,4 +1,6 @@
 using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace Glovelly.Api.Endpoints;
@@ -24,5 +26,16 @@ internal static class InvoiceEndpointSupport
         return firstGigDate == default
             ? null
             : new DateOnly(firstGigDate.Year, firstGigDate.Month, 1);
+    }
+
+    public static IQueryable<Invoice> WhereContributingToPaidIncome(
+        this IQueryable<Invoice> query,
+        FinancialYearPeriod period)
+    {
+        return query.Where(invoice =>
+            invoice.Status == InvoiceStatus.Paid &&
+            invoice.PaidOn.HasValue &&
+            invoice.PaidOn.Value >= period.Start &&
+            invoice.PaidOn.Value <= period.End);
     }
 }

--- a/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/InvoiceEndpoints.cs
@@ -27,6 +27,31 @@ public static class InvoiceEndpoints
             return Results.Ok(invoices);
         });
 
+        group.MapGet("/paid-income-summary", async (
+            AppDbContext db,
+            ClaimsPrincipal user,
+            ICurrentUserAccessor currentUserAccessor,
+            TimeProvider timeProvider,
+            CancellationToken cancellationToken) =>
+        {
+            var userId = currentUserAccessor.TryGetUserId(user);
+            var period = UkFinancialYear.Current(timeProvider);
+            var contributions = await db.Invoices
+                .WhereVisibleTo(userId)
+                .WhereContributingToPaidIncome(period)
+                .AsNoTracking()
+                .Select(invoice => new PaidIncomeContribution(
+                    invoice.Id,
+                    invoice.Lines.Sum(line => (decimal?)(line.Quantity * line.UnitPrice)) ?? 0m))
+                .ToListAsync(cancellationToken);
+
+            return Results.Ok(new InvoicePaidIncomeSummary(
+                period.Start,
+                period.End,
+                contributions.Sum(contribution => contribution.Total),
+                contributions.Select(contribution => contribution.Id).ToList()));
+        });
+
         group.MapGet("/{id:guid}/pdf", async (
             Guid id,
             AppDbContext db,
@@ -118,6 +143,7 @@ public static class InvoiceEndpoints
             invoice.PdfContentType = null;
             invoice.PdfSizeBytes = null;
             invoice.PdfGeneratedAt = null;
+            invoice.PaidOn = null;
             invoice.Client = null;
             invoice.Lines = new List<InvoiceLine>();
             EndpointSupport.StampCreate(invoice, userId);
@@ -136,6 +162,7 @@ public static class InvoiceEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IInvoiceWorkflowService invoiceWorkflowService,
+            TimeProvider timeProvider,
             IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -195,6 +222,9 @@ public static class InvoiceEndpoints
             {
                 invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow;
                 invoice.Status = request.Status;
+                invoice.PaidOn = requestedStatus is InvoiceStatus.Paid
+                    ? UkFinancialYear.CurrentDate(timeProvider)
+                    : null;
             }
             EndpointSupport.StampUpdate(invoice, userId);
 
@@ -211,6 +241,7 @@ public static class InvoiceEndpoints
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
             IInvoiceWorkflowService invoiceWorkflowService,
+            TimeProvider timeProvider,
             IBusinessLifecycleSignal businessLifecycleSignal) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
@@ -251,6 +282,9 @@ public static class InvoiceEndpoints
 
             invoice.Status = request.Status;
             invoice.StatusUpdatedUtc = DateTimeOffset.UtcNow;
+            invoice.PaidOn = request.Status is InvoiceStatus.Paid
+                ? UkFinancialYear.CurrentDate(timeProvider)
+                : null;
             EndpointSupport.StampUpdate(invoice, userId);
             await db.SaveChangesAsync();
             await businessLifecycleSignal.TrackInvoiceAsync(invoice);
@@ -498,6 +532,12 @@ public static class InvoiceEndpoints
         return group;
     }
 
+    private sealed record PaidIncomeContribution(Guid Id, decimal Total);
+    private sealed record InvoicePaidIncomeSummary(
+        DateOnly FinancialYearStart,
+        DateOnly FinancialYearEnd,
+        decimal Total,
+        IReadOnlyList<Guid> InvoiceIds);
     private sealed record InvoiceStatusUpdateRequest(InvoiceStatus Status);
     private sealed record InvoiceDescriptionUpdateRequest(string? Description);
     private sealed record InvoiceAdjustmentCreateRequest(decimal Amount, string Reason);

--- a/backend/Glovelly.Api/Models/Invoice.cs
+++ b/backend/Glovelly.Api/Models/Invoice.cs
@@ -14,6 +14,7 @@ public sealed class Invoice
     public DateOnly DueDate { get; set; }
     public InvoiceStatus Status { get; set; } = InvoiceStatus.Draft;
     public DateTimeOffset? StatusUpdatedUtc { get; set; }
+    public DateOnly? PaidOn { get; set; }
     public DateTimeOffset? FirstIssuedUtc { get; set; }
     public Guid? FirstIssuedByUserId { get; set; }
     public int ReissueCount { get; set; }

--- a/backend/Glovelly.Api/Services/InvoiceWorkflowService.cs
+++ b/backend/Glovelly.Api/Services/InvoiceWorkflowService.cs
@@ -238,6 +238,7 @@ public sealed class InvoiceWorkflowService(
             cancellationToken);
         invoice.Status = InvoiceStatus.Draft;
         invoice.StatusUpdatedUtc = reissuedUtc;
+        invoice.PaidOn = null;
         invoice.ReissueCount += 1;
         invoice.LastReissuedUtc = reissuedUtc;
         invoice.LastReissuedByUserId = userId;

--- a/backend/Glovelly.Api/Services/UkFinancialYear.cs
+++ b/backend/Glovelly.Api/Services/UkFinancialYear.cs
@@ -1,0 +1,31 @@
+namespace Glovelly.Api.Services;
+
+public static class UkFinancialYear
+{
+    private static readonly TimeZoneInfo LondonTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
+
+    public static FinancialYearPeriod Current(TimeProvider timeProvider)
+    {
+        var londonNow = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), LondonTimeZone);
+        return ForDate(DateOnly.FromDateTime(londonNow.DateTime));
+    }
+
+    public static DateOnly CurrentDate(TimeProvider timeProvider)
+    {
+        var londonNow = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), LondonTimeZone);
+        return DateOnly.FromDateTime(londonNow.DateTime);
+    }
+
+    public static FinancialYearPeriod ForDate(DateOnly date)
+    {
+        var startYear = date.Month < 4 || (date.Month == 4 && date.Day < 6)
+            ? date.Year - 1
+            : date.Year;
+
+        return new FinancialYearPeriod(
+            new DateOnly(startYear, 4, 6),
+            new DateOnly(startYear + 1, 4, 5));
+    }
+}
+
+public sealed record FinancialYearPeriod(DateOnly Start, DateOnly End);

--- a/backend/Glovelly.Migrations/Migrations/20260727204611_AddInvoicePaidOn.Designer.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260727204611_AddInvoicePaidOn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Glovelly.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Glovelly.Migrations.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727204611_AddInvoicePaidOn")]
+    partial class AddInvoicePaidOn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Glovelly.Migrations/Migrations/20260727204611_AddInvoicePaidOn.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260727204611_AddInvoicePaidOn.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Glovelly.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvoicePaidOn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "PaidOn",
+                table: "Invoices",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "Invoices"
+                SET "PaidOn" = ("StatusUpdatedUtc" AT TIME ZONE 'Europe/London')::date
+                WHERE "Status" = 'Paid' AND "StatusUpdatedUtc" IS NOT NULL;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PaidOn",
+                table: "Invoices");
+        }
+    }
+}

--- a/docs/uat/invoices.md
+++ b/docs/uat/invoices.md
@@ -222,6 +222,24 @@ Expected result: only draft invoices expose an editable Description and save act
 
 Status transitions are explicit, delivery state is recorded, delivered drafts can be promoted to issued by choice, issuing an invoice can complete linked gigs by choice, declined prompts leave existing invoice/gig state unchanged, PDF remains downloadable, and receipt attachments are included only when requested.
 
+## Paid Income Dashboard
+
+> **Automation:** Backend integration tests cover payment-date lifecycle, UK financial-year boundaries, income inclusion, ownership, and total reconciliation. Frontend Vitest coverage verifies the invoice dashboard card and its distinct loading, zero, and error states.
+
+### Steps
+
+1. Open an issued or overdue invoice and mark it as Paid.
+2. Open the Invoices workspace and confirm the `Income this financial year` dashboard card includes the payment.
+3. Confirm the card displays the current UK financial-year period, from 6 April through 5 April.
+4. Select the income card.
+5. Confirm the invoice list shows the `Income this financial year` filter and only invoices contributing to the card total.
+6. Re-issue the paid invoice.
+7. Return to the Invoices workspace and confirm that invoice no longer contributes to the income card or its drill-down.
+
+### Expected Results
+
+Marking an invoice Paid records its payment date using the current UK date. The dashboard total includes only paid invoices received within the displayed financial year, the drill-down reconciles with that total, and reissuing the invoice clears its payment contribution.
+
 ## Notes
 
 - Issued invoices should not be silently changed by later gig edits.

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -1046,7 +1046,7 @@
   margin-bottom: 2px;
 }
 
-.outstanding-card strong {
+.dashboard-card-ready strong {
   display: block;
   font-family: var(--display);
   font-size: clamp(2rem, 6vw, 3.1rem);
@@ -1054,10 +1054,15 @@
   line-height: 0.95;
 }
 
-.invoice-action-card {
+.dashboard-card-error {
   background:
-    linear-gradient(135deg, color-mix(in srgb, #f47d2a 18%, transparent), transparent 64%),
+    linear-gradient(135deg, color-mix(in srgb, #a12828 14%, transparent), transparent 64%),
     var(--surface-highlight);
+}
+
+.dashboard-card-loading strong {
+  color: var(--muted-strong);
+  font-size: 1.1rem;
 }
 
 .compact-action {
@@ -3202,7 +3207,7 @@ button:disabled {
     display: none;
   }
 
-  .outstanding-card strong {
+  .dashboard-card-ready strong {
     font-size: clamp(1.5rem, 9vw, 2.2rem);
   }
 

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -17,7 +17,7 @@ import {
   SignInScreen,
   UserSettingsModal,
 } from './AppSections'
-import type { AppNavigationItem, DashboardSummary } from './AppSections'
+import type { AppNavigationItem } from './AppSections'
 import {
   buildApiUrl,
   buildReturnUrl,
@@ -34,7 +34,7 @@ import {
   invoiceEmailBodyTokens,
   invoiceFilenameTokens,
 } from './invoicePreview'
-import { formatCurrency, formatDate } from './formatters'
+import { getDashboardCards } from './dashboardCards'
 import { useAdminWorkspace } from './hooks/useAdminWorkspace'
 import { useClientsWorkspace } from './hooks/useClientsWorkspace'
 import { useGigsWorkspace } from './hooks/useGigsWorkspace'
@@ -95,6 +95,7 @@ function App({ appMetadata }: AppProps) {
   const { setThemePreference, themePreference } = useThemePreference()
   const [monthlyInvoiceMonth, setMonthlyInvoiceMonth] = useState(getCurrentMonthValue)
   const [monthlyInvoiceStatus, setMonthlyInvoiceStatus] = useState('')
+  const [invoiceListScrollRequest, setInvoiceListScrollRequest] = useState(0)
   const [isGigImportsOpen, setIsGigImportsOpen] = useState(false)
   const [forScoreSnapshot, setForScoreSnapshot] = useState<ForScoreLibrarySnapshot | null>(null)
   const [forScoreLibraryStatus, setForScoreLibraryStatus] = useState('No forScore library snapshot imported yet.')
@@ -316,6 +317,8 @@ function App({ appMetadata }: AppProps) {
     isInvoiceEditorOpen,
     issuedInvoiceCount,
     isInvoiceLoading,
+    loadPaidIncomeSummary,
+    paidIncomeSummary,
     resetInvoicesWorkspace,
     selectedInvoice,
     setAdjustmentAmount,
@@ -563,6 +566,12 @@ function App({ appMetadata }: AppProps) {
       }
     }
   }, [expireSession, isAuthenticated, setInvoices])
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      void loadPaidIncomeSummary()
+    }
+  }, [isAuthenticated, loadPaidIncomeSummary])
 
   useWorkspaceEvents({
     enabled: isAuthenticated,
@@ -1033,73 +1042,19 @@ function App({ appMetadata }: AppProps) {
     (count, batch) => count + batch.pendingCount + batch.acceptedCount,
     0
   )
-  const nextDashboardGig = useMemo(() => {
-    const today = new Date().toISOString().slice(0, 10)
-
-    return [...gigs]
-      .filter((gig) => gig.status !== 'Cancelled' && gig.date >= today)
-      .sort((left, right) => {
-        const dateComparison = left.date.localeCompare(right.date)
-        if (dateComparison !== 0) {
-          return dateComparison
-        }
-
-        return left.title.localeCompare(right.title)
-      })[0] ?? null
-  }, [gigs])
-
-  const dashboardInvoiceCandidate = useMemo(() => {
-    const today = new Date().toISOString().slice(0, 10)
-
-    return [...gigs]
-      .filter(
-        (gig) =>
-          !gig.isInvoiced &&
-          gig.status !== 'Cancelled' &&
-          gig.status !== 'Draft' &&
-          gig.date <= today
-      )
-      .sort((left, right) => {
-        const dateComparison = right.date.localeCompare(left.date)
-        if (dateComparison !== 0) {
-          return dateComparison
-        }
-
-        const statusPriority = (gig: Gig) => (gig.status === 'Completed' ? 0 : 1)
-        const statusComparison = statusPriority(left) - statusPriority(right)
-        if (statusComparison !== 0) {
-          return statusComparison
-        }
-
-        return left.title.localeCompare(right.title)
-      })[0] ?? null
-  }, [gigs])
-
-  const dashboardSummary: DashboardSummary = useMemo(() => {
-    const outstandingInvoices = invoices.filter(
-      (invoice) => invoice.status !== 'Paid' && invoice.status !== 'Cancelled'
-    )
-    const toGigSummary = (gig: Gig) => ({
-      title: gig.title,
-      clientName: clientNamesById.get(gig.clientId) ?? 'Unknown client',
-      dateLabel: formatDate(gig.date),
-      venue: gig.venue || 'No venue set',
-    })
-
-    return {
-      outstandingBalanceLabel: formatCurrency(
-        outstandingInvoices.reduce((total, invoice) => total + invoice.total, 0)
-      ),
-      outstandingInvoiceCount: outstandingInvoices.length,
-      nextGig: nextDashboardGig ? toGigSummary(nextDashboardGig) : null,
-      invoiceCandidate: dashboardInvoiceCandidate
-        ? {
-            ...toGigSummary(dashboardInvoiceCandidate),
-            feeLabel: formatCurrency(dashboardInvoiceCandidate.fee),
-          }
-        : null,
-    }
-  }, [clientNamesById, dashboardInvoiceCandidate, invoices, nextDashboardGig])
+  const dashboardCards = useMemo(
+    () =>
+      getDashboardCards({
+        activeSection,
+        clients,
+        gigs,
+        invoices,
+        isWorkspaceLoading: isLoading,
+        paidIncomeSummary,
+        today: new Date().toISOString().slice(0, 10),
+      }),
+    [activeSection, clients, gigs, invoices, isLoading, paidIncomeSummary]
+  )
 
   const signIn = () => {
     const loginUrl = buildApiUrl(
@@ -1454,33 +1409,17 @@ function App({ appMetadata }: AppProps) {
     }
   }
 
-  const openDashboardNextGig = () => {
-    if (!nextDashboardGig) {
-      return
-    }
-
-    if (!selectGig(nextDashboardGig.id)) {
-      return
-    }
-
-    setSelectedGigIds([])
-    setGigSearchQuery('')
-    setActiveSection('gigs')
-  }
-
-  const generateDashboardInvoice = () => {
-    if (!dashboardInvoiceCandidate) {
-      return
-    }
-
-    if (!selectGig(dashboardInvoiceCandidate.id)) {
-      return
-    }
-
-    setSelectedGigIds([])
-    setGigSearchQuery('')
-    setActiveSection('gigs')
-    void handleGenerateInvoice(dashboardInvoiceCandidate)
+  const handleDashboardCardAction = (action: 'invoices-outstanding' | 'invoices-overdue' | 'invoices-income') => {
+    setActiveSection('invoices')
+    setInvoiceSearchQuery('')
+    setInvoiceQuickFilter(
+      action === 'invoices-income'
+        ? 'income-this-financial-year'
+        : action === 'invoices-overdue'
+          ? 'overdue'
+          : 'outstanding'
+    )
+    setInvoiceListScrollRequest((request) => request + 1)
   }
 
   const handleGenerateMonthlyInvoice = async () => {
@@ -1801,6 +1740,7 @@ function App({ appMetadata }: AppProps) {
         onSelectInvoice={setSelectedInvoiceId}
         onSortChange={setInvoiceSort}
         onStartEditing={startInvoiceEdit}
+        scrollToListRequest={invoiceListScrollRequest}
         sellerProfileNotice={sellerProfileNotice}
         selectedInvoice={selectedInvoice}
       />
@@ -1813,11 +1753,10 @@ function App({ appMetadata }: AppProps) {
       authUser={authUser}
       currentSection={currentSection}
       currentSectionContent={currentSectionContent}
-      dashboardSummary={dashboardSummary}
+      dashboardCards={dashboardCards}
       isAdmin={isAdmin}
       isAdminLoading={isAdminLoading}
       isGigLoading={isGigLoading}
-      isInvoiceLoading={isInvoiceLoading}
       isLoading={isLoading}
       isProfileMenuOpen={isProfileMenuOpen}
       isQuickAttachmentSaving={isQuickAttachmentSaving}
@@ -1826,9 +1765,8 @@ function App({ appMetadata }: AppProps) {
       isUserSettingsSaving={isUserSettingsSaving}
       navigationItems={navigationItems}
       pendingGigImportCount={pendingGigImportCount}
-      onGenerateDashboardInvoice={generateDashboardInvoice}
+      onDashboardCardAction={handleDashboardCardAction}
       onOpenGigImports={openGigImports}
-      onOpenNextGig={openDashboardNextGig}
       onOpenSellerProfile={openSellerProfile}
       onOpenConnectedServices={openConnectedServices}
       onOpenUserSettings={openUserSettings}

--- a/frontend/glovelly-web/src/AppSections.tsx
+++ b/frontend/glovelly-web/src/AppSections.tsx
@@ -16,4 +16,4 @@ export {
   SignInScreen,
   UserSettingsModal,
 } from './components'
-export type { AppNavigationItem, DashboardSummary } from './components'
+export type { AppNavigationItem } from './components'

--- a/frontend/glovelly-web/src/components/AppShell.tsx
+++ b/frontend/glovelly-web/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import type {
   ThemePreference,
 } from '../types'
 import { formatBuildMetadata } from '../formatters'
+import type { DashboardCard, DashboardCardAction } from '../dashboardCards'
 
 export type AppNavigationItem = {
   id: AppSection
@@ -17,24 +18,6 @@ export type AppNavigationItem = {
   disabled?: boolean
 }
 
-export type DashboardGigSummary = {
-  title: string
-  clientName: string
-  dateLabel: string
-  venue: string
-}
-
-export type DashboardInvoiceCandidate = DashboardGigSummary & {
-  feeLabel: string
-}
-
-export type DashboardSummary = {
-  outstandingBalanceLabel: string
-  outstandingInvoiceCount: number
-  nextGig: DashboardGigSummary | null
-  invoiceCandidate: DashboardInvoiceCandidate | null
-}
-
 type AppShellProps = {
   activeSection: AppSection
   appMetadata: AppMetadata
@@ -42,11 +25,10 @@ type AppShellProps = {
   children: ReactNode
   currentSection: AppNavigationItem | undefined
   currentSectionContent: ReactNode
-  dashboardSummary: DashboardSummary
+  dashboardCards: DashboardCard[]
   isAdmin: boolean
   isAdminLoading: boolean
   isGigLoading: boolean
-  isInvoiceLoading: boolean
   isLoading: boolean
   isProfileMenuOpen: boolean
   isQuickAttachmentSaving: boolean
@@ -56,9 +38,8 @@ type AppShellProps = {
   navigationItems: AppNavigationItem[]
   pendingGigImportCount: number
   onOpenGigImports: () => void
-  onOpenNextGig: () => void
   onOpenSellerProfile: () => void
-  onGenerateDashboardInvoice: () => void
+  onDashboardCardAction: (action: DashboardCardAction) => void
   onOpenConnectedServices: () => void
   onOpenUserSettings: () => void
   onProfileMenuToggle: () => void
@@ -79,11 +60,10 @@ export function AppShell({
   children,
   currentSection,
   currentSectionContent,
-  dashboardSummary,
+  dashboardCards,
   isAdmin,
   isAdminLoading,
   isGigLoading,
-  isInvoiceLoading,
   isLoading,
   isProfileMenuOpen,
   isQuickAttachmentSaving,
@@ -93,9 +73,8 @@ export function AppShell({
   navigationItems,
   pendingGigImportCount,
   onOpenGigImports,
-  onOpenNextGig,
   onOpenSellerProfile,
-  onGenerateDashboardInvoice,
+  onDashboardCardAction,
   onOpenConnectedServices,
   onOpenUserSettings,
   onProfileMenuToggle,
@@ -365,63 +344,27 @@ export function AppShell({
 
             <div className="content-header-aside">
               <div className="dashboard-summary" aria-label="Dashboard summary">
-                <article className="dashboard-card outstanding-card" data-testid="dashboard-outstanding-balance">
-                  <p className="section-label">Outstanding balance</p>
-                  <strong>{dashboardSummary.outstandingBalanceLabel}</strong>
-                  <span>
-                    {dashboardSummary.outstandingInvoiceCount === 1
-                      ? '1 invoice needs attention'
-                      : `${dashboardSummary.outstandingInvoiceCount} invoices need attention`}
-                  </span>
-                </article>
-
-                <article className="dashboard-card" data-testid="dashboard-next-gig">
-                  <p className="section-label">Next gig</p>
-                  {dashboardSummary.nextGig ? (
-                    <>
-                      <strong>{dashboardSummary.nextGig.title}</strong>
-                      <span>
-                        {dashboardSummary.nextGig.dateLabel} · {dashboardSummary.nextGig.clientName}
-                      </span>
-                      <span>{dashboardSummary.nextGig.venue}</span>
+                {dashboardCards.map((card) => (
+                  <article
+                    className={`dashboard-card dashboard-card-${card.state}`}
+                    data-testid={`dashboard-${card.label.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')}`}
+                    key={card.label}
+                  >
+                    <p className="section-label">{card.label}</p>
+                    <strong>{card.value}</strong>
+                    <span>{card.detail}</span>
+                    {card.action ? (
                       <button
                         className="ghost-button compact-action"
-                        data-testid="dashboard-open-next-gig-button"
-                        onClick={onOpenNextGig}
+                        disabled={card.state !== 'ready'}
+                        onClick={() => onDashboardCardAction(card.action!)}
                         type="button"
                       >
-                        Open gig
+                        View invoices
                       </button>
-                    </>
-                  ) : (
-                    <span>No upcoming gigs on the books.</span>
-                  )}
-                </article>
-
-                <article className="dashboard-card invoice-action-card" data-testid="dashboard-invoice-prompt">
-                  <p className="section-label">Invoice prompt</p>
-                  {dashboardSummary.invoiceCandidate ? (
-                    <>
-                      <strong>{dashboardSummary.invoiceCandidate.title}</strong>
-                      <span>
-                        {dashboardSummary.invoiceCandidate.dateLabel} ·{' '}
-                        {dashboardSummary.invoiceCandidate.clientName}
-                      </span>
-                      <span>{dashboardSummary.invoiceCandidate.feeLabel}</span>
-                      <button
-                        className="primary-button compact-action"
-                        data-testid="dashboard-generate-invoice-button"
-                        disabled={isLoading || isInvoiceLoading}
-                        onClick={onGenerateDashboardInvoice}
-                        type="button"
-                      >
-                        Generate invoice
-                      </button>
-                    </>
-                  ) : (
-                    <span>No recent uninvoiced gigs ready for a draft.</span>
-                  )}
-                </article>
+                    ) : null}
+                  </article>
+                ))}
               </div>
             </div>
           </div>

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -57,6 +57,7 @@ type InvoicesSectionProps = {
   onSelectInvoice: (invoiceId: string) => void
   onSortChange: (sort: InvoiceSort) => void
   onStartEditing: () => void
+  scrollToListRequest: number
   sellerProfileNotice: string
   selectedInvoice: Invoice | null
 }
@@ -101,10 +102,12 @@ export function InvoicesSection({
   onSelectInvoice,
   onSortChange,
   onStartEditing,
+  scrollToListRequest,
   sellerProfileNotice,
   selectedInvoice,
 }: InvoicesSectionProps) {
   const editorSlotRef = useRef<HTMLDivElement | null>(null)
+  const listControlsRef = useRef<HTMLDivElement | null>(null)
   const { ref: detailPanelRef, blockSize: detailPanelBlockSize } = useMeasuredBlockSize<HTMLDivElement>()
   const workspaceStyle = detailPanelBlockSize > 0
     ? ({ '--workspace-detail-height': `${detailPanelBlockSize}px` } as CSSProperties)
@@ -127,6 +130,7 @@ export function InvoicesSection({
     { value: 'drafts', label: 'Drafts' },
     { value: 'overdue', label: 'Overdue' },
     { value: 'paid', label: 'Paid' },
+    { value: 'income-this-financial-year', label: 'Income this financial year' },
   ]
 
   useEffect(() => {
@@ -138,6 +142,12 @@ export function InvoicesSection({
       editorSlotRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }, 80)
   }, [isEditorOpen])
+
+  useEffect(() => {
+    if (scrollToListRequest > 0) {
+      listControlsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [scrollToListRequest])
 
   return (
     <section className="section-layout">
@@ -182,7 +192,7 @@ export function InvoicesSection({
             </article>
           </div>
 
-          <div className="compact-list-controls" aria-label="Invoice list controls">
+          <div className="compact-list-controls" aria-label="Invoice list controls" ref={listControlsRef}>
             <div className="compact-list-main-controls">
               <label className="search-field compact-search-field">
                 <span>Search</span>

--- a/frontend/glovelly-web/src/components/index.ts
+++ b/frontend/glovelly-web/src/components/index.ts
@@ -1,5 +1,5 @@
 export { AppShell } from './AppShell'
-export type { AppNavigationItem, DashboardSummary } from './AppShell'
+export type { AppNavigationItem } from './AppShell'
 export { AdminSection } from './AdminSection'
 export { ClientSettingsModal } from './ClientSettingsModal'
 export { ConnectedServicesModal } from './ConnectedServicesModal'

--- a/frontend/glovelly-web/src/dashboardCards.test.ts
+++ b/frontend/glovelly-web/src/dashboardCards.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { getDashboardCards } from './dashboardCards'
+import type { Client, Gig, Invoice } from './types'
+
+const client = (id: string) => ({ id, name: id }) as Client
+
+const gig = (id: string, overrides: Partial<Gig> = {}) =>
+  ({
+    id,
+    clientId: 'client-a',
+    date: '2026-07-30',
+    status: 'Confirmed',
+    isInvoiced: false,
+    ...overrides,
+  }) as Gig
+
+const invoice = (id: string, overrides: Partial<Invoice> = {}) =>
+  ({
+    id,
+    clientId: 'client-a',
+    status: 'Issued',
+    total: 100,
+    ...overrides,
+  }) as Invoice
+
+const cards = (overrides: Partial<Parameters<typeof getDashboardCards>[0]> = {}) =>
+  getDashboardCards({
+    activeSection: 'gigs',
+    clients: [],
+    gigs: [],
+    invoices: [],
+    isWorkspaceLoading: false,
+    paidIncomeSummary: { status: 'ready', summary: {
+      financialYearStart: '2026-04-06', financialYearEnd: '2027-04-05', total: 0, invoiceIds: [],
+    } },
+    today: '2026-07-27',
+    ...overrides,
+  })
+
+describe('getDashboardCards', () => {
+  it('selects the three Gigs metrics', () => {
+    const result = cards({
+      gigs: [
+        gig('upcoming'),
+        gig('draft', { status: 'Draft' }),
+        gig('completed', { status: 'Completed' }),
+        gig('invoiced', { status: 'Completed', isInvoiced: true }),
+      ],
+    })
+
+    expect(result.map((card) => [card.label, card.value])).toEqual([
+      ['Upcoming gigs', '1'],
+      ['Awaiting confirmation', '1'],
+      ['Completed, uninvoiced', '1'],
+    ])
+  })
+
+  it('selects the three Invoices metrics including paid income', () => {
+    const result = cards({
+      activeSection: 'invoices',
+      invoices: [invoice('issued', { total: 75 }), invoice('overdue', { status: 'Overdue', total: 25 })],
+      paidIncomeSummary: { status: 'ready', summary: {
+        financialYearStart: '2026-04-06', financialYearEnd: '2027-04-05', total: 125, invoiceIds: ['paid'],
+      } },
+    })
+
+    expect(result.map((card) => [card.label, card.value, card.action])).toEqual([
+      ['Outstanding balance', '£100.00', 'invoices-outstanding'],
+      ['Overdue invoices', '1', 'invoices-overdue'],
+      ['Income this financial year', '£125.00', 'invoices-income'],
+    ])
+  })
+
+  it('selects the three Clients metrics', () => {
+    const result = cards({
+      activeSection: 'clients',
+      clients: [client('client-a'), client('client-b')],
+      gigs: [gig('active'), gig('another', { clientId: 'client-b' }), gig('third', { clientId: 'client-b' })],
+      invoices: [invoice('outstanding')],
+    })
+
+    expect(result.map((card) => [card.label, card.value])).toEqual([
+      ['Active clients', '2'],
+      ['Clients with outstanding invoices', '1'],
+      ['Most frequent client', 'client-b'],
+    ])
+  })
+
+  it('keeps loading, zero, and error states distinct', () => {
+    expect(cards({ activeSection: 'invoices', isWorkspaceLoading: true })[0]).toMatchObject({
+      state: 'loading', value: 'Loading...',
+    })
+    expect(cards({ activeSection: 'invoices' })[2]).toMatchObject({
+      state: 'ready', value: '£0.00', detail: '6 Apr 2026 to 5 Apr 2027',
+    })
+    expect(cards({ activeSection: 'invoices', paidIncomeSummary: { status: 'error' } })[2]).toMatchObject({
+      state: 'error', value: 'Unavailable',
+    })
+  })
+})

--- a/frontend/glovelly-web/src/dashboardCards.test.ts
+++ b/frontend/glovelly-web/src/dashboardCards.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getDashboardCards } from './dashboardCards'
+import { formatDate } from './formatters'
 import type { Client, Gig, Invoice } from './types'
 
 const client = (id: string) => ({ id, name: id }) as Client
@@ -91,7 +92,9 @@ describe('getDashboardCards', () => {
       state: 'loading', value: 'Loading...',
     })
     expect(cards({ activeSection: 'invoices' })[2]).toMatchObject({
-      state: 'ready', value: '£0.00', detail: '6 Apr 2026 to 5 Apr 2027',
+      state: 'ready',
+      value: '£0.00',
+      detail: `${formatDate('2026-04-06')} to ${formatDate('2027-04-05')}`,
     })
     expect(cards({ activeSection: 'invoices', paidIncomeSummary: { status: 'error' } })[2]).toMatchObject({
       state: 'error', value: 'Unavailable',

--- a/frontend/glovelly-web/src/dashboardCards.ts
+++ b/frontend/glovelly-web/src/dashboardCards.ts
@@ -1,0 +1,166 @@
+import { formatCurrency, formatDate } from './formatters'
+import type { AppSection, Client, Gig, Invoice, PaidIncomeSummary } from './types'
+
+export type DashboardCardAction = 'invoices-outstanding' | 'invoices-overdue' | 'invoices-income'
+export type DashboardCardState = 'loading' | 'ready' | 'error'
+
+export type DashboardCard = {
+  action?: DashboardCardAction
+  detail: string
+  label: string
+  state: DashboardCardState
+  value: string
+}
+
+export type PaidIncomeSummaryState =
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'ready'; summary: PaidIncomeSummary }
+
+type DashboardCardOptions = {
+  activeSection: AppSection
+  clients: Client[]
+  gigs: Gig[]
+  invoices: Invoice[]
+  isWorkspaceLoading: boolean
+  paidIncomeSummary: PaidIncomeSummaryState
+  today: string
+}
+
+const loadingCard = (label: string): DashboardCard => ({
+  label,
+  value: 'Loading...',
+  detail: 'Updating your workspace summary.',
+  state: 'loading',
+})
+
+export function getDashboardCards({
+  activeSection,
+  clients,
+  gigs,
+  invoices,
+  isWorkspaceLoading,
+  paidIncomeSummary,
+  today,
+}: DashboardCardOptions): DashboardCard[] {
+  if (isWorkspaceLoading) {
+    const labels = activeSection === 'clients'
+      ? ['Active clients', 'Clients with outstanding invoices', 'Recently added clients']
+      : activeSection === 'invoices'
+        ? ['Outstanding balance', 'Overdue invoices', 'Income this financial year']
+        : ['Upcoming gigs', 'Awaiting confirmation', 'Completed, uninvoiced']
+    return labels.map(loadingCard)
+  }
+
+  if (activeSection === 'clients') {
+    const activeClientIds = new Set(
+      gigs.filter((gig) => gig.status !== 'Cancelled').map((gig) => gig.clientId)
+    )
+    const outstandingClientIds = new Set(
+      invoices
+        .filter((invoice) => invoice.status !== 'Paid' && invoice.status !== 'Cancelled')
+        .map((invoice) => invoice.clientId)
+    )
+    const gigCountByClientId = gigs
+      .filter((gig) => gig.status !== 'Cancelled')
+      .reduce((counts, gig) => counts.set(gig.clientId, (counts.get(gig.clientId) ?? 0) + 1), new Map<string, number>())
+    const mostFrequentClient = clients
+      .map((client) => ({ client, gigCount: gigCountByClientId.get(client.id) ?? 0 }))
+      .filter(({ gigCount }) => gigCount > 0)
+      .sort((left, right) => right.gigCount - left.gigCount || left.client.name.localeCompare(right.client.name))[0]
+
+    return [
+      {
+        label: 'Active clients',
+        value: String(activeClientIds.size),
+        detail: activeClientIds.size === 1 ? '1 client with active work' : `${activeClientIds.size} clients with active work`,
+        state: 'ready',
+      },
+      {
+        label: 'Clients with outstanding invoices',
+        value: String(outstandingClientIds.size),
+        detail: outstandingClientIds.size === 1 ? '1 client awaiting payment' : `${outstandingClientIds.size} clients awaiting payment`,
+        state: 'ready',
+      },
+      {
+        label: 'Most frequent client',
+        value: mostFrequentClient?.client.name ?? 'None yet',
+        detail: mostFrequentClient
+          ? mostFrequentClient.gigCount === 1
+            ? '1 non-cancelled gig'
+            : `${mostFrequentClient.gigCount} non-cancelled gigs`
+          : 'No gig history yet',
+        state: 'ready',
+      },
+    ]
+  }
+
+  if (activeSection === 'invoices') {
+    const outstandingInvoices = invoices.filter(
+      (invoice) => invoice.status !== 'Paid' && invoice.status !== 'Cancelled'
+    )
+    const overdueInvoices = invoices.filter((invoice) => invoice.status === 'Overdue')
+    const incomeCard: DashboardCard = paidIncomeSummary.status === 'loading'
+      ? loadingCard('Income this financial year')
+      : paidIncomeSummary.status === 'error'
+        ? {
+            label: 'Income this financial year',
+            value: 'Unavailable',
+            detail: 'Unable to load paid income.',
+            state: 'error',
+          }
+        : {
+            action: 'invoices-income',
+            label: 'Income this financial year',
+            value: formatCurrency(paidIncomeSummary.summary.total),
+            detail: `${formatDate(paidIncomeSummary.summary.financialYearStart)} to ${formatDate(paidIncomeSummary.summary.financialYearEnd)}`,
+            state: 'ready',
+          }
+
+    return [
+      {
+        action: 'invoices-outstanding',
+        label: 'Outstanding balance',
+        value: formatCurrency(outstandingInvoices.reduce((total, invoice) => total + invoice.total, 0)),
+        detail: outstandingInvoices.length === 1 ? '1 invoice needs attention' : `${outstandingInvoices.length} invoices need attention`,
+        state: 'ready',
+      },
+      {
+        action: 'invoices-overdue',
+        label: 'Overdue invoices',
+        value: String(overdueInvoices.length),
+        detail: overdueInvoices.length === 1 ? '1 invoice is overdue' : `${overdueInvoices.length} invoices are overdue`,
+        state: 'ready',
+      },
+      incomeCard,
+    ]
+  }
+
+  const upcomingGigs = gigs.filter(
+    (gig) => gig.status === 'Confirmed' && gig.date >= today
+  )
+  const draftGigs = gigs.filter((gig) => gig.status === 'Draft')
+  const completedUninvoicedGigs = gigs.filter(
+    (gig) => gig.status === 'Completed' && !gig.isInvoiced
+  )
+  return [
+    {
+      label: 'Upcoming gigs',
+      value: String(upcomingGigs.length),
+      detail: upcomingGigs.length === 1 ? '1 confirmed gig ahead' : `${upcomingGigs.length} confirmed gigs ahead`,
+      state: 'ready',
+    },
+    {
+      label: 'Awaiting confirmation',
+      value: String(draftGigs.length),
+      detail: draftGigs.length === 1 ? '1 draft gig to confirm' : `${draftGigs.length} draft gigs to confirm`,
+      state: 'ready',
+    },
+    {
+      label: 'Completed, uninvoiced',
+      value: String(completedUninvoicedGigs.length),
+      detail: completedUninvoicedGigs.length === 1 ? '1 gig ready to invoice' : `${completedUninvoicedGigs.length} gigs ready to invoice`,
+      state: 'ready',
+    },
+  ]
+}

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -9,7 +9,15 @@ import {
 } from '../api'
 import { defaultInvoiceStatus } from '../forms'
 import { formatCurrency, formatDateTime } from '../formatters'
-import type { Invoice, InvoiceLine, InvoiceQuickFilter, InvoiceSort, InvoiceStatus } from '../types'
+import type {
+  Invoice,
+  InvoiceLine,
+  InvoiceQuickFilter,
+  InvoiceSort,
+  InvoiceStatus,
+  PaidIncomeSummary,
+} from '../types'
+import type { PaidIncomeSummaryState } from '../dashboardCards'
 
 type GoogleDrivePublishLink = {
   href: string
@@ -46,6 +54,10 @@ export function useInvoicesWorkspace({
   const [googleDrivePublishLink, setGoogleDrivePublishLink] =
     useState<GoogleDrivePublishLink | null>(null)
   const [isInvoiceLoading, setIsInvoiceLoading] = useState(false)
+  const [paidIncomeSummary, setPaidIncomeSummary] = useState<PaidIncomeSummaryState>({
+    status: 'loading',
+  })
+  const [incomeInvoiceIds, setIncomeInvoiceIds] = useState<string[]>([])
   const [adjustmentAmount, setAdjustmentAmount] = useState('')
   const [adjustmentReason, setAdjustmentReason] = useState('')
   const [invoiceDescription, setInvoiceDescription] = useState('')
@@ -55,6 +67,23 @@ export function useInvoicesWorkspace({
     () => new Map(invoices.map((invoice) => [invoice.id, invoice])),
     [invoices]
   )
+
+  const loadPaidIncomeSummary = useCallback(async () => {
+    setPaidIncomeSummary({ status: 'loading' })
+
+    try {
+      const response = await fetchWithSession(buildApiUrl('/invoices/paid-income-summary'))
+      if (!response.ok) {
+        throw new Error('Unable to load paid income.')
+      }
+
+      const summary = (await response.json()) as PaidIncomeSummary
+      setPaidIncomeSummary({ status: 'ready', summary })
+      setIncomeInvoiceIds(summary.invoiceIds)
+    } catch {
+      setPaidIncomeSummary({ status: 'error' })
+    }
+  }, [])
 
   const filteredInvoices = useMemo(() => {
     const query = deferredInvoiceSearchQuery.trim().toLowerCase()
@@ -138,6 +167,8 @@ export function useInvoicesWorkspace({
           return invoice.status === 'Overdue'
         case 'paid':
           return invoice.status === 'Paid'
+        case 'income-this-financial-year':
+          return incomeInvoiceIds.includes(invoice.id)
         case 'all':
         default:
           return true
@@ -161,7 +192,7 @@ export function useInvoicesWorkspace({
         .toLowerCase()
         .includes(query)
     })
-  }, [clientNamesById, deferredInvoiceSearchQuery, invoiceQuickFilter, invoiceSort, invoices])
+  }, [clientNamesById, deferredInvoiceSearchQuery, incomeInvoiceIds, invoiceQuickFilter, invoiceSort, invoices])
 
   const selectedInvoice = selectedInvoiceId
     ? invoicesById.get(selectedInvoiceId) ?? null
@@ -186,6 +217,8 @@ export function useInvoicesWorkspace({
     setInvoiceStatus(defaultInvoiceStatus)
     setGoogleDrivePublishLink(null)
     setIsInvoiceLoading(false)
+    setPaidIncomeSummary({ status: 'loading' })
+    setIncomeInvoiceIds([])
     setAdjustmentAmount('')
     setAdjustmentReason('')
     setInvoiceDescription('')
@@ -264,6 +297,7 @@ export function useInvoicesWorkspace({
         current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
       )
       setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} is now ${updatedInvoice.status}.`)
+      await loadPaidIncomeSummary()
       return updatedInvoice
     } catch (error) {
       setInvoiceStatus(error instanceof Error ? error.message : 'Unable to update invoice status.')
@@ -321,6 +355,7 @@ export function useInvoicesWorkspace({
         setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} re-issued at ${reissuedAt}.`)
       }
 
+      await loadPaidIncomeSummary()
       return updatedInvoice
     } catch (error) {
       setInvoiceStatus(
@@ -637,7 +672,9 @@ export function useInvoicesWorkspace({
     isInvoiceEditorOpen,
     issuedInvoiceCount: invoices.filter((invoice) => invoice.status === 'Issued').length,
     isInvoiceLoading,
+    loadPaidIncomeSummary,
     overdueInvoiceCount: invoices.filter((invoice) => invoice.status === 'Overdue').length,
+    paidIncomeSummary,
     resetInvoicesWorkspace,
     selectedInvoice,
     setAdjustmentAmount,

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -585,6 +585,7 @@ export type Invoice = {
   invoiceDate: string
   dueDate: string
   status: InvoiceStatus
+  paidOn: string | null
   firstIssuedUtc: string | null
   firstIssuedByUserId: string | null
   reissueCount: number
@@ -605,6 +606,13 @@ export type Invoice = {
   lines: InvoiceLine[]
 }
 
+export type PaidIncomeSummary = {
+  financialYearStart: string
+  financialYearEnd: string
+  total: number
+  invoiceIds: string[]
+}
+
 export type InvoiceSortKey =
   | 'priority'
   | 'invoiceDate'
@@ -617,7 +625,13 @@ export type InvoiceSort = {
   key: InvoiceSortKey
   direction: SortDirection
 }
-export type InvoiceQuickFilter = 'all' | 'outstanding' | 'drafts' | 'overdue' | 'paid'
+export type InvoiceQuickFilter =
+  | 'all'
+  | 'outstanding'
+  | 'drafts'
+  | 'overdue'
+  | 'paid'
+  | 'income-this-financial-year'
 
 export type GigForm = {
   clientId: string

--- a/openspec/changes/archive/2026-07-27-contextual-dashboard-income/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-contextual-dashboard-income/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-contextual-dashboard-income/design.md
+++ b/openspec/changes/archive/2026-07-27-contextual-dashboard-income/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The authenticated application has three primary workspaces: Clients, Gigs, and Invoices. `AppShell` renders a fixed three-card dashboard summary above all of them, while `App.tsx` derives its values from client-side gig and invoice collections. The card grid already has three fixed columns and responsive single-column behaviour.
+
+Invoices currently store status and a status-update timestamp but no payment date. The paid status transition is managed by the invoice endpoint, and reissuing an invoice returns it to Draft. The system has no user-configurable financial-year, timezone, currency, or locale settings. This slice establishes an explicit UK-only convention rather than introducing internationalized settings.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep exactly three dashboard card slots while changing their content for the selected Clients, Gigs, or Invoices workspace.
+- Record a canonical invoice payment date when an invoice becomes Paid.
+- Calculate current-financial-year income from user-visible paid invoices and make the card and drill-down reconcile exactly.
+- Use Europe/London to determine the current date and an inclusive 6 April to 5 April financial year.
+- Cover card selection through the existing pure Vitest setup and financial rules through backend integration tests.
+
+**Non-Goals:**
+- Partial payments, payment amounts, payment history, or manual payment-date editing.
+- Per-user financial-year, timezone, currency, or locale configuration.
+- A general reporting screen, URL-persisted dashboard context, or a browser-component test framework.
+- Changing invoice status-transition rules other than clearing payment metadata on reissue.
+
+## Decisions
+
+### Persist `PaidOn` as a nullable `DateOnly`
+
+Add a nullable `PaidOn` property to `Invoice`. When an invoice transitions to Paid, the backend sets it to the current date in `Europe/London`. When reissue changes a paid invoice to Draft, it clears `PaidOn`.
+
+This is a stable cash-basis fact rather than an inference from `StatusUpdatedUtc`, which is an audit timestamp and cannot represent a user-received payment date. A separate payment ledger was considered, but is deferred because partial payments and corrections are explicitly out of scope.
+
+### Make the UK financial year an application convention
+
+A reusable financial-year helper resolves the current Europe/London date and returns the inclusive range 6 April through 5 April. The helper is used by the paid-income query and any frontend display/filter support so boundary rules remain explicit and consistent.
+
+Per-user fiscal-year and timezone settings were considered but would introduce settings, persistence, validation, and migration scope without a current internationalization need.
+
+### Use a dedicated, user-scoped invoice income summary
+
+Expose an invoice-summary endpoint within the existing invoices API group. Its response includes the financial-year start and end dates, paid-income total, and the IDs of contributing invoices. The endpoint uses `WhereVisibleTo` and a reusable query predicate that includes only invoices that are Paid and have `PaidOn` within the inclusive range.
+
+Returning contributing IDs lets the frontend drill-down filter the already loaded invoice list without reimplementing inclusion logic. It also makes reconciliation testable: the displayed total and visible drill-down members originate from the same server query. A client-only calculation was rejected because it duplicates business rules and requires every invoice solely for a dashboard total.
+
+### Model dashboard cards as pure, context-selected view data
+
+Move dashboard-card selection and ordinary card derivation into a pure frontend helper. It receives the active section and workspace data, and returns exactly three card view models. `AppShell` renders those cards consistently, including loading, empty/zero, and error presentation.
+
+The fixed three-card grid is retained to avoid layout movement. Gigs cards focus on upcoming, draft/awaiting confirmation, and completed-uninvoiced work; Invoice cards focus on outstanding, overdue, and received-this-financial-year income; Client cards focus on active, outstanding, and recently added clients. "Recently added" is selected over "recent activity" because the client record already has a creation timestamp while activity has no single defined source.
+
+### Drill down through a named invoice quick filter
+
+Add an `income-this-financial-year` invoice quick filter backed by the summary response's contributing invoice IDs. Selecting the income card activates Invoices, applies that filter, and leaves the normal list sorting and selection behaviour intact.
+
+URL/query filters were considered but are broader navigation infrastructure than this slice needs.
+
+## Risks / Trade-offs
+
+- [A payment is recorded on a different calendar day from the London date.] → This shortcut intentionally stamps the Paid transition; a later payment-management slice will support corrections.
+- [A reissued paid invoice could remain counted as income.] → Clear `PaidOn` whenever reissue returns the invoice to Draft and test the result.
+- [Dashboard and list totals diverge.] → Use a single server query for the total and contributing invoice IDs; test their membership and sum together.
+- [Initial data loading produces misleading zeros.] → Render an explicit loading state until the relevant workspace data and, for income, the summary request have resolved; keep zero distinct from unavailable/error.
+- [Existing PostgreSQL databases do not receive the new column.] → The application currently uses `EnsureCreated` rather than EF migrations; deployment must include the repository's established schema-evolution mechanism or a safe additive database migration before code that writes `PaidOn` is released.
+- [The fixed dashboard header increases UI coupling in `App.tsx`.] → Keep the selection/derivation pure and presentational rendering in `AppShell`; do not expand workflow logic in either component.
+
+## Migration Plan
+
+1. Add the nullable `PaidOn` column as an additive schema change; existing invoices retain null and therefore do not contribute to paid-income summaries.
+2. Deploy backend status/reissue behaviour and the income summary endpoint.
+3. Deploy frontend invoice typing, contextual cards, and drill-down behaviour.
+4. Roll back the frontend/backend application code if needed; the nullable column is safe to retain and no historic paid dates are fabricated.
+
+## Open Questions
+
+- None for this slice. The UK-only financial-year convention and automatic PaidOn stamping are deliberate temporary constraints.

--- a/openspec/changes/archive/2026-07-27-contextual-dashboard-income/proposal.md
+++ b/openspec/changes/archive/2026-07-27-contextual-dashboard-income/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The dashboard currently shows the same generic summary cards regardless of whether a user is working with clients, gigs, or invoices. Users also cannot see cash income received in the current UK financial year, because invoices do not record the date on which payment was received.
+
+This change makes the dashboard immediately useful in its current context while establishing a small, consistent cash-basis income foundation for future reporting.
+
+## What Changes
+
+- Replace the fixed dashboard summary with three stable card slots whose content is relevant to the selected Clients, Gigs, or Invoices workspace.
+- Add a nullable invoice `PaidOn` date that is populated automatically when an invoice transitions to Paid and cleared when a paid invoice is reissued as a Draft.
+- Define the current financial year as the UK period from 6 April through 5 April, using the Europe/London local date convention.
+- Add a reusable, user-visible paid-income summary for the current financial year that includes only paid invoices whose `PaidOn` date is within that inclusive period.
+- Show the paid-income total and applicable financial-year dates in the Invoices dashboard context, with a drill-down to the same contributing invoices.
+- Provide consistent loading, zero/empty, and error states for dashboard cards, and add backend and Vitest coverage for the new behaviour.
+
+## Capabilities
+
+### New Capabilities
+- `contextual-dashboard-cards`: Present a stable, context-specific dashboard card set for the Clients, Gigs, and Invoices workspaces.
+- `paid-income-summary`: Record invoice payment dates and provide a UK-financial-year cash-income summary and reconciled invoice drill-down.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Frontend dashboard presentation and state coordination in `frontend/glovelly-web/src/App.tsx` and `src/components/AppShell.tsx`.
+- Frontend invoice types, quick filtering, and pure Vitest summary/card-selection coverage.
+- Invoice persistence model, API response shape, paid-status transition, reissue workflow, and user-scoped summary query/endpoints in `backend/Glovelly.Api`.
+- Backend invoice integration tests and invoice/dashboard UAT documentation.

--- a/openspec/changes/archive/2026-07-27-contextual-dashboard-income/specs/contextual-dashboard-cards/spec.md
+++ b/openspec/changes/archive/2026-07-27-contextual-dashboard-income/specs/contextual-dashboard-cards/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Context-specific dashboard cards
+The system SHALL render exactly three dashboard cards for the active Clients, Gigs, or Invoices workspace. Each workspace SHALL display a context-relevant card set while retaining the shared card layout.
+
+#### Scenario: Selecting the Gigs workspace updates the dashboard cards
+- **WHEN** the user selects the Gigs workspace
+- **THEN** the dashboard SHALL show cards for upcoming gigs, gigs requiring confirmation or still in Draft, and completed uninvoiced gigs
+
+#### Scenario: Selecting the Invoices workspace updates the dashboard cards
+- **WHEN** the user selects the Invoices workspace
+- **THEN** the dashboard SHALL show cards for outstanding balance, overdue invoices, and income received in the current financial year
+
+#### Scenario: Selecting the Clients workspace updates the dashboard cards
+- **WHEN** the user selects the Clients workspace
+- **THEN** the dashboard SHALL show cards for active clients, clients with outstanding invoices, and recently added clients
+
+### Requirement: Contextual-card refresh and actionability
+The system SHALL refresh contextual card values when the underlying workspace data changes. A card that represents a filtered record set SHALL provide navigation to its relevant workspace and filter where that navigation is useful.
+
+#### Scenario: Invoice payment updates current-financial-year income
+- **WHEN** an invoice is marked Paid and its `PaidOn` date falls in the current financial year
+- **THEN** the Invoices dashboard income card SHALL refresh to include that invoice
+
+#### Scenario: Invoice card navigates to its relevant records
+- **WHEN** a user selects a filterable Invoices dashboard card
+- **THEN** the application SHALL open the invoice workspace with the card's relevant invoice filter applied
+
+### Requirement: Dashboard card states and responsive layout
+The system SHALL distinguish loading, zero-or-empty, and error states for dashboard cards. The three-card dashboard layout SHALL remain usable at mobile and desktop viewport widths without changing the number of card slots by context.
+
+#### Scenario: Income summary loading does not appear as zero income
+- **WHEN** the Invoices workspace is selected and the paid-income summary is still loading
+- **THEN** the income card SHALL show a loading state rather than a zero monetary value
+
+#### Scenario: No qualifying income is distinct from an unavailable summary
+- **WHEN** the paid-income summary succeeds with no contributing invoices
+- **THEN** the income card SHALL show a zero monetary value and the financial-year period
+
+#### Scenario: Income summary failure is visible
+- **WHEN** the paid-income summary request fails
+- **THEN** the income card SHALL show an error or unavailable state rather than a zero monetary value

--- a/openspec/changes/archive/2026-07-27-contextual-dashboard-income/specs/paid-income-summary/spec.md
+++ b/openspec/changes/archive/2026-07-27-contextual-dashboard-income/specs/paid-income-summary/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Invoice payment-date recording
+The system SHALL persist a nullable `PaidOn` date for each invoice. When an invoice transitions from a non-Paid status to Paid, the system SHALL set `PaidOn` to the current date in the Europe/London timezone. When reissuing an invoice changes it to Draft, the system SHALL clear `PaidOn`.
+
+#### Scenario: Marking an invoice as paid records a UK-local payment date
+- **WHEN** a visible issued or overdue invoice is transitioned to Paid
+- **THEN** the invoice response SHALL contain a `PaidOn` date equal to the current Europe/London date
+
+#### Scenario: Reissuing a paid invoice clears its payment date
+- **WHEN** a paid invoice with a `PaidOn` value is reissued
+- **THEN** the resulting Draft invoice SHALL have a null `PaidOn` value
+
+### Requirement: UK financial-year paid-income summary
+The system SHALL provide a user-scoped current-financial-year paid-income summary. The financial year SHALL begin on 6 April and end on 5 April inclusive, based on the current Europe/London date. The summary SHALL include the financial-year boundaries, the total of contributing invoice values, and the IDs of contributing invoices.
+
+#### Scenario: Current financial year starts on 6 April
+- **WHEN** the current Europe/London date is 6 April 2026
+- **THEN** the summary period SHALL run from 6 April 2026 through 5 April 2027 inclusive
+
+#### Scenario: Current financial year before 6 April began in the prior calendar year
+- **WHEN** the current Europe/London date is 5 April 2027
+- **THEN** the summary period SHALL run from 6 April 2026 through 5 April 2027 inclusive
+
+### Requirement: Paid-income inclusion rules
+The paid-income summary SHALL include an invoice only when it is visible to the authenticated user, has status Paid, has a non-null `PaidOn` date, and that date falls within the summary's inclusive financial-year range. Draft, Issued, Overdue, Cancelled, and invoices without a qualifying date SHALL not contribute.
+
+#### Scenario: A paid invoice received in the financial year contributes
+- **WHEN** a visible Paid invoice has a `PaidOn` date within the current financial year
+- **THEN** its total and ID SHALL be included in the paid-income summary
+
+#### Scenario: A paid invoice received outside the financial year is excluded
+- **WHEN** a visible Paid invoice has a `PaidOn` date outside the current financial year
+- **THEN** its total and ID SHALL not be included in the paid-income summary
+
+#### Scenario: An unpaid invoice is excluded regardless of its dates
+- **WHEN** a visible invoice is Draft, Issued, Overdue, or Cancelled and has dates within the current financial year
+- **THEN** its total and ID SHALL not be included in the paid-income summary
+
+### Requirement: Reconciled paid-income drill-down
+The system SHALL let a user open the invoice workspace from the current-financial-year income card with a filter that displays exactly the invoice IDs supplied by the paid-income summary.
+
+#### Scenario: Income-card drill-down reconciles with the summary
+- **WHEN** a user selects the current-financial-year income card
+- **THEN** the invoice workspace SHALL display only the contributing invoices from the same summary response

--- a/openspec/changes/archive/2026-07-27-contextual-dashboard-income/tasks.md
+++ b/openspec/changes/archive/2026-07-27-contextual-dashboard-income/tasks.md
@@ -1,0 +1,27 @@
+## 1. Paid-Income Foundation
+
+- [x] 1.1 Add nullable `PaidOn` invoice persistence and API contract support, including the required additive PostgreSQL schema evolution.
+- [x] 1.2 Add a reusable UK financial-year helper that resolves Europe/London dates and inclusive 6 April to 5 April boundaries.
+- [x] 1.3 Set `PaidOn` when an invoice enters Paid and clear it when reissue returns an invoice to Draft.
+- [x] 1.4 Add a user-scoped invoice paid-income summary endpoint that returns period boundaries, total, and contributing invoice IDs from one shared inclusion query.
+- [x] 1.5 Add backend integration tests for PaidOn lifecycle, UK financial-year boundaries, inclusion/exclusion, owner visibility, and total-to-ID reconciliation.
+
+## 2. Invoice Drill-Down State
+
+- [x] 2.1 Extend frontend invoice types and loading/error state for the paid-income summary response.
+- [x] 2.2 Add the `income-this-financial-year` invoice quick filter backed by contributing invoice IDs.
+- [x] 2.3 Refresh the paid-income summary after invoice payment-status and reissue changes, and navigate from the income card into its reconciled filter.
+
+## 3. Contextual Dashboard Cards
+
+- [x] 3.1 Extract pure dashboard-card view-data selection for Clients, Gigs, and Invoices, retaining exactly three card slots per context.
+- [x] 3.2 Implement Gigs cards for upcoming work, Draft/awaiting-confirmation work, and completed uninvoiced work.
+- [x] 3.3 Implement Invoices cards for outstanding balance, overdue invoices, and received income in the current financial year.
+- [x] 3.4 Implement Clients cards for active clients, clients with outstanding invoices, and recently added clients.
+- [x] 3.5 Update `AppShell` card rendering, actions, and responsive styles to distinguish loading, zero/empty, and error states consistently.
+
+## 4. Verification And Documentation
+
+- [x] 4.1 Add Vitest coverage for all context card sets, card values, and dashboard state distinctions using pure view-data helpers.
+- [x] 4.2 Add or update invoice and dashboard UAT journeys for marking an invoice paid, financial-year income, and the reconciled drill-down.
+- [x] 4.3 Run `dotnet test glovelly.sln -m:1`, `npm --prefix frontend/glovelly-web run test`, `npm --prefix frontend/glovelly-web run lint`, and `npm --prefix frontend/glovelly-web run build`.

--- a/openspec/specs/contextual-dashboard-cards/spec.md
+++ b/openspec/specs/contextual-dashboard-cards/spec.md
@@ -1,0 +1,46 @@
+## Purpose
+
+Provide dashboard cards tailored to the active workspace.
+
+## Requirements
+
+### Requirement: Context-specific dashboard cards
+The system SHALL render exactly three dashboard cards for the active Clients, Gigs, or Invoices workspace. Each workspace SHALL display a context-relevant card set while retaining the shared card layout.
+
+#### Scenario: Selecting the Gigs workspace updates the dashboard cards
+- **WHEN** the user selects the Gigs workspace
+- **THEN** the dashboard SHALL show cards for upcoming gigs, gigs requiring confirmation or still in Draft, and completed uninvoiced gigs
+
+#### Scenario: Selecting the Invoices workspace updates the dashboard cards
+- **WHEN** the user selects the Invoices workspace
+- **THEN** the dashboard SHALL show cards for outstanding balance, overdue invoices, and income received in the current financial year
+
+#### Scenario: Selecting the Clients workspace updates the dashboard cards
+- **WHEN** the user selects the Clients workspace
+- **THEN** the dashboard SHALL show cards for active clients, clients with outstanding invoices, and the most frequently used client
+
+### Requirement: Contextual-card refresh and actionability
+The system SHALL refresh contextual card values when the underlying workspace data changes. A card that represents a filtered record set SHALL provide navigation to its relevant workspace and filter where that navigation is useful.
+
+#### Scenario: Invoice payment updates current-financial-year income
+- **WHEN** an invoice is marked Paid and its `PaidOn` date falls in the current financial year
+- **THEN** the Invoices dashboard income card SHALL refresh to include that invoice
+
+#### Scenario: Invoice card navigates to its relevant records
+- **WHEN** a user selects a filterable Invoices dashboard card
+- **THEN** the application SHALL open the invoice workspace with the card's relevant invoice filter applied
+
+### Requirement: Dashboard card states and responsive layout
+The system SHALL distinguish loading, zero-or-empty, and error states for dashboard cards. The three-card dashboard layout SHALL remain usable at mobile and desktop viewport widths without changing the number of card slots by context.
+
+#### Scenario: Income summary loading does not appear as zero income
+- **WHEN** the Invoices workspace is selected and the paid-income summary is still loading
+- **THEN** the income card SHALL show a loading state rather than a zero monetary value
+
+#### Scenario: No qualifying income is distinct from an unavailable summary
+- **WHEN** the paid-income summary succeeds with no contributing invoices
+- **THEN** the income card SHALL show a zero monetary value and the financial-year period
+
+#### Scenario: Income summary failure is visible
+- **WHEN** the paid-income summary request fails
+- **THEN** the income card SHALL show an error or unavailable state rather than a zero monetary value

--- a/openspec/specs/paid-income-summary/spec.md
+++ b/openspec/specs/paid-income-summary/spec.md
@@ -1,0 +1,49 @@
+## Purpose
+
+Provide a user-scoped summary of income received in the current UK financial year.
+
+## Requirements
+
+### Requirement: Invoice payment-date recording
+The system SHALL persist a nullable `PaidOn` date for each invoice. When an invoice transitions from a non-Paid status to Paid, the system SHALL set `PaidOn` to the current date in the Europe/London timezone. When reissuing an invoice changes it to Draft, the system SHALL clear `PaidOn`.
+
+#### Scenario: Marking an invoice as paid records a UK-local payment date
+- **WHEN** a visible issued or overdue invoice is transitioned to Paid
+- **THEN** the invoice response SHALL contain a `PaidOn` date equal to the current Europe/London date
+
+#### Scenario: Reissuing a paid invoice clears its payment date
+- **WHEN** a paid invoice with a `PaidOn` value is reissued
+- **THEN** the resulting Draft invoice SHALL have a null `PaidOn` value
+
+### Requirement: UK financial-year paid-income summary
+The system SHALL provide a user-scoped current-financial-year paid-income summary. The financial year SHALL begin on 6 April and end on 5 April inclusive, based on the current Europe/London date. The summary SHALL include the financial-year boundaries, the total of contributing invoice values, and the IDs of contributing invoices.
+
+#### Scenario: Current financial year starts on 6 April
+- **WHEN** the current Europe/London date is 6 April 2026
+- **THEN** the summary period SHALL run from 6 April 2026 through 5 April 2027 inclusive
+
+#### Scenario: Current financial year before 6 April began in the prior calendar year
+- **WHEN** the current Europe/London date is 5 April 2027
+- **THEN** the summary period SHALL run from 6 April 2026 through 5 April 2027 inclusive
+
+### Requirement: Paid-income inclusion rules
+The paid-income summary SHALL include an invoice only when it is visible to the authenticated user, has status Paid, has a non-null `PaidOn` date, and that date falls within the summary's inclusive financial-year range. Draft, Issued, Overdue, Cancelled, and invoices without a qualifying date SHALL not contribute.
+
+#### Scenario: A paid invoice received in the financial year contributes
+- **WHEN** a visible Paid invoice has a `PaidOn` date within the current financial year
+- **THEN** its total and ID SHALL be included in the paid-income summary
+
+#### Scenario: A paid invoice received outside the financial year is excluded
+- **WHEN** a visible Paid invoice has a `PaidOn` date outside the current financial year
+- **THEN** its total and ID SHALL not be included in the paid-income summary
+
+#### Scenario: An unpaid invoice is excluded regardless of its dates
+- **WHEN** a visible invoice is Draft, Issued, Overdue, or Cancelled and has dates within the current financial year
+- **THEN** its total and ID SHALL not be included in the paid-income summary
+
+### Requirement: Reconciled paid-income drill-down
+The system SHALL let a user open the invoice workspace from the current-financial-year income card with a filter that displays exactly the invoice IDs supplied by the paid-income summary.
+
+#### Scenario: Income-card drill-down reconciles with the summary
+- **WHEN** a user selects the current-financial-year income card
+- **THEN** the invoice workspace SHALL display only the contributing invoices from the same summary response

--- a/tests/Glovelly.Uat.Tests/DashboardSummaryTests.cs
+++ b/tests/Glovelly.Uat.Tests/DashboardSummaryTests.cs
@@ -6,79 +6,48 @@ namespace Glovelly.Uat.Tests;
 public sealed class DashboardSummaryTests : InvoiceUatTestBase
 {
     [Fact]
-    public Task DashboardHighlightsNextGigOutstandingBalanceAndInvoicePrompt() => RunWithDiagnosticsAsync(
-        nameof(DashboardHighlightsNextGigOutstandingBalanceAndInvoicePrompt),
+    public Task DashboardShowsContextSpecificCardsAndInvoiceDrillDown() => RunWithDiagnosticsAsync(
+        nameof(DashboardShowsContextSpecificCardsAndInvoiceDrillDown),
         async () =>
         {
             var runId = CreateRunId();
             var clientName = $"{runId} Dashboard Client";
-            var gigTitle = $"000 {runId} Dashboard Gig";
+            var completedGigTitle = $"000 {runId} Completed Dashboard Gig";
+            var upcomingGigTitle = $"000 {runId} Upcoming Dashboard Gig";
 
             await AuthenticateWithUatSecretAsync();
             await CreateClientAsync(clientName);
             await CreateGigAsync(
                 clientName,
-                gigTitle,
+                completedGigTitle,
                 DateTime.UtcNow.ToString("yyyy-MM-dd"),
                 fee: "187.00",
                 status: "Completed");
+            await CreateGigAsync(
+                clientName,
+                upcomingGigTitle,
+                DateTime.UtcNow.AddDays(1).ToString("yyyy-MM-dd"),
+                fee: "187.00",
+                status: "Confirmed");
 
-            await Assertions.Expect(Page.GetByTestId("dashboard-next-gig").Locator("strong")).ToBeVisibleAsync(
+            await Assertions.Expect(Page.GetByTestId("dashboard-upcoming-gigs")).ToBeVisibleAsync(
                 new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
-            await Assertions.Expect(Page.GetByTestId("dashboard-invoice-prompt").Locator("strong")).ToBeVisibleAsync(
+            await Assertions.Expect(Page.GetByTestId("dashboard-awaiting-confirmation")).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+            await Assertions.Expect(Page.GetByTestId("dashboard-completed-uninvoiced")).ToBeVisibleAsync(
                 new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
 
-            var dashboardNextGigTitle = (await Page.GetByTestId("dashboard-next-gig").Locator("strong").InnerTextAsync()).Trim();
-            var dashboardInvoicePromptTitle = (await Page.GetByTestId("dashboard-invoice-prompt").Locator("strong").InnerTextAsync()).Trim();
-
-            await Page.GetByTestId("dashboard-open-next-gig-button").ClickAsync();
-            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = dashboardNextGigTitle })).ToBeVisibleAsync(
+            await Page.GetByTestId("nav-invoices").ClickAsync();
+            await Assertions.Expect(Page.GetByTestId("dashboard-outstanding-balance")).ToBeVisibleAsync(
                 new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
-            await Assertions.Expect(Page.GetByTestId("selected-gig-status")).ToBeVisibleAsync();
+            await Assertions.Expect(Page.GetByTestId("dashboard-overdue-invoices")).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+            await Assertions.Expect(Page.GetByTestId("dashboard-income-this-financial-year")).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
 
-            await Page.GetByTestId("dashboard-generate-invoice-button").ClickAsync();
-            await WaitForInvoicePreviewAsync();
-            await Page.GetByRole(AriaRole.Button, new() { Name = "Close" }).ClickAsync();
-
-            var expectedOutstandingBalance = await FormatCurrentOutstandingBalanceAsync();
-            await Assertions.Expect(Page.GetByTestId("dashboard-outstanding-balance")).ToContainTextAsync(
-                expectedOutstandingBalance,
-                new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
-            await Assertions.Expect(Page.GetByTestId("dashboard-invoice-prompt")).Not.ToContainTextAsync(
-                dashboardInvoicePromptTitle,
-                new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
-
-            await OpenGigAsync(dashboardInvoicePromptTitle);
-            await ExpectContainsAsync(Page.GetByTestId("generate-invoice-button"), "Already invoiced");
-            await Page.GetByTestId("gig-open-linked-invoice-button").WaitForAsync(new LocatorWaitForOptions
-            {
-                State = WaitForSelectorState.Visible,
-                Timeout = 30_000,
-            });
+            await Page.GetByTestId("dashboard-outstanding-balance").GetByRole(AriaRole.Button, new() { Name = "View invoices" }).ClickAsync();
+            await Assertions.Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Outstanding", Exact = true })).ToHaveClassAsync(
+                "compact-filter-chip selected",
+                new LocatorAssertionsToHaveClassOptions { Timeout = 30_000 });
         });
-
-    private async Task<string> FormatCurrentOutstandingBalanceAsync()
-    {
-        return await Page.EvaluateAsync<string>(
-            """
-            async () => {
-              const response = await fetch('/invoices', { credentials: 'include' });
-              if (!response.ok) {
-                throw new Error(`Unable to load invoices: ${response.status}`);
-              }
-
-              const invoices = await response.json();
-              const total = invoices
-                .filter((invoice) => invoice.status !== 'Paid' && invoice.status !== 'Cancelled')
-                .reduce((sum, invoice) => sum + invoice.total, 0);
-
-              return new Intl.NumberFormat(undefined, {
-                style: 'currency',
-                currency: 'GBP',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              }).format(total);
-            }
-            """);
-    }
 }


### PR DESCRIPTION
## Summary
- add context-specific dashboard cards for clients, gigs, and invoices
- record invoice `PaidOn` dates and show paid income for the current UK financial year
- add the `AddInvoicePaidOn` EF migration, including a London-date backfill for existing paid invoices
- add reconciled invoice drill-down, tests, UAT guidance, and archived OpenSpec artifacts

Closes #211
Closes #209

## Verification
- `dotnet test glovelly.sln -m:1`
- `dotnet tool run dotnet-ef migrations has-pending-model-changes --project backend/Glovelly.Migrations/Glovelly.Migrations.csproj --startup-project backend/Glovelly.Migrations/Glovelly.Migrations.csproj --context AppDbContext`
- `npm --prefix frontend/glovelly-web run test`
- `npm --prefix frontend/glovelly-web run lint`
- `npm --prefix frontend/glovelly-web run build`