### PR TITLE
Target the gig type filter in expense statement UAT

### DIFF
--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -240,7 +240,11 @@ export function GigsSection({
               </label>
               <label>
                 <span>Type</span>
-                <select value={gigTypeFilter} onChange={(event) => onGigTypeFilterChange(event.target.value as GigType | 'all')}>
+                <select
+                  data-testid="gig-type-filter"
+                  value={gigTypeFilter}
+                  onChange={(event) => onGigTypeFilterChange(event.target.value as GigType | 'all')}
+                >
                   <option value="all">All types</option>
                   <option value="Performance">Performance</option>
                   <option value="Teaching">Teaching</option>

--- a/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
+++ b/tests/Glovelly.Uat.Tests/ExpenseStatementTests.cs
@@ -225,7 +225,7 @@ public sealed class ExpenseStatementTests : InvoiceUatTestBase
     {
         await Page.GetByTestId("nav-gigs").ClickAsync();
         await Page.GetByTestId("gig-search-input").FillAsync(string.Empty);
-        await Page.GetByLabel("Type").SelectOptionAsync("all");
+        await Page.GetByTestId("gig-type-filter").SelectOptionAsync("all");
         await Page.GetByLabel("Gig filters").GetByRole(AriaRole.Button, new() { Name = "All", Exact = true }).ClickAsync();
         var card = GigCard(gigTitle);
         await card.WaitForAsync(new LocatorWaitForOptions


### PR DESCRIPTION
## Summary
- target the gig filter's existing test ID instead of the ambiguous Type label
- avoid Playwright strict-mode failures when the invoice form is also visible

## Verification
- dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj