### PR TITLE
Stabilize expense statement gig selection UAT

### DIFF
--- a/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
+++ b/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
@@ -225,6 +225,8 @@ public sealed class ExpenseStatementTests : InvoiceUatTestBase
     {
         await Page.GetByTestId("nav-gigs").ClickAsync();
         await Page.GetByTestId("gig-search-input").FillAsync(string.Empty);
+        await Page.GetByLabel("Type").SelectOptionAsync("all");
+        await Page.GetByLabel("Gig filters").GetByRole(AriaRole.Button, new() { Name = "All", Exact = true }).ClickAsync();
         var card = GigCard(gigTitle);
         await card.WaitForAsync(new LocatorWaitForOptions
         {


### PR DESCRIPTION
## Summary
- reset gig type and quick filters before selecting a gig in the expense statement UAT
- prevent active list filters from hiding the target invoiced gig

## Verification
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
- dotnet test glovelly.sln -m:1

The deployed UAT was not run locally because GLOVELLY_UAT_BASE_URL is not configured.