### PR TITLE
Add Vertex AI receipt analysis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,8 +269,12 @@ jobs:
             Mcp__OAuth__Clients__0__Scopes__0=mcp:read
             SetListChartRanking__Provider=${{ vars.SET_LIST_CHART_RANKING_PROVIDER || 'Deterministic' }}
             SetListChartRanking__VertexAiProjectId=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_PROJECT_ID || env.GCP_PROJECT_ID }}
-            SetListChartRanking__VertexAiLocation=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_LOCATION || env.GCP_REGION }}
-            SetListChartRanking__VertexAiModel=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_MODEL || 'gemini-2.5-flash' }}
+            SetListChartRanking__VertexAiLocation=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_LOCATION || 'eu' }}
+            SetListChartRanking__VertexAiModel=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_MODEL || 'gemini-3.1-flash-lite' }}
+            ReceiptAnalysis__Enabled=${{ vars.RECEIPT_ANALYSIS_ENABLED || 'false' }}
+            ReceiptAnalysis__VertexAiProjectId=${{ vars.RECEIPT_ANALYSIS_VERTEX_AI_PROJECT_ID || env.GCP_PROJECT_ID }}
+            ReceiptAnalysis__VertexAiLocation=${{ vars.RECEIPT_ANALYSIS_VERTEX_AI_LOCATION || 'eu' }}
+            ReceiptAnalysis__VertexAiModel=${{ vars.RECEIPT_ANALYSIS_VERTEX_AI_MODEL || 'gemini-3.1-flash-lite' }}
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest
@@ -455,8 +459,12 @@ jobs:
             Mcp__OAuth__Clients__0__Scopes__0=mcp:read
             SetListChartRanking__Provider=${{ vars.SET_LIST_CHART_RANKING_PROVIDER || 'Deterministic' }}
             SetListChartRanking__VertexAiProjectId=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_PROJECT_ID || env.GCP_PROJECT_ID }}
-            SetListChartRanking__VertexAiLocation=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_LOCATION || env.GCP_REGION }}
-            SetListChartRanking__VertexAiModel=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_MODEL || 'gemini-2.5-flash' }}
+            SetListChartRanking__VertexAiLocation=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_LOCATION || 'eu' }}
+            SetListChartRanking__VertexAiModel=${{ vars.SET_LIST_CHART_RANKING_VERTEX_AI_MODEL || 'gemini-3.1-flash-lite' }}
+            ReceiptAnalysis__Enabled=${{ vars.RECEIPT_ANALYSIS_ENABLED || 'false' }}
+            ReceiptAnalysis__VertexAiProjectId=${{ vars.RECEIPT_ANALYSIS_VERTEX_AI_PROJECT_ID || env.GCP_PROJECT_ID }}
+            ReceiptAnalysis__VertexAiLocation=${{ vars.RECEIPT_ANALYSIS_VERTEX_AI_LOCATION || 'eu' }}
+            ReceiptAnalysis__VertexAiModel=${{ vars.RECEIPT_ANALYSIS_VERTEX_AI_MODEL || 'gemini-3.1-flash-lite' }}
           secrets: |-
             Authentication__Google__ClientId=google-client-id:latest
             Authentication__Google__ClientSecret=google-client-secret:latest

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Google.Cloud.AIPlatform.V1" Version="3.72.0" />
+    <PackageVersion Include="Google.GenAI" Version="1.16.0" />
     <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.14.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.8" />

--- a/README.md
+++ b/README.md
@@ -149,12 +149,16 @@ export Email__Invoices__FromDisplayName="Glovelly Invoices"
    - `Email__Mode`
    - `Email__AccessRequests__FromAddress`
    - `Email__AccessRequests__FromDisplayName`
-    - `Email__Invoices__FromAddress`
-    - `Email__Invoices__FromDisplayName`
-    - `SetListChartRanking__Provider`
-    - `SetListChartRanking__VertexAiProjectId`
-    - `SetListChartRanking__VertexAiLocation`
-    - `SetListChartRanking__VertexAiModel`
+   - `Email__Invoices__FromAddress`
+   - `Email__Invoices__FromDisplayName`
+   - `SetListChartRanking__Provider`
+   - `SetListChartRanking__VertexAiProjectId`
+   - `SetListChartRanking__VertexAiLocation`
+   - `SetListChartRanking__VertexAiModel`
+   - `ReceiptAnalysis__Enabled`
+   - `ReceiptAnalysis__VertexAiProjectId`
+   - `ReceiptAnalysis__VertexAiLocation`
+   - `ReceiptAnalysis__VertexAiModel`
 
 The frontend signs users in through `/auth/login`, the backend completes the Google OpenID Connect flow, and the app stores the session in a secure cookie before allowing access to `/clients`, `/gigs`, `/invoices`, and `/invoice-lines`.
 
@@ -167,11 +171,30 @@ gcloud auth application-default login
 cd backend/Glovelly.Api
 dotnet user-secrets set "SetListChartRanking:Provider" "VertexAi"
 dotnet user-secrets set "SetListChartRanking:VertexAiProjectId" "your-gcp-project-id"
-dotnet user-secrets set "SetListChartRanking:VertexAiLocation" "europe-west1"
-dotnet user-secrets set "SetListChartRanking:VertexAiModel" "gemini-2.5-flash"
+dotnet user-secrets set "SetListChartRanking:VertexAiLocation" "eu"
+dotnet user-secrets set "SetListChartRanking:VertexAiModel" "gemini-3.1-flash-lite"
 ```
 
 The configured principal must be able to call Vertex AI, for example with `roles/aiplatform.user`. If any required Vertex AI setting is missing or `Provider` remains `Deterministic`, Glovelly uses the deterministic fallback and does not call Gemini.
+
+### Vertex AI receipt analysis
+
+Receipt analysis is disabled unless `ReceiptAnalysis:Enabled` is `true` and its Vertex project, location, and model are configured. The Cloud Run service account needs `roles/aiplatform.user`. Receipt analysis defaults to Gemini 3.5 Flash, while set-list chart matching remains on Gemini 3.1 Flash Lite. A user explicitly starts analysis from a stored expense receipt; Glovelly sends supported receipt media up to the configured analysis limit to Vertex AI and presents validated suggestions for review. Analysis does not automatically change an expense.
+
+To enable it locally, authenticate with Application Default Credentials and configure the receipt-analysis options with user secrets:
+
+```bash
+gcloud auth application-default login
+cd backend/Glovelly.Api
+dotnet user-secrets set "ReceiptAnalysis:Enabled" "true"
+dotnet user-secrets set "ReceiptAnalysis:VertexAiProjectId" "your-gcp-project-id"
+dotnet user-secrets set "ReceiptAnalysis:VertexAiLocation" "eu"
+dotnet user-secrets set "ReceiptAnalysis:VertexAiModel" "gemini-3.1-flash-lite"
+```
+
+Optional limits can be configured with `ReceiptAnalysis:MaxFileSizeBytes`, `ReceiptAnalysis:Timeout`, `ReceiptAnalysis:PerUserPermitLimit`, and `ReceiptAnalysis:PerUserWindow`.
+
+Do not enable provider request/response logging for receipt analysis. Operational logs contain only identifiers, configured model, outcome, elapsed time, and failure classification. Monitor Vertex usage and cost from the Google Cloud billing console before widening access or enabling automatic/background analysis.
 
 ### Google Routes mileage estimates
 

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -588,6 +588,48 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task ReceiptAnalysisEndpoints_PersistUnavailableAttemptAndReturnLatest()
+    {
+        var createResponse = await _client.PostAsJsonAsync("/gigs", new
+        {
+            clientId = TestData.FoxAndFinchId, title = "Receipt analysis test", date = "2026-06-10", venue = "Station", fee = 120m,
+            travelMiles = 0m, wasDriving = true, status = 1, expenses = new[] { new { description = "Taxi", amount = 38.42m } },
+        }, TestContext.Current.CancellationToken);
+        var gig = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        var gigId = gig.GetProperty("id").GetGuid();
+        var expenseId = gig.GetProperty("expenses")[0].GetProperty("id").GetGuid();
+        using var form = new MultipartFormDataContent();
+        using var file = new ByteArrayContent("receipt evidence"u8.ToArray());
+        file.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        form.Add(file, "file", "receipt.pdf");
+        var upload = await _client.PostAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments", form, TestContext.Current.CancellationToken);
+        var attachment = await upload.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        var attachmentId = attachment.GetProperty("id").GetGuid();
+
+        var analysis = await _client.PostAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}/analysis", null, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, analysis.StatusCode);
+        var created = await analysis.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("Failed", created.GetProperty("status").GetString());
+        Assert.Equal("unavailable", created.GetProperty("failureCode").GetString());
+
+        var latest = await _client.GetAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}/analysis", TestContext.Current.CancellationToken);
+        var latestResult = await latest.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(created.GetProperty("id").GetGuid(), latestResult.GetProperty("id").GetGuid());
+        var unchangedGig = await _client.GetFromJsonAsync<JsonElement>($"/gigs/{gigId}", JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("Taxi", unchangedGig.GetProperty("expenses")[0].GetProperty("description").GetString());
+        Assert.Equal(38.42m, unchangedGig.GetProperty("expenses")[0].GetProperty("amount").GetDecimal());
+
+        for (var attempt = 1; attempt < 10; attempt++)
+        {
+            var retry = await _client.PostAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}/analysis", null, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, retry.StatusCode);
+        }
+
+        var limited = await _client.PostAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}/analysis", null, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);
+    }
+
+    [Fact]
     public async Task QuickReceiptDraft_WithNearbyGig_CreatesDraftExpenseAndAttachment()
     {
         var today = new DateOnly(2026, 1, 1);

--- a/backend/Glovelly.Api.Tests/VertexAiSetListChartContextualRankerTests.cs
+++ b/backend/Glovelly.Api.Tests/VertexAiSetListChartContextualRankerTests.cs
@@ -1,10 +1,11 @@
-using Google.Cloud.AIPlatform.V1;
+using Google.GenAI.Types;
 using Glovelly.Api.Models;
 using Glovelly.Api.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 using Xunit;
+using GenAiType = Google.GenAI.Types.Type;
 
 namespace Glovelly.Api.Tests;
 
@@ -15,8 +16,8 @@ public sealed class VertexAiSetListChartContextualRankerTests
     {
         Provider = "VertexAi",
         VertexAiProjectId = "test-project",
-        VertexAiLocation = "europe-west1",
-        VertexAiModel = "gemini-2.5-flash",
+        VertexAiLocation = "eu",
+        VertexAiModel = "gemini-3.1-flash-lite",
     };
 
     private static readonly Guid ChartId = Guid.NewGuid();
@@ -66,6 +67,35 @@ public sealed class VertexAiSetListChartContextualRankerTests
         Assert.Equal(ForScoreMappingConfidence.High, decision.Confidence);
         Assert.Equal(ChartId, decision.SelectedChartId);
         Assert.Equal(1, decision.SourceRowNumber);
+    }
+
+    [Fact]
+    public async Task RankAsync_SendsJsonOnlyRequestToConfiguredModel()
+    {
+        string? capturedModel = null;
+        GenerateContentConfig? capturedConfig = null;
+        var ranker = new VertexAiSetListChartContextualRanker(
+            (model, _, config, _) =>
+            {
+                capturedModel = model;
+                capturedConfig = config;
+                return Task.FromResult(new GenerateContentResponse
+                {
+                    Candidates = [new Candidate { Content = new Content { Parts = [new Part { Text = "{\"decisions\":[]}" }] } }],
+                });
+            },
+            SettingsOptions,
+            Fallback,
+            NullLogger<VertexAiSetListChartContextualRanker>.Instance);
+
+        await ranker.RankAsync(SingleRowRequest, TestContext.Current.CancellationToken);
+
+        Assert.Equal("gemini-3.1-flash-lite", capturedModel);
+        Assert.NotNull(capturedConfig);
+        Assert.Equal("application/json", capturedConfig!.ResponseMimeType);
+        var decisionSchema = capturedConfig.ResponseSchema!.Properties!["decisions"].Items!;
+        Assert.Equal(GenAiType.String, decisionSchema.Properties!["selectedChartId"].Type);
+        Assert.All(decisionSchema.Properties.Values, schema => Assert.False(schema.Nullable));
     }
 
     [Fact]
@@ -246,25 +276,22 @@ public sealed class VertexAiSetListChartContextualRankerTests
         Assert.Null(decision.SelectedChartId);
     }
 
-    private static Func<GenerateContentRequest, CancellationToken, Task<GenerateContentResponse>> CreateGenerateContentAsync(string responseText)
+    private static Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> CreateGenerateContentAsync(string responseText)
     {
-        return (_, _) =>
+        return (_, _, _, _) =>
         {
-            var response = new GenerateContentResponse();
-            response.Candidates.Add(new Candidate
+            return Task.FromResult(new GenerateContentResponse
             {
-                Content = new Content
+                Candidates = [new Candidate
                 {
-                    Parts = { new Part { Text = responseText } }
-                }
+                    Content = new Content { Parts = [new Part { Text = responseText }] }
+                }]
             });
-
-            return Task.FromResult(response);
         };
     }
 
-    private static Func<GenerateContentRequest, CancellationToken, Task<GenerateContentResponse>> CreateGenerateContentAsync(Exception exception)
+    private static Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> CreateGenerateContentAsync(Exception exception)
     {
-        return (_, _) => throw exception;
+        return (_, _, _, _) => throw exception;
     }
 }

--- a/backend/Glovelly.Api.Tests/VertexReceiptAnalysisServiceTests.cs
+++ b/backend/Glovelly.Api.Tests/VertexReceiptAnalysisServiceTests.cs
@@ -1,0 +1,113 @@
+using Google.GenAI.Types;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Glovelly.Api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Text;
+using Xunit;
+using GenAiType = Google.GenAI.Types.Type;
+
+namespace Glovelly.Api.Tests;
+
+public sealed class VertexReceiptAnalysisServiceTests
+{
+    [Fact]
+    public async Task AnalyzeAsync_PersistsValidatedSuggestionsAndSendsInlineMedia()
+    {
+        string? capturedModel = null;
+        List<Content>? capturedContents = null;
+        GenerateContentConfig? capturedConfig = null;
+        await using var db = CreateDb();
+        var store = await CreateStoreAsync();
+        var service = CreateService(db, store, (model, contents, config) =>
+        {
+            capturedModel = model;
+            capturedContents = contents;
+            capturedConfig = config;
+            return """{"merchant":"Station Cafe","merchantConfidence":"high","transactionDate":"2026-01-02","totalAmount":"12.50","totalAmountConfidence":"medium","currency":"GBP","suggestedCategory":"meals","warnings":[]}""";
+        });
+
+        var result = await service.AnalyzeAsync(CreateAttachment(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(ReceiptAnalysisStatus.Succeeded, result.Status);
+        Assert.Equal("Station Cafe", result.Merchant.Value);
+        Assert.Equal(12.50m, result.TotalAmount.Value);
+        Assert.Equal(ReceiptAnalysisConfidence.High, result.Merchant.Confidence);
+        Assert.Equal("test-model", capturedModel);
+        Assert.NotNull(capturedConfig);
+        Assert.Equal("application/json", capturedConfig!.ResponseMimeType);
+        Assert.Equal(GenAiType.Object, capturedConfig.ResponseSchema!.Type);
+        Assert.Equal(GenAiType.String, capturedConfig.ResponseSchema.Properties!["merchantConfidence"].Type);
+        Assert.False(capturedConfig.ResponseSchema.Properties["merchant"].Nullable);
+        Assert.NotNull(capturedContents);
+        Assert.Equal("image/jpeg", capturedContents![0].Parts![1].InlineData!.MimeType);
+        var attempt = Assert.Single(db.ReceiptAnalyses);
+        Assert.Equal("VertexAi", attempt.Provider);
+        Assert.Equal("receipt-v1", attempt.PromptVersion);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_RetainsValidFieldsAndWarnsForInvalidOnes()
+    {
+        await using var db = CreateDb();
+        var service = CreateService(db, await CreateStoreAsync(), (_, _, _) =>
+            """{"merchant":"Station Cafe","merchantConfidence":"high","transactionDate":"02/01/2026","totalAmount":12.50,"currency":"gbp","suggestedCategory":"unknown","warnings":["Check total"]}""");
+
+        var result = await service.AnalyzeAsync(CreateAttachment(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(ReceiptAnalysisStatus.Succeeded, result.Status);
+        Assert.Equal("Station Cafe", result.Merchant.Value);
+        Assert.Null(result.TransactionDate.Value);
+        Assert.Null(result.TotalAmount.Value);
+        Assert.Contains("transactionDate was ignored because it was invalid.", result.Warnings);
+        Assert.Contains("Check total", result.Warnings);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_DoesNotCallVertexForUnsupportedMediaAndPersistsSafeFailure()
+    {
+        await using var db = CreateDb();
+        var called = false;
+        var service = CreateService(db, await CreateStoreAsync(), (_, _, _) => { called = true; return "{}"; });
+        var attachment = CreateAttachment();
+        attachment.ContentType = "image/heic";
+
+        var result = await service.AnalyzeAsync(attachment, TestContext.Current.CancellationToken);
+
+        Assert.Equal(ReceiptAnalysisStatus.Failed, result.Status);
+        Assert.Equal("unsupported_media", result.FailureCode);
+        Assert.False(called);
+        Assert.Null(result.Merchant.Value);
+    }
+
+    private static AppDbContext CreateDb() => new(new DbContextOptionsBuilder<AppDbContext>()
+        .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+
+    private static async Task<InMemoryExpenseAttachmentStore> CreateStoreAsync()
+    {
+        var store = new InMemoryExpenseAttachmentStore();
+        await store.SaveAsync("receipt", new MemoryStream(Encoding.UTF8.GetBytes("receipt")), "image/jpeg");
+        return store;
+    }
+
+    private static ExpenseAttachment CreateAttachment() => new()
+    {
+        Id = Guid.NewGuid(), GigExpenseId = Guid.NewGuid(), StorageKey = "receipt", ContentType = "image/jpeg", SizeBytes = 7,
+    };
+
+    private static VertexReceiptAnalysisService CreateService(AppDbContext db, IExpenseAttachmentStore store, Func<string, List<Content>, GenerateContentConfig, string> response)
+    {
+        return new VertexReceiptAnalysisService(
+            (model, contents, config, _) => Task.FromResult(new GenerateContentResponse
+            {
+                Candidates = [new Candidate { Content = new Content { Parts = [new Part { Text = response(model, contents, config) }] } }],
+            }),
+            db,
+            store,
+            Options.Create(new ReceiptAnalysisSettings { Enabled = true, VertexAiProjectId = "test-project", VertexAiLocation = "eu", VertexAiModel = "test-model" }),
+            TimeProvider.System,
+            NullLogger<VertexReceiptAnalysisService>.Instance);
+    }
+}

--- a/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -20,6 +20,8 @@ internal static class InfrastructureServiceCollectionExtensions
     {
         var accessRequestSettings = configuration.GetSection(AccessRequestProtectionSettings.SectionName)
             .Get<AccessRequestProtectionSettings>() ?? new AccessRequestProtectionSettings();
+        var receiptAnalysisSettings = configuration.GetSection(ReceiptAnalysisSettings.SectionName)
+            .Get<ReceiptAnalysisSettings>() ?? new ReceiptAnalysisSettings();
 
         services.AddSingleton(settings);
         services.AddEndpointsApiExplorer();
@@ -103,6 +105,16 @@ internal static class InfrastructureServiceCollectionExtensions
         {
             options.OnRejected = async (context, cancellationToken) =>
             {
+                if (context.HttpContext.Request.Path.StartsWithSegments("/gigs"))
+                {
+                    context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                    context.HttpContext.Response.ContentType = "application/json";
+                    await context.HttpContext.Response.WriteAsync(
+                        "{\"message\":\"Receipt analysis rate limit reached. Please try again later.\"}",
+                        cancellationToken);
+                    return;
+                }
+
                 var logger = context.HttpContext.RequestServices
                     .GetRequiredService<ILoggerFactory>()
                     .CreateLogger("Glovelly.AccessRequests");
@@ -126,6 +138,19 @@ internal static class InfrastructureServiceCollectionExtensions
                         Window = accessRequestSettings.PerIpShortWindow,
                         QueueLimit = 0,
                         AutoReplenishment = true
+                    });
+            });
+            options.AddPolicy<string>("ReceiptAnalysis", httpContext =>
+            {
+                var userId = httpContext.User.FindFirst(GlovellyClaimTypes.UserId)?.Value ?? "anonymous";
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    userId,
+                    _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = receiptAnalysisSettings.PerUserPermitLimit,
+                        Window = receiptAnalysisSettings.PerUserWindow,
+                        QueueLimit = 0,
+                        AutoReplenishment = true,
                     });
             });
         });

--- a/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
+++ b/backend/Glovelly.Api/Configuration/WebApplicationExtensions.cs
@@ -44,8 +44,8 @@ internal static class WebApplicationExtensions
             app.UseCors(settings.DevCorsPolicy);
         }
 
-        app.UseRateLimiter();
         app.UseAuthentication();
+        app.UseRateLimiter();
         app.UseAuthorization();
         app.UseDefaultFiles();
         app.UseStaticFiles();

--- a/backend/Glovelly.Api/Data/AppDbContext.cs
+++ b/backend/Glovelly.Api/Data/AppDbContext.cs
@@ -22,6 +22,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<ForScoreLibrarySnapshot> ForScoreLibrarySnapshots => Set<ForScoreLibrarySnapshot>();
     public DbSet<ForScoreChart> ForScoreCharts => Set<ForScoreChart>();
     public DbSet<ExpenseAttachment> ExpenseAttachments => Set<ExpenseAttachment>();
+    public DbSet<ReceiptAnalysis> ReceiptAnalyses => Set<ReceiptAnalysis>();
     public DbSet<Invoice> Invoices => Set<Invoice>();
     public DbSet<InvoiceLine> InvoiceLines => Set<InvoiceLine>();
     public DbSet<SellerProfile> SellerProfiles => Set<SellerProfile>();

--- a/backend/Glovelly.Api/Data/Configuration/ReceiptAnalysisConfiguration.cs
+++ b/backend/Glovelly.Api/Data/Configuration/ReceiptAnalysisConfiguration.cs
@@ -1,0 +1,28 @@
+using Glovelly.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Glovelly.Api.Data.Configuration;
+
+internal sealed class ReceiptAnalysisConfiguration : IEntityTypeConfiguration<ReceiptAnalysis>
+{
+    public void Configure(EntityTypeBuilder<ReceiptAnalysis> entity)
+    {
+        entity.HasKey(analysis => analysis.Id);
+        entity.Property(analysis => analysis.Status).HasConversion<string>().HasMaxLength(20);
+        entity.Property(analysis => analysis.Provider).IsRequired().HasMaxLength(50);
+        entity.Property(analysis => analysis.Model).IsRequired().HasMaxLength(200);
+        entity.Property(analysis => analysis.PromptVersion).IsRequired().HasMaxLength(50);
+        entity.Property(analysis => analysis.Merchant).HasMaxLength(200);
+        entity.Property(analysis => analysis.Currency).HasMaxLength(3);
+        entity.Property(analysis => analysis.SuggestedCategory).HasMaxLength(50);
+        entity.Property(analysis => analysis.FailureCode).HasMaxLength(50);
+        entity.Property(analysis => analysis.FailureMessage).HasMaxLength(300);
+        entity.Property(analysis => analysis.Warnings).HasColumnType("jsonb");
+        entity.HasIndex(analysis => new { analysis.ExpenseAttachmentId, analysis.RequestedAt });
+        entity.HasOne(analysis => analysis.ExpenseAttachment)
+            .WithMany(attachment => attachment.Analyses)
+            .HasForeignKey(analysis => analysis.ExpenseAttachmentId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
+++ b/backend/Glovelly.Api/Data/DevelopmentDataSeeder.cs
@@ -21,6 +21,7 @@ public sealed record DevelopmentSeedFixture(
 public static class DevelopmentDataSeeder
 {
     private static readonly DateTimeOffset SeededCreatedUtc = new(2026, 3, 15, 9, 0, 0, TimeSpan.Zero);
+    private static readonly DateOnly SeededToday = DateOnly.FromDateTime(DateTime.UtcNow);
     private static readonly byte[] SeededPdfContent = "Seeded development invoice PDF placeholder"u8.ToArray();
 
     public static async Task SeedAsync(
@@ -294,7 +295,7 @@ public static class DevelopmentDataSeeder
                 ClientId = foxAndFinchId,
                 InvoiceId = invoices[0].Id,
                 Title = "Spring Product Launch",
-                Date = new DateOnly(2026, 4, 18),
+                Date = SeededToday.AddDays(-1),
                 Venue = "Albert Hall, Manchester",
                 Fee = 650m,
                 TravelMiles = 24m,
@@ -361,7 +362,7 @@ public static class DevelopmentDataSeeder
                 Id = Guid.Parse("58dc078d-bf9d-4dfb-b515-c9ec9cb2d75b"),
                 ClientId = northlightId,
                 Title = "Lakeside Wedding Reception",
-                Date = new DateOnly(2026, 5, 2),
+                Date = SeededToday,
                 Venue = "The Glasshouse, Windermere",
                 Fee = 920m,
                 TravelMiles = 78m,
@@ -407,7 +408,7 @@ public static class DevelopmentDataSeeder
                 ClientId = riversideId,
                 InvoiceId = invoices[1].Id,
                 Title = "Community Residency Weekend",
-                Date = new DateOnly(2026, 5, 11),
+                Date = SeededToday.AddDays(1),
                 Venue = "Riverside Arts Centre",
                 Fee = 360m,
                 TravelMiles = 12m,
@@ -723,7 +724,7 @@ public static class DevelopmentDataSeeder
             .Select(index =>
             {
                 var status = statuses[index % statuses.Length];
-                var date = new DateOnly(2026, 4, 10).AddDays(index * 4);
+                var date = SeededToday.AddDays(-32 + (index * 4));
                 var invoice = index < additionalInvoices.Count ? additionalInvoices[index] : null;
 
                 return new Gig

--- a/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigEndpoints.cs
@@ -12,7 +12,8 @@ public static class GigEndpoints
             .MapGigExternalResourceEndpoints()
             .MapGigSetListImportEndpoints()
             .MapGigMileageEndpoints()
-            .MapGigAttachmentEndpoints();
+            .MapGigAttachmentEndpoints()
+            .MapGigReceiptAnalysisEndpoints();
 
         return group;
     }

--- a/backend/Glovelly.Api/Endpoints/GigReceiptAnalysisEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigReceiptAnalysisEndpoints.cs
@@ -1,0 +1,37 @@
+using Glovelly.Api.Auth;
+using Glovelly.Api.Data;
+using Glovelly.Api.Services;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace Glovelly.Api.Endpoints;
+
+internal static class GigReceiptAnalysisEndpoints
+{
+    public static RouteGroupBuilder MapGigReceiptAnalysisEndpoints(this RouteGroupBuilder group)
+    {
+        const string route = "/{gigId:guid}/expenses/{expenseId:guid}/attachments/{attachmentId:guid}/analysis";
+
+        group.MapGet(route, async (Guid gigId, Guid expenseId, Guid attachmentId, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor) =>
+        {
+            var attachment = await GigEndpointSupport.FindVisibleAttachmentAsync(db, currentUserAccessor.TryGetUserId(user), gigId, expenseId, attachmentId, asNoTracking: true);
+            if (attachment is null) return Results.NotFound();
+
+            var latest = await db.ReceiptAnalyses.AsNoTracking()
+                .Where(analysis => analysis.ExpenseAttachmentId == attachmentId)
+                .OrderByDescending(analysis => analysis.RequestedAt)
+                .FirstOrDefaultAsync();
+            return latest is null ? Results.NoContent() : Results.Ok(VertexReceiptAnalysisService.ToResult(latest));
+        });
+
+        group.MapPost(route, async (Guid gigId, Guid expenseId, Guid attachmentId, AppDbContext db, ClaimsPrincipal user, ICurrentUserAccessor currentUserAccessor, IReceiptAnalysisService receiptAnalysisService, CancellationToken cancellationToken) =>
+        {
+            var attachment = await GigEndpointSupport.FindVisibleAttachmentAsync(db, currentUserAccessor.TryGetUserId(user), gigId, expenseId, attachmentId, asNoTracking: false);
+            if (attachment is null) return Results.NotFound();
+            return Results.Ok(await receiptAnalysisService.AnalyzeAsync(attachment, cancellationToken));
+        }).RequireRateLimiting("ReceiptAnalysis");
+
+        return group;
+    }
+}

--- a/backend/Glovelly.Api/Glovelly.Api.csproj
+++ b/backend/Glovelly.Api/Glovelly.Api.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.AIPlatform.V1" />
+    <PackageReference Include="Google.GenAI" />
     <PackageReference Include="Google.Cloud.Storage.V1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" />

--- a/backend/Glovelly.Api/Models/ExpenseAttachment.cs
+++ b/backend/Glovelly.Api/Models/ExpenseAttachment.cs
@@ -15,4 +15,6 @@ public sealed class ExpenseAttachment
 
     [JsonIgnore]
     public GigExpense? Expense { get; set; }
+    [JsonIgnore]
+    public ICollection<ReceiptAnalysis> Analyses { get; set; } = new List<ReceiptAnalysis>();
 }

--- a/backend/Glovelly.Api/Models/ReceiptAnalysis.cs
+++ b/backend/Glovelly.Api/Models/ReceiptAnalysis.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Glovelly.Api.Models;
+
+public enum ReceiptAnalysisStatus
+{
+    Succeeded,
+    Failed,
+}
+
+public enum ReceiptAnalysisConfidence
+{
+    None,
+    Low,
+    Medium,
+    High,
+}
+
+public sealed class ReceiptAnalysis
+{
+    public Guid Id { get; set; }
+    public Guid ExpenseAttachmentId { get; set; }
+    public ReceiptAnalysisStatus Status { get; set; }
+    public string Provider { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public string PromptVersion { get; set; } = string.Empty;
+    public DateTimeOffset RequestedAt { get; set; }
+    public DateTimeOffset CompletedAt { get; set; }
+    public string? Merchant { get; set; }
+    public DateOnly? TransactionDate { get; set; }
+    public decimal? TotalAmount { get; set; }
+    public string? Currency { get; set; }
+    public string? SuggestedCategory { get; set; }
+    public ReceiptAnalysisConfidence MerchantConfidence { get; set; }
+    public ReceiptAnalysisConfidence TransactionDateConfidence { get; set; }
+    public ReceiptAnalysisConfidence TotalAmountConfidence { get; set; }
+    public ReceiptAnalysisConfidence CurrencyConfidence { get; set; }
+    public ReceiptAnalysisConfidence SuggestedCategoryConfidence { get; set; }
+    public List<string> Warnings { get; set; } = [];
+    public string? FailureCode { get; set; }
+    public string? FailureMessage { get; set; }
+
+    [JsonIgnore]
+    public ExpenseAttachment? ExpenseAttachment { get; set; }
+}

--- a/backend/Glovelly.Api/Services/ReceiptAnalysisContracts.cs
+++ b/backend/Glovelly.Api/Services/ReceiptAnalysisContracts.cs
@@ -1,0 +1,29 @@
+using Glovelly.Api.Models;
+
+namespace Glovelly.Api.Services;
+
+public sealed record ReceiptAnalysisTarget(Guid GigId, Guid ExpenseId, Guid AttachmentId);
+
+public sealed record ReceiptAnalysisField<T>(T Value, ReceiptAnalysisConfidence Confidence);
+
+public sealed record ReceiptAnalysisResult(
+    Guid Id,
+    ReceiptAnalysisStatus Status,
+    string Provider,
+    string Model,
+    string PromptVersion,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset CompletedAt,
+    ReceiptAnalysisField<string?> Merchant,
+    ReceiptAnalysisField<DateOnly?> TransactionDate,
+    ReceiptAnalysisField<decimal?> TotalAmount,
+    ReceiptAnalysisField<string?> Currency,
+    ReceiptAnalysisField<string?> SuggestedCategory,
+    IReadOnlyList<string> Warnings,
+    string? FailureCode,
+    string? FailureMessage);
+
+public interface IReceiptAnalysisService
+{
+    Task<ReceiptAnalysisResult> AnalyzeAsync(ExpenseAttachment attachment, CancellationToken cancellationToken = default);
+}

--- a/backend/Glovelly.Api/Services/ReceiptAnalysisSettings.cs
+++ b/backend/Glovelly.Api/Services/ReceiptAnalysisSettings.cs
@@ -1,0 +1,21 @@
+namespace Glovelly.Api.Services;
+
+public sealed class ReceiptAnalysisSettings
+{
+    public const string SectionName = "ReceiptAnalysis";
+
+    public bool Enabled { get; set; }
+    public string? VertexAiProjectId { get; set; }
+    public string? VertexAiLocation { get; set; } = "eu";
+    public string? VertexAiModel { get; set; } = "gemini-3.1-flash-lite";
+    public string[] AllowedContentTypes { get; set; } = ["image/jpeg", "image/png", "image/webp", "application/pdf"];
+    public long MaxFileSizeBytes { get; set; } = 5 * 1024 * 1024;
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(20);
+    public int PerUserPermitLimit { get; set; } = 10;
+    public TimeSpan PerUserWindow { get; set; } = TimeSpan.FromHours(1);
+
+    public bool IsConfigured => Enabled
+        && !string.IsNullOrWhiteSpace(VertexAiProjectId)
+        && !string.IsNullOrWhiteSpace(VertexAiLocation)
+        && !string.IsNullOrWhiteSpace(VertexAiModel);
+}

--- a/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
+++ b/backend/Glovelly.Api/Services/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Google.Cloud.AIPlatform.V1;
 using Google.Cloud.Storage.V1;
 using Glovelly.Api.Configuration;
 using Microsoft.Extensions.Options;
@@ -13,6 +12,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(TimeProvider.System);
         services.AddOptions<SetListChartRankingSettings>()
             .BindConfiguration(SetListChartRankingSettings.SectionName);
+        services.AddOptions<ReceiptAnalysisSettings>()
+            .BindConfiguration(ReceiptAnalysisSettings.SectionName);
         services.AddScoped<AccessRequestWorkflowService>();
         services.AddScoped<AccessRequestRetentionService>();
         services.AddScoped<IExpenseStatementBuilder, ExpenseStatementBuilder>();
@@ -31,6 +32,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<SetListChartMatchJobProcessor>();
         services.AddScoped<DeterministicSetListChartContextualRanker>();
         services.AddScoped<VertexAiSetListChartContextualRanker>();
+        services.AddScoped<VertexReceiptAnalysisService>();
+        services.AddScoped<IReceiptAnalysisService, VertexReceiptAnalysisService>();
         services.AddScoped<ISetListChartContextualRanker>(provider =>
         {
             var settings = provider.GetRequiredService<IOptions<SetListChartRankingSettings>>().Value;
@@ -39,7 +42,7 @@ public static class ServiceCollectionExtensions
             {
                 logger.LogInformation(
                     "Set list chart ranking provider selected: VertexAi using model {Model} in {Location}.",
-                    settings.VertexAiModel ?? "gemini-2.5-flash",
+                    settings.VertexAiModel ?? "gemini-3.1-flash-lite",
                     settings.VertexAiLocation);
                 return provider.GetRequiredService<VertexAiSetListChartContextualRanker>();
             }

--- a/backend/Glovelly.Api/Services/SetListChartRankingSettings.cs
+++ b/backend/Glovelly.Api/Services/SetListChartRankingSettings.cs
@@ -8,9 +8,9 @@ public sealed class SetListChartRankingSettings
 
     public string? VertexAiProjectId { get; set; }
 
-    public string? VertexAiLocation { get; set; }
+    public string? VertexAiLocation { get; set; } = "eu";
 
-    public string? VertexAiModel { get; set; }
+    public string? VertexAiModel { get; set; } = "gemini-3.1-flash-lite";
 
     public bool IsVertexAiConfigured =>
         string.Equals(Provider, "VertexAi", StringComparison.OrdinalIgnoreCase)

--- a/backend/Glovelly.Api/Services/VertexAiSetListChartContextualRanker.cs
+++ b/backend/Glovelly.Api/Services/VertexAiSetListChartContextualRanker.cs
@@ -1,14 +1,17 @@
 using Glovelly.Api.Models;
-using Google.Cloud.AIPlatform.V1;
+using Google.GenAI;
+using Google.GenAI.Types;
 using Microsoft.Extensions.Options;
 using System.Diagnostics;
 using System.Text.Json;
+using GenAiClient = Google.GenAI.Client;
+using GenAiType = Google.GenAI.Types.Type;
 
 namespace Glovelly.Api.Services;
 
 public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextualRanker
 {
-    private readonly Func<GenerateContentRequest, CancellationToken, Task<GenerateContentResponse>> _generateContentAsync;
+    private readonly Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> _generateContentAsync;
     private readonly SetListChartRankingSettings _settings;
     private readonly DeterministicSetListChartContextualRanker _fallback;
     private readonly ILogger<VertexAiSetListChartContextualRanker> _logger;
@@ -22,7 +25,7 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
     }
 
     public VertexAiSetListChartContextualRanker(
-        Func<GenerateContentRequest, CancellationToken, Task<GenerateContentResponse>> generateContentAsync,
+        Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> generateContentAsync,
         IOptions<SetListChartRankingSettings> options,
         DeterministicSetListChartContextualRanker fallback,
         ILogger<VertexAiSetListChartContextualRanker> logger)
@@ -33,14 +36,10 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
         _logger = logger;
     }
 
-    private static Func<GenerateContentRequest, CancellationToken, Task<GenerateContentResponse>> CreateGenerateContentAsync(SetListChartRankingSettings settings)
+    private static Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> CreateGenerateContentAsync(SetListChartRankingSettings settings)
     {
-        var client = new PredictionServiceClientBuilder
-        {
-            Endpoint = $"{settings.VertexAiLocation ?? "europe-west1"}-aiplatform.googleapis.com",
-        }.Build();
-
-        return client.GenerateContentAsync;
+        var client = new GenAiClient(project: settings.VertexAiProjectId, location: settings.VertexAiLocation, enterprise: true);
+        return (model, contents, config, cancellationToken) => client.Models.GenerateContentAsync(model, contents, config, cancellationToken);
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -63,20 +62,21 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
         var songRows = request.CandidateSets.Count(candidateSet => candidateSet.Input.Kind == GigSetListItemKind.Song && candidateSet.Input.Include);
         var candidateCount = request.CandidateSets.Sum(candidateSet => candidateSet.Candidates.Count);
 
-        var generateRequest = new GenerateContentRequest
+        var generateConfig = new GenerateContentConfig
         {
-            Model = $"projects/{_settings.VertexAiProjectId}/locations/{_settings.VertexAiLocation}/publishers/google/models/{_settings.VertexAiModel ?? "gemini-2.5-flash"}",
+            ResponseMimeType = "application/json",
+            ResponseSchema = ResponseSchema,
             SystemInstruction = new Content
             {
-                Parts = { new Part { Text = SystemPrompt } }
+                Parts = [new Part { Text = SystemPrompt }]
             },
-            Contents =
+        };
+        var contents = new List<Content>
+        {
+            new()
             {
-                new Content
-                {
-                    Role = "user",
-                    Parts = { new Part { Text = prompt } }
-                }
+                Role = "user",
+                Parts = [new Part { Text = prompt }]
             }
         };
 
@@ -84,7 +84,7 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
         {
             _logger.LogInformation(
                 "Calling Vertex AI chart ranker using model {Model} in {Location} for snapshot {SnapshotId}: {SongRowCount} song rows, {CandidateCount} supplied candidates, {PromptLength} prompt characters.",
-                _settings.VertexAiModel ?? "gemini-2.5-flash",
+                _settings.VertexAiModel ?? "gemini-3.1-flash-lite",
                 _settings.VertexAiLocation,
                 request.SnapshotId,
                 songRows,
@@ -92,7 +92,7 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
                 prompt.Length);
 
             var stopwatch = Stopwatch.StartNew();
-            var response = await _generateContentAsync(generateRequest, cancellationToken);
+            var response = await _generateContentAsync(_settings.VertexAiModel ?? "gemini-3.1-flash-lite", contents, generateConfig, cancellationToken);
             stopwatch.Stop();
             var text = response?.Candidates?.FirstOrDefault()?.Content?.Parts?.FirstOrDefault()?.Text;
             if (string.IsNullOrWhiteSpace(text))
@@ -221,7 +221,7 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
 
                 Guid? selectedId = null;
                 var invalidSelectedChartId = false;
-                if (decision.SelectedChartId is string idStr && Guid.TryParse(idStr, out var parsed))
+                if (!string.IsNullOrWhiteSpace(decision.SelectedChartId) && Guid.TryParse(decision.SelectedChartId, out var parsed))
                 {
                     if (!validIds.Contains(parsed))
                     {
@@ -236,7 +236,7 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
                         selectedId = parsed;
                     }
                 }
-                else if (decision.SelectedChartId is not null)
+                else if (!string.IsNullOrWhiteSpace(decision.SelectedChartId))
                 {
                     _logger.LogWarning(
                         "Vertex AI chart ranker response selected malformed chart id for row {SourceRowNumber} in snapshot {SnapshotId}. Marking row for review.",
@@ -344,13 +344,46 @@ public sealed class VertexAiSetListChartContextualRanker : ISetListChartContextu
         1. Chart number evidence outranks title similarity when both are available.
         2. If multiple candidates have the same title, the one matching the row's chart number wins.
         3. Nearby chart numbers (+/-1) are weaker evidence and should not override clear title or context matches.
-        4. Return "selectedChartId" as the candidate's chart ID string or null if no candidate is clearly correct.
+        4. Return "selectedChartId" as the candidate's chart ID string, or an empty string if no candidate is clearly correct.
         5. Return status: "suggested" (confident), "needs_review" (ambiguous or low confidence), or "missing_from_latest_library" (no suitable candidate).
         6. Return confidence: "high", "medium", "low", or "none".
         7. You must copy selectedChartId exactly from one of the supplied candidate chartId values for the same row. Never invent, transform, truncate, or infer IDs.
-        8. If no supplied candidate chartId is clearly correct for a row, return selectedChartId as null and status as "needs_review".
-        9. Respond with valid JSON only, no other text or markdown formatting.
+        8. If no supplied candidate chartId is clearly correct for a row, return an empty selectedChartId and status as "needs_review".
+        9. Respond with a valid JSON object containing a "decisions" array only, with no other text or markdown formatting.
         """;
+
+    private static readonly Schema StringSchema = new()
+    {
+        Type = GenAiType.String,
+        Nullable = false,
+    };
+
+    private static readonly Schema ResponseSchema = new()
+    {
+        Type = GenAiType.Object,
+        Nullable = false,
+        Properties = new Dictionary<string, Schema>
+        {
+            ["decisions"] = new Schema
+            {
+                Type = GenAiType.Array,
+                Nullable = false,
+                Items = new Schema
+                {
+                    Type = GenAiType.Object,
+                    Nullable = false,
+                    Properties = new Dictionary<string, Schema>
+                    {
+                        ["rowNumber"] = new Schema { Type = GenAiType.Integer, Nullable = false },
+                        ["selectedChartId"] = StringSchema,
+                        ["status"] = StringSchema,
+                        ["confidence"] = StringSchema,
+                        ["reason"] = StringSchema,
+                    },
+                },
+            },
+        },
+    };
 
     private sealed record PromptRow
     {

--- a/backend/Glovelly.Api/Services/VertexReceiptAnalysisService.cs
+++ b/backend/Glovelly.Api/Services/VertexReceiptAnalysisService.cs
@@ -1,0 +1,234 @@
+using Google.GenAI;
+using Google.GenAI.Types;
+using Glovelly.Api.Data;
+using Glovelly.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using GenAiClient = Google.GenAI.Client;
+using GenAiType = Google.GenAI.Types.Type;
+
+namespace Glovelly.Api.Services;
+
+public sealed class VertexReceiptAnalysisService : IReceiptAnalysisService
+{
+    private const string Provider = "VertexAi";
+    private const string PromptVersion = "receipt-v1";
+    private static readonly HashSet<string> Categories = new(StringComparer.Ordinal) { "travel", "meals", "accommodation", "equipment", "other" };
+    private readonly Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> _generateContentAsync;
+    private readonly AppDbContext _db;
+    private readonly IExpenseAttachmentStore _attachmentStore;
+    private readonly ReceiptAnalysisSettings _settings;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<VertexReceiptAnalysisService> _logger;
+
+    public VertexReceiptAnalysisService(AppDbContext db, IExpenseAttachmentStore attachmentStore, IOptions<ReceiptAnalysisSettings> options, TimeProvider timeProvider, ILogger<VertexReceiptAnalysisService> logger)
+        : this(CreateGenerateContentAsync(options.Value), db, attachmentStore, options, timeProvider, logger) { }
+
+    public VertexReceiptAnalysisService(Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> generateContentAsync, AppDbContext db, IExpenseAttachmentStore attachmentStore, IOptions<ReceiptAnalysisSettings> options, TimeProvider timeProvider, ILogger<VertexReceiptAnalysisService> logger)
+    {
+        _generateContentAsync = generateContentAsync;
+        _db = db;
+        _attachmentStore = attachmentStore;
+        _settings = options.Value;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<ReceiptAnalysisResult> AnalyzeAsync(ExpenseAttachment attachment, CancellationToken cancellationToken = default)
+    {
+        var requestedAt = _timeProvider.GetUtcNow();
+        var analysis = NewAnalysis(attachment.Id, requestedAt);
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            if (!_settings.IsConfigured)
+                return await SaveFailureAsync(analysis, "unavailable", "Receipt analysis is currently unavailable.", stopwatch);
+            if (!_settings.AllowedContentTypes.Contains(attachment.ContentType, StringComparer.OrdinalIgnoreCase))
+                return await SaveFailureAsync(analysis, "unsupported_media", "This receipt type cannot be analysed.", stopwatch);
+            if (attachment.SizeBytes <= 0 || attachment.SizeBytes > _settings.MaxFileSizeBytes)
+                return await SaveFailureAsync(analysis, "size_limit", "This receipt is too large to analyse.", stopwatch);
+
+            var stored = await _attachmentStore.OpenReadAsync(attachment.StorageKey, cancellationToken);
+            using var source = stored.Content;
+            using var content = new MemoryStream();
+            await source.CopyToAsync(content, cancellationToken);
+            if (content.Length == 0 || content.Length > _settings.MaxFileSizeBytes)
+                return await SaveFailureAsync(analysis, "missing_content", "The receipt content is unavailable.", stopwatch);
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(_settings.Timeout);
+            var request = BuildRequest(attachment.ContentType, content.ToArray());
+            var response = await _generateContentAsync(_settings.VertexAiModel!, request.Contents, request.Config, timeout.Token);
+            var text = response.Candidates?.FirstOrDefault()?.Content?.Parts?.FirstOrDefault()?.Text;
+            if (!TryParse(text, analysis, out var invalidResponse))
+                return await SaveFailureAsync(analysis, "invalid_response", invalidResponse, stopwatch);
+
+            analysis.Status = ReceiptAnalysisStatus.Succeeded;
+            analysis.CompletedAt = _timeProvider.GetUtcNow();
+            _db.ReceiptAnalyses.Add(analysis);
+            await _db.SaveChangesAsync(cancellationToken);
+            LogCompletion(analysis, stopwatch.ElapsedMilliseconds);
+            return ToResult(analysis);
+        }
+        catch (FileNotFoundException)
+        {
+            return await SaveFailureAsync(analysis, "missing_content", "The receipt content is unavailable.", stopwatch);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return await SaveFailureAsync(analysis, "timeout", "Receipt analysis timed out. Please try again.", stopwatch);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Receipt analysis failed for attachment {AttachmentId}.", attachment.Id);
+            return await SaveFailureAsync(analysis, "provider_failure", "Receipt analysis could not be completed. Please try again.", stopwatch);
+        }
+    }
+
+    private static Func<string, List<Content>, GenerateContentConfig, CancellationToken, Task<GenerateContentResponse>> CreateGenerateContentAsync(ReceiptAnalysisSettings settings)
+    {
+        if (!settings.IsConfigured)
+            return (_, _, _, _) => throw new InvalidOperationException("Receipt analysis is not configured.");
+
+        var client = new GenAiClient(vertexAI: true, project: settings.VertexAiProjectId, location: settings.VertexAiLocation, enterprise: true);
+        return (model, contents, config, cancellationToken) => client.Models.GenerateContentAsync(model, contents, config, cancellationToken);
+    }
+
+    private static (List<Content> Contents, GenerateContentConfig Config) BuildRequest(string contentType, byte[] content) =>
+        ([new Content
+        {
+            Role = "user",
+            Parts = [new Part { Text = Prompt }, new Part { InlineData = new Blob { MimeType = contentType, Data = content } }],
+        }],
+        new GenerateContentConfig
+        {
+            ResponseMimeType = "application/json",
+            ResponseSchema = ResponseSchema,
+        });
+
+    private async Task<ReceiptAnalysisResult> SaveFailureAsync(ReceiptAnalysis analysis, string code, string message, Stopwatch stopwatch)
+    {
+        analysis.Status = ReceiptAnalysisStatus.Failed;
+        analysis.FailureCode = code;
+        analysis.FailureMessage = message;
+        analysis.CompletedAt = _timeProvider.GetUtcNow();
+        _db.ReceiptAnalyses.Add(analysis);
+        await _db.SaveChangesAsync();
+        LogCompletion(analysis, stopwatch.ElapsedMilliseconds);
+        return ToResult(analysis);
+    }
+
+    private ReceiptAnalysis NewAnalysis(Guid attachmentId, DateTimeOffset requestedAt) => new()
+    {
+        Id = Guid.NewGuid(), ExpenseAttachmentId = attachmentId, Provider = Provider,
+        Model = _settings.VertexAiModel ?? "", PromptVersion = PromptVersion, RequestedAt = requestedAt,
+    };
+
+    private void LogCompletion(ReceiptAnalysis analysis, long elapsedMilliseconds) => _logger.LogInformation(
+        "Receipt analysis completed for attachment {AttachmentId} using {Model}: {Status}, {FailureCode}, {ElapsedMilliseconds} ms.",
+        analysis.ExpenseAttachmentId, analysis.Model, analysis.Status, analysis.FailureCode, elapsedMilliseconds);
+
+    private static bool TryParse(string? text, ReceiptAnalysis analysis, out string failureMessage)
+    {
+        failureMessage = "Receipt analysis returned an invalid response.";
+        if (string.IsNullOrWhiteSpace(text) || text.Length > 16_384) return false;
+        try
+        {
+            using var document = JsonDocument.Parse(text);
+            if (document.RootElement.ValueKind != JsonValueKind.Object) return false;
+            var root = document.RootElement;
+            var validFields = 0;
+            ApplyString(root, "merchant", 200, value => analysis.Merchant = value, value => analysis.MerchantConfidence = value, analysis, ref validFields);
+            ApplyDate(root, analysis, ref validFields);
+            ApplyTotal(root, analysis, ref validFields);
+            ApplyCurrency(root, analysis, ref validFields);
+            ApplyCategory(root, analysis, ref validFields);
+            ApplyWarnings(root, analysis);
+            if (validFields == 0 && analysis.Warnings.Count == 0) return false;
+            return true;
+        }
+        catch (JsonException) { return false; }
+    }
+
+    private static void ApplyString(JsonElement root, string name, int maxLength, Action<string> setValue, Action<ReceiptAnalysisConfidence> setConfidence, ReceiptAnalysis analysis, ref int validFields)
+    {
+        if (!root.TryGetProperty(name, out var property) || property.ValueKind == JsonValueKind.Null) return;
+        if (property.ValueKind == JsonValueKind.String && string.IsNullOrWhiteSpace(property.GetString())) return;
+        if (property.ValueKind != JsonValueKind.String || property.GetString() is not { } value || value.Length > maxLength) { analysis.Warnings.Add($"{name} was ignored because it was invalid."); return; }
+        setValue(value.Trim()); setConfidence(ReadConfidence(root, name)); validFields++;
+    }
+    private static void ApplyDate(JsonElement root, ReceiptAnalysis analysis, ref int validFields)
+    {
+        if (!root.TryGetProperty("transactionDate", out var property) || property.ValueKind == JsonValueKind.Null) return;
+        if (property.ValueKind == JsonValueKind.String && string.IsNullOrWhiteSpace(property.GetString())) return;
+        if (property.ValueKind == JsonValueKind.String && DateOnly.TryParseExact(property.GetString(), "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var value)) { analysis.TransactionDate = value; analysis.TransactionDateConfidence = ReadConfidence(root, "transactionDate"); validFields++; } else analysis.Warnings.Add("transactionDate was ignored because it was invalid.");
+    }
+    private static void ApplyTotal(JsonElement root, ReceiptAnalysis analysis, ref int validFields)
+    {
+        if (!root.TryGetProperty("totalAmount", out var property) || property.ValueKind == JsonValueKind.Null) return;
+        if (property.ValueKind == JsonValueKind.String && string.IsNullOrWhiteSpace(property.GetString())) return;
+        if (property.ValueKind == JsonValueKind.String && decimal.TryParse(property.GetString(), NumberStyles.Number, CultureInfo.InvariantCulture, out var value) && value >= 0 && value <= 1_000_000m) { analysis.TotalAmount = value; analysis.TotalAmountConfidence = ReadConfidence(root, "totalAmount"); validFields++; } else analysis.Warnings.Add("totalAmount was ignored because it was invalid.");
+    }
+    private static void ApplyCurrency(JsonElement root, ReceiptAnalysis analysis, ref int validFields)
+    {
+        if (!root.TryGetProperty("currency", out var property) || property.ValueKind == JsonValueKind.Null) return;
+        var value = property.ValueKind == JsonValueKind.String ? property.GetString() : null;
+        if (string.IsNullOrWhiteSpace(value)) return;
+        if (value is { Length: 3 } && value.All(char.IsAsciiLetter) && value == value.ToUpperInvariant()) { analysis.Currency = value; analysis.CurrencyConfidence = ReadConfidence(root, "currency"); validFields++; } else analysis.Warnings.Add("currency was ignored because it was invalid.");
+    }
+    private static void ApplyCategory(JsonElement root, ReceiptAnalysis analysis, ref int validFields)
+    {
+        if (!root.TryGetProperty("suggestedCategory", out var property) || property.ValueKind == JsonValueKind.Null) return;
+        var value = property.ValueKind == JsonValueKind.String ? property.GetString() : null;
+        if (string.IsNullOrWhiteSpace(value)) return;
+        if (value is not null && Categories.Contains(value)) { analysis.SuggestedCategory = value; analysis.SuggestedCategoryConfidence = ReadConfidence(root, "suggestedCategory"); validFields++; } else analysis.Warnings.Add("suggestedCategory was ignored because it was invalid.");
+    }
+    private static void ApplyWarnings(JsonElement root, ReceiptAnalysis analysis)
+    {
+        if (!root.TryGetProperty("warnings", out var property) || property.ValueKind == JsonValueKind.Null) return;
+        if (property.ValueKind != JsonValueKind.Array) { analysis.Warnings.Add("warnings was ignored because it was invalid."); return; }
+        foreach (var warning in property.EnumerateArray().Take(10)) if (warning.ValueKind == JsonValueKind.String && warning.GetString() is { Length: > 0 and <= 300 } value) analysis.Warnings.Add(value);
+    }
+    private static ReceiptAnalysisConfidence ReadConfidence(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty($"{name}Confidence", out var confidence) || confidence.ValueKind != JsonValueKind.String) return ReceiptAnalysisConfidence.None;
+        return confidence.GetString()?.ToLowerInvariant() switch { "low" => ReceiptAnalysisConfidence.Low, "medium" => ReceiptAnalysisConfidence.Medium, "high" => ReceiptAnalysisConfidence.High, _ => ReceiptAnalysisConfidence.None };
+    }
+    public static ReceiptAnalysisResult ToResult(ReceiptAnalysis value) => new(value.Id, value.Status, value.Provider, value.Model, value.PromptVersion, value.RequestedAt, value.CompletedAt, new ReceiptAnalysisField<string?>(value.Merchant, value.MerchantConfidence), new ReceiptAnalysisField<DateOnly?>(value.TransactionDate, value.TransactionDateConfidence), new ReceiptAnalysisField<decimal?>(value.TotalAmount, value.TotalAmountConfidence), new ReceiptAnalysisField<string?>(value.Currency, value.CurrencyConfidence), new ReceiptAnalysisField<string?>(value.SuggestedCategory, value.SuggestedCategoryConfidence), value.Warnings, value.FailureCode, value.FailureMessage);
+
+    private const string Prompt = "Extract receipt suggestions. Return only a JSON object with merchant, merchantConfidence, transactionDate (YYYY-MM-DD), transactionDateConfidence, totalAmount (invariant decimal string), totalAmountConfidence, currency (uppercase ISO 4217), currencyConfidence, suggestedCategory (travel, meals, accommodation, equipment, or other), suggestedCategoryConfidence, and warnings array. Confidence values must be high, medium, low, or none. Omit unavailable values or return an empty string. Do not infer unavailable values.";
+
+    private static readonly Schema StringSchema = new()
+    {
+        Type = GenAiType.String,
+        Nullable = false,
+    };
+
+    private static readonly Schema ResponseSchema = new()
+    {
+        Type = GenAiType.Object,
+        Nullable = false,
+        Properties = new Dictionary<string, Schema>
+        {
+            ["merchant"] = StringSchema,
+            ["merchantConfidence"] = StringSchema,
+            ["transactionDate"] = StringSchema,
+            ["transactionDateConfidence"] = StringSchema,
+            ["totalAmount"] = StringSchema,
+            ["totalAmountConfidence"] = StringSchema,
+            ["currency"] = StringSchema,
+            ["currencyConfidence"] = StringSchema,
+            ["suggestedCategory"] = StringSchema,
+            ["suggestedCategoryConfidence"] = StringSchema,
+            ["warnings"] = new Schema
+            {
+                Type = GenAiType.Array,
+                Nullable = false,
+                Items = StringSchema,
+            },
+        },
+    };
+}

--- a/backend/Glovelly.Api/appsettings.Development.json
+++ b/backend/Glovelly.Api/appsettings.Development.json
@@ -26,8 +26,8 @@
   "SetListChartRanking": {
     "Provider": "Deterministic",
     "VertexAiProjectId": "",
-    "VertexAiLocation": "europe-west1",
-    "VertexAiModel": "gemini-2.5-flash"
+    "VertexAiLocation": "eu",
+    "VertexAiModel": "gemini-3.1-flash-lite"
   },
   "Cors": {
     "AllowedOrigins": [

--- a/backend/Glovelly.Api/appsettings.json
+++ b/backend/Glovelly.Api/appsettings.json
@@ -41,8 +41,8 @@
   "SetListChartRanking": {
     "Provider": "Deterministic",
     "VertexAiProjectId": "",
-    "VertexAiLocation": "europe-west1",
-    "VertexAiModel": "gemini-2.5-flash"
+    "VertexAiLocation": "eu",
+    "VertexAiModel": "gemini-3.1-flash-lite"
   },
   "Cors": {
     "AllowedOrigins": []
@@ -71,6 +71,17 @@
   "ExpenseAttachments": {
     "BucketName": "",
     "MaxFileSizeBytes": 10485760
+  },
+  "ReceiptAnalysis": {
+    "Enabled": false,
+    "VertexAiProjectId": "",
+    "VertexAiLocation": "eu",
+    "VertexAiModel": "gemini-3.1-flash-lite",
+    "AllowedContentTypes": [ "image/jpeg", "image/png", "image/webp", "application/pdf" ],
+    "MaxFileSizeBytes": 5242880,
+    "Timeout": "00:00:20",
+    "PerUserPermitLimit": 10,
+    "PerUserWindow": "01:00:00"
   },
   "BlobStorage": {
     "BucketName": ""

--- a/backend/Glovelly.Migrations/Migrations/20260729205306_AddReceiptAnalysis.Designer.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260729205306_AddReceiptAnalysis.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Glovelly.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Glovelly.Migrations.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729205306_AddReceiptAnalysis")]
+    partial class AddReceiptAnalysis
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Glovelly.Migrations/Migrations/20260729205306_AddReceiptAnalysis.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260729205306_AddReceiptAnalysis.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Glovelly.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReceiptAnalysis : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReceiptAnalyses",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ExpenseAttachmentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Provider = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Model = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    PromptVersion = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    RequestedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Merchant = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    TransactionDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    TotalAmount = table.Column<decimal>(type: "numeric", nullable: true),
+                    Currency = table.Column<string>(type: "character varying(3)", maxLength: 3, nullable: true),
+                    SuggestedCategory = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    MerchantConfidence = table.Column<int>(type: "integer", nullable: false),
+                    TransactionDateConfidence = table.Column<int>(type: "integer", nullable: false),
+                    TotalAmountConfidence = table.Column<int>(type: "integer", nullable: false),
+                    CurrencyConfidence = table.Column<int>(type: "integer", nullable: false),
+                    SuggestedCategoryConfidence = table.Column<int>(type: "integer", nullable: false),
+                    Warnings = table.Column<string>(type: "jsonb", nullable: false),
+                    FailureCode = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    FailureMessage = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReceiptAnalyses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ReceiptAnalyses_ExpenseAttachments_ExpenseAttachmentId",
+                        column: x => x.ExpenseAttachmentId,
+                        principalTable: "ExpenseAttachments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReceiptAnalyses_ExpenseAttachmentId_RequestedAt",
+                table: "ReceiptAnalyses",
+                columns: new[] { "ExpenseAttachmentId", "RequestedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReceiptAnalyses");
+        }
+    }
+}

--- a/docs/engineering/deployment-pipeline.md
+++ b/docs/engineering/deployment-pipeline.md
@@ -121,7 +121,7 @@ Secrets are bound from Secret Manager for values such as:
 - MCP OAuth client ID and client secret
 - MCP OAuth redirect URI values
 
-Set list chart matching defaults to deterministic ranking. To enable Gemini-backed ranking in a GitHub Environment, set `SET_LIST_CHART_RANKING_PROVIDER` to `VertexAi`. Optional override variables are `SET_LIST_CHART_RANKING_VERTEX_AI_PROJECT_ID`, `SET_LIST_CHART_RANKING_VERTEX_AI_LOCATION`, and `SET_LIST_CHART_RANKING_VERTEX_AI_MODEL`; the workflow otherwise uses the deployment project, deployment region, and `gemini-2.5-flash`. The Cloud Run runtime service account must have permission to call Vertex AI, for example `roles/aiplatform.user`.
+Set list chart matching defaults to deterministic ranking. To enable Gemini-backed ranking in a GitHub Environment, set `SET_LIST_CHART_RANKING_PROVIDER` to `VertexAi`. Optional override variables are `SET_LIST_CHART_RANKING_VERTEX_AI_PROJECT_ID`, `SET_LIST_CHART_RANKING_VERTEX_AI_LOCATION`, and `SET_LIST_CHART_RANKING_VERTEX_AI_MODEL`; the workflow otherwise uses the deployment project, deployment region, and `gemini-3.1-flash-lite`. The Cloud Run runtime service account must have permission to call Vertex AI, for example `roles/aiplatform.user`.
 
 Do not commit secret values, OAuth client secrets, Resend API keys, database connection strings, or user-specific credential material.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -40,6 +40,7 @@ Glovelly may collect and store the following categories of information.
 - Gig details such as dates, venues, fees, mileage, passenger counts, and status.
 - Expense details such as descriptions, categories, amounts, tax treatment, reimbursement status, and receipt attachments.
 - Receipt files or images uploaded by users. These may contain personal information visible on the receipt, such as names, partial payment card details, locations, timestamps, or purchase details.
+- When you explicitly request receipt analysis, the receipt file or image, its MIME type, upload date, optional default currency, and permitted suggestion categories are sent to Google Cloud Vertex AI. Glovelly uses the result only to show reviewable suggestions; it does not automatically change an expense record.
 - Invoice details such as invoice numbers, line items, payment status, issue/reissue history, delivery details, PDF files, and Google Drive publication references.
 - Seller profile details used to generate invoices, such as trading name, address, payment details, invoice defaults, and tax or business identifiers where provided.
 
@@ -109,6 +110,7 @@ Glovelly uses personal information to:
 - maintain invoice, accounting, tax, and business administration records
 - secure the service and detect misuse
 - maintain, debug, test, and improve the service
+- provide user-requested receipt analysis and show its reviewable suggestions
 - comply with legal, accounting, tax, and record-keeping obligations
 - respond to requests, questions, and rights exercises
 
@@ -158,6 +160,7 @@ Service providers are expected to process personal information only as needed to
 Current expected subprocessors include:
 
 - Google Cloud Platform, for hosting, infrastructure, managed secrets, and related cloud services
+- Google Cloud Vertex AI, for optional user-requested receipt analysis
 - Google, for sign-in, Google Drive integration, and Google Calendar integration
 - Neon, for database hosting
 - Resend or another configured email delivery provider, for transactional email
@@ -185,6 +188,7 @@ Typical retention expectations are:
 - access request records: normally up to 12 months after handling, unless needed for security, audit, or dispute purposes
 - email delivery records: for as long as needed to confirm delivery, investigate delivery issues, or maintain business records
 - logs and diagnostic records: normally for a limited operational period, such as up to 90 days, unless needed for security investigation, debugging, legal, accounting, or dispute purposes
+- receipt-analysis attempt metadata and validated suggestions: for as long as the associated receipt is retained for business, tax, accounting, or dispute purposes; provider responses and receipt content are not included in application logs
 - documentation site technical records: according to the retention practices of GitHub or other hosting providers used to serve the site
 
 Some information may be retained for longer where required by law, tax rules, accounting obligations, security needs, dispute resolution, or backup retention.

--- a/docs/uat/expenses.md
+++ b/docs/uat/expenses.md
@@ -28,6 +28,25 @@ Use these journeys when a change may affect gig expenses, receipt attachments, q
 
 Receipt metadata, storage, download, and deletion all work without changing the expense reimbursement state.
 
+## Receipt Analysis Journey
+
+> **Automation:** Backend automated; browser review remains manual until a consented Vertex test environment and fixture set are available.
+
+### Steps
+
+1. Open a saved gig with an existing expense receipt and select **Analyse** beside that receipt.
+2. Confirm the review dialog identifies the receipt and either shows a prior analysis or offers **Analyse receipt**.
+3. Analyse a supported test JPEG, PNG, WebP, or PDF receipt.
+4. Confirm merchant and total are clearly labelled as suggestions, confidence and warnings are visible, and date, currency, and category are labelled review-only.
+5. Select **Use merchant and total** and confirm the normal expense editor opens with the suggested values but does not save them automatically.
+6. Save the expense only after reviewing the populated fields.
+7. Repeat using a receipt saved through **Scan receipt**. Confirm **Analyse receipt** opens the same review dialog and only fills the editable draft fields after explicit use.
+8. Check an unsupported or oversized test attachment. Confirm the saved attachment and expense remain unchanged and the dialog gives a safe analysis failure message.
+
+### Expected Results
+
+Receipt analysis augments, but never blocks or silently changes, the manual expense workflow.
+
 ## Quick Receipt Journey
 
 > **Automation:** Backend automated; manual UAT: `Glovelly.Api.Tests.GigEndpointsTests.QuickReceiptDraft_*` covers draft creation, candidate matching, updates, and reassignment; browser capture remains manual.

--- a/frontend/glovelly-web/src/App.css
+++ b/frontend/glovelly-web/src/App.css
@@ -502,6 +502,56 @@
   gap: 18px;
 }
 
+.receipt-analysis-modal {
+  display: grid;
+  gap: 18px;
+  width: min(100%, 580px);
+}
+
+.receipt-analysis-results {
+  display: grid;
+  gap: 10px;
+}
+
+.receipt-analysis-suggestion {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 3px 14px;
+  padding: 11px 13px;
+  border: 1px solid var(--surface-border);
+  border-radius: 14px;
+  background: var(--surface-soft);
+}
+
+.receipt-analysis-suggestion span,
+.receipt-analysis-suggestion small,
+.receipt-analysis-note {
+  color: var(--muted);
+}
+
+.ai-sparkle-icon {
+  width: 1em;
+  height: 1em;
+  margin-right: 0.35em;
+  vertical-align: -0.15em;
+  fill: currentColor;
+}
+
+.receipt-analysis-suggestion strong {
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.receipt-analysis-suggestion small {
+  grid-column: 1 / -1;
+}
+
+.receipt-analysis-note {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
 .gig-imports-modal {
   display: grid;
   gap: 18px;
@@ -2041,7 +2091,7 @@ button.compact-record-row.selected {
   margin-top: 8px;
 }
 
-.setlist-import-modal .ai-button {
+.ghost-button.ai-button {
   gap: 7px;
   border-color: color-mix(in srgb, var(--compact-control-accent) 42%, var(--surface-border));
   background: color-mix(in srgb, var(--compact-control-accent) 8%, transparent);

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -1671,6 +1671,7 @@ function App({ appMetadata }: AppProps) {
         onCloneGig={cloneSelectedGig}
         onOpenClient={openClientShortcut}
         onOpenLinkedInvoice={openSelectedGigInvoice}
+        onSessionExpired={expireSession}
         onUploadExpenseAttachment={uploadExpenseAttachment}
         onUploadExternalResourceAttachment={uploadExternalResourceAttachment}
         onDeleteExpenseAttachment={deleteExpenseAttachment}
@@ -1937,6 +1938,7 @@ function App({ appMetadata }: AppProps) {
         onGoToGig={goToQuickReceiptGig}
         onSaveDetails={saveQuickReceiptDetails}
         onSaveDraft={savePendingReceiptToSelectedGig}
+        onSessionExpired={expireSession}
         onSelectedGigChange={setQuickReceiptSelectedGigId}
         pendingFile={pendingReceiptFile}
         selectedGigId={quickReceiptSelectedGigId}

--- a/frontend/glovelly-web/src/components/AiSparkleIcon.tsx
+++ b/frontend/glovelly-web/src/components/AiSparkleIcon.tsx
@@ -1,0 +1,8 @@
+export function AiSparkleIcon() {
+  return (
+    <svg aria-hidden="true" className="ai-sparkle-icon" viewBox="0 0 24 24">
+      <path d="M12 2l1.7 6.3L20 10l-6.3 1.7L12 18l-1.7-6.3L4 10l6.3-1.7L12 2z" />
+      <path d="M19 15l.7 2.3L22 18l-2.3.7L19 21l-.7-2.3L16 18l2.3-.7L19 15z" />
+    </svg>
+  )
+}

--- a/frontend/glovelly-web/src/components/GigExpensesPanel.tsx
+++ b/frontend/glovelly-web/src/components/GigExpensesPanel.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import { formatCurrency } from '../formatters'
-import type { Gig, GigExpenseForm, GigExpenseReimbursementStatus } from '../types'
+import type { Gig, GigExpenseForm, GigExpenseReimbursementStatus, ReceiptAnalysisTarget } from '../types'
+import { ReceiptAnalysisModal } from './ReceiptAnalysisModal'
+import { AiSparkleIcon } from './AiSparkleIcon'
 import { TrashIcon } from './TrashIcon'
 
 type GigExpensesPanelProps = {
@@ -21,6 +23,7 @@ type GigExpensesPanelProps = {
     status: GigExpenseReimbursementStatus
   ) => void
   onUploadExpenseAttachment: (index: number, file: File) => void
+  onSessionExpired: (message: string) => void
 }
 
 export function GigExpensesPanel({
@@ -34,11 +37,13 @@ export function GigExpensesPanel({
   onSaveExpenseDraft,
   onUpdateExpenseReimbursement,
   onUploadExpenseAttachment,
+  onSessionExpired,
 }: GigExpensesPanelProps) {
   const [expandedExpenseKey, setExpandedExpenseKey] = useState<string>('')
   const [isExpenseEditorOpen, setIsExpenseEditorOpen] = useState(false)
   const [editingExpenseIndex, setEditingExpenseIndex] = useState<number | null>(null)
   const [expenseDraft, setExpenseDraft] = useState({ description: '', amount: '' })
+  const [analysisTarget, setAnalysisTarget] = useState<(ReceiptAnalysisTarget & { expenseIndex: number }) | null>(null)
   const expenseEditorTitle = editingExpenseIndex === null ? 'Add expense' : 'Edit expense'
 
   useEffect(() => {
@@ -61,6 +66,19 @@ export function GigExpensesPanel({
     setIsExpenseEditorOpen(false)
     setEditingExpenseIndex(null)
     setExpenseDraft({ description: '', amount: '' })
+  }
+
+  const applyReceiptSuggestions = (suggestions: { merchant: string | null; totalAmount: number | null }) => {
+    if (!analysisTarget) return
+    const expense = expenses[analysisTarget.expenseIndex]
+    if (!expense) return
+    setEditingExpenseIndex(analysisTarget.expenseIndex)
+    setExpenseDraft({
+      description: suggestions.merchant || expense.description,
+      amount: suggestions.totalAmount === null ? expense.amount : String(suggestions.totalAmount),
+    })
+    setIsExpenseEditorOpen(true)
+    setAnalysisTarget(null)
   }
 
   const submitExpenseDraft = async (event: FormEvent<HTMLFormElement>) => {
@@ -216,7 +234,22 @@ export function GigExpensesPanel({
                                     onClick={() => onDownloadExpenseAttachment(expense, attachment.id)}
                                     disabled={isGigLoading}
                                   >
-                                    {attachment.fileName}
+                                   {attachment.fileName}
+                                  </button>
+                                  <button
+                                    className="ghost-button ai-button"
+                                    onClick={() => selectedGig && setAnalysisTarget({
+                                      gigId: selectedGig.id,
+                                      expenseId: expense.id,
+                                      attachmentId: attachment.id,
+                                      fileName: attachment.fileName,
+                                      expenseIndex: index,
+                                    })}
+                                    type="button"
+                                    disabled={isGigLoading}
+                                  >
+                                    <AiSparkleIcon />
+                                    Analyse
                                   </button>
                                   <button
                                     aria-label={`Delete receipt ${attachment.fileName}`}
@@ -331,6 +364,14 @@ export function GigExpensesPanel({
           </section>
         </div>
       )}
+      {analysisTarget ? (
+        <ReceiptAnalysisModal
+          target={analysisTarget}
+          onClose={() => setAnalysisTarget(null)}
+          onApply={applyReceiptSuggestions}
+          onSessionExpired={onSessionExpired}
+        />
+      ) : null}
     </>
   )
 }

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -62,6 +62,7 @@ type GigsSectionProps = {
   onCloneGig: () => void
   onOpenClient: (clientId: string) => void
   onOpenLinkedInvoice: () => void
+  onSessionExpired: (message: string) => void
   onUploadExpenseAttachment: (index: number, file: File) => void
   onUploadExternalResourceAttachment: (resource: GigExternalResource, file: File) => void
   onDeleteExpenseAttachment: (expense: GigExpenseForm, attachmentId: string) => void
@@ -135,6 +136,7 @@ export function GigsSection({
   onCloneGig,
   onOpenClient,
   onOpenLinkedInvoice,
+  onSessionExpired,
   onUploadExpenseAttachment,
   onUploadExternalResourceAttachment,
   onDeleteExpenseAttachment,
@@ -550,6 +552,7 @@ export function GigsSection({
                 onSaveExpenseDraft={onSaveExpenseDraft}
                 onUpdateExpenseReimbursement={onUpdateExpenseReimbursement}
                 onUploadExpenseAttachment={onUploadExpenseAttachment}
+                onSessionExpired={onSessionExpired}
               />
             </>
           ) : (

--- a/frontend/glovelly-web/src/components/QuickReceiptModal.tsx
+++ b/frontend/glovelly-web/src/components/QuickReceiptModal.tsx
@@ -3,6 +3,9 @@ import type {
   QuickReceiptDraftResponse,
 } from '../types'
 import { QuickCaptureGigSelect } from './QuickCaptureGigSelect'
+import { ReceiptAnalysisModal } from './ReceiptAnalysisModal'
+import { AiSparkleIcon } from './AiSparkleIcon'
+import { useState } from 'react'
 
 type QuickReceiptModalProps = {
   candidates: QuickReceiptCandidate[]
@@ -13,7 +16,7 @@ type QuickReceiptModalProps = {
   onClose: () => void
   onDescriptionChange: (value: string) => void
   onGoToGig: () => void
-  onSaveDetails: () => void
+  onSaveDetails: (details?: { description: string; amount: string }) => Promise<void>
   onSaveDraft: () => void
   onSelectedGigChange: (gigId: string) => void
   pendingFile: File | null
@@ -21,6 +24,7 @@ type QuickReceiptModalProps = {
   status: string
   amount: string
   description: string
+  onSessionExpired: (message: string) => void
 }
 
 export function QuickReceiptModal({
@@ -40,7 +44,9 @@ export function QuickReceiptModal({
   pendingFile,
   selectedGigId,
   status,
+  onSessionExpired,
 }: QuickReceiptModalProps) {
+  const [isAnalysisOpen, setIsAnalysisOpen] = useState(false)
   if (!pendingFile && !draft) {
     return null
   }
@@ -134,11 +140,20 @@ export function QuickReceiptModal({
             <>
               <button
                 className="primary-button"
-                onClick={onSaveDetails}
+                onClick={() => void onSaveDetails()}
                 type="button"
                 disabled={isSaving || !selectedGigId}
               >
                 {isSaving ? 'Saving...' : 'Save details'}
+              </button>
+              <button
+                className="ghost-button ai-button"
+                onClick={() => setIsAnalysisOpen(true)}
+                type="button"
+                disabled={isSaving}
+              >
+                <AiSparkleIcon />
+                Analyse receipt
               </button>
               <button
                 className="ghost-button"
@@ -162,6 +177,26 @@ export function QuickReceiptModal({
           <span className="status-pill">{status}</span>
         </div>
       </section>
+      {draft && isAnalysisOpen ? (
+        <ReceiptAnalysisModal
+          target={{
+            gigId: draft.gig.id,
+            expenseId: draft.expenseId,
+            attachmentId: draft.attachmentId,
+            fileName: uploadedFileName,
+          }}
+          onClose={() => setIsAnalysisOpen(false)}
+          onApply={({ merchant, totalAmount }) => {
+            const nextDescription = merchant || description
+            const nextAmount = totalAmount === null ? amount : String(totalAmount)
+            onDescriptionChange(nextDescription)
+            onAmountChange(nextAmount)
+            void onSaveDetails({ description: nextDescription, amount: nextAmount })
+            setIsAnalysisOpen(false)
+          }}
+          onSessionExpired={onSessionExpired}
+        />
+      ) : null}
     </div>
   )
 }

--- a/frontend/glovelly-web/src/components/ReceiptAnalysisModal.tsx
+++ b/frontend/glovelly-web/src/components/ReceiptAnalysisModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useEffectEvent, useState } from 'react'
+import {
+  buildApiUrl,
+  fetchWithSession,
+  getResponseErrorMessage,
+  handleSessionExpired,
+} from '../api'
+import type { ReceiptAnalysisResult, ReceiptAnalysisTarget } from '../types'
+import { AiSparkleIcon } from './AiSparkleIcon'
+
+type ReceiptAnalysisModalProps = {
+  onApply: (suggestions: { merchant: string | null; totalAmount: number | null }) => void
+  onClose: () => void
+  onSessionExpired: (message: string) => void
+  target: ReceiptAnalysisTarget
+}
+
+export function ReceiptAnalysisModal({
+  onApply,
+  onClose,
+  onSessionExpired,
+  target,
+}: ReceiptAnalysisModalProps) {
+  const [analysis, setAnalysis] = useState<ReceiptAnalysisResult | null>(null)
+  const [isAnalysing, setIsAnalysing] = useState(false)
+  const [status, setStatus] = useState('')
+
+  const endpoint = `/gigs/${target.gigId}/expenses/${target.expenseId}/attachments/${target.attachmentId}/analysis`
+
+  const analyse = async () => {
+    setIsAnalysing(true)
+    setStatus('Analysing receipt...')
+    try {
+      const response = await fetchWithSession(buildApiUrl(endpoint), { method: 'POST' })
+      if (handleSessionExpired(response, onSessionExpired, 'Your session expired. Sign in again to analyse receipts.')) {
+        return
+      }
+      if (!response.ok) {
+        throw new Error(await getResponseErrorMessage(response, 'Unable to analyse receipt.'))
+      }
+      const result = (await response.json()) as ReceiptAnalysisResult
+      setAnalysis(result)
+      setStatus(result.status === 'Succeeded' ? 'Suggestions are ready to review.' : (result.failureMessage ?? 'Receipt analysis could not be completed.'))
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Unable to analyse receipt.')
+    } finally {
+      setIsAnalysing(false)
+    }
+  }
+
+  const analyseOnOpen = useEffectEvent(() => {
+    void analyse()
+  })
+
+  useEffect(() => {
+    analyseOnOpen()
+  }, [target.attachmentId])
+
+  const canApply = analysis?.status === 'Succeeded' && (analysis.merchant.value || analysis.totalAmount.value !== null)
+
+  return (
+    <div className="settings-overlay receipt-analysis-overlay" role="presentation">
+      <section aria-labelledby="receipt-analysis-title" className="settings-modal receipt-analysis-modal panel" role="dialog" aria-modal="true">
+        <div className="panel-heading">
+          <div>
+            <p className="section-label">Receipt analysis</p>
+            <h2 id="receipt-analysis-title">Review suggestions</h2>
+          </div>
+          <button className="ghost-button" onClick={onClose} type="button" disabled={isAnalysing}>Close</button>
+        </div>
+
+        <div className="quick-receipt-summary">
+          <strong>{target.fileName}</strong>
+          <span>{status || 'Analysing receipt...'}</span>
+        </div>
+
+        {analysis?.status === 'Succeeded' ? (
+          <div className="receipt-analysis-results">
+            <Suggestion label="Merchant" field={analysis.merchant} applyable />
+            <Suggestion label="Total" field={analysis.totalAmount} applyable />
+            <Suggestion label="Transaction date" field={analysis.transactionDate} />
+            <Suggestion label="Currency" field={analysis.currency} />
+            <Suggestion label="Suggested category" field={analysis.suggestedCategory} />
+            <p className="receipt-analysis-note">Date, currency, and category are review-only suggestions. They do not change the expense record.</p>
+            {analysis.warnings.length > 0 ? (
+              <div className="quick-receipt-warning">
+                <strong>Check these details</strong>
+                <span>{analysis.warnings.join(' ')}</span>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="form-actions">
+          <button className="ghost-button ai-button" onClick={() => void analyse()} type="button" disabled={isAnalysing}>
+            <AiSparkleIcon />
+            {isAnalysing ? 'Analysing...' : 'Analyse again'}
+          </button>
+          {canApply ? (
+            <button className="ghost-button" onClick={() => onApply({ merchant: analysis!.merchant.value, totalAmount: analysis!.totalAmount.value })} type="button" disabled={isAnalysing}>
+              Use merchant and total
+            </button>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function Suggestion<T>({ label, field, applyable = false }: { label: string; field: { value: T | null; confidence: string }; applyable?: boolean }) {
+  if (field.value === null || field.value === '') return null
+  return (
+    <div className="receipt-analysis-suggestion">
+      <span>{label}{applyable ? ' (can use)' : ' (review only)'}</span>
+      <strong>{String(field.value)}</strong>
+      <small>{field.confidence.toLowerCase()} confidence</small>
+    </div>
+  )
+}

--- a/frontend/glovelly-web/src/hooks/useQuickReceipt.ts
+++ b/frontend/glovelly-web/src/hooks/useQuickReceipt.ts
@@ -158,14 +158,14 @@ export function useQuickReceipt({
     void uploadQuickReceiptDraft(pendingReceiptFile, quickReceiptSelectedGigId)
   }
 
-  const saveQuickReceiptDetails = async () => {
+  const saveQuickReceiptDetails = async (details?: { description: string; amount: string }) => {
     if (!quickReceiptDraft || !quickReceiptSelectedGigId) {
       setQuickReceiptStatus('Choose a gig before saving this receipt draft.')
       return
     }
 
-    const description = quickReceiptDescription.trim()
-    const amount = Number(quickReceiptAmount || '0')
+    const description = (details?.description ?? quickReceiptDescription).trim()
+    const amount = Number((details?.amount ?? quickReceiptAmount) || '0')
 
     if (!description) {
       setQuickReceiptStatus('Add a description before saving receipt details.')

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -232,6 +232,38 @@ export type ExpenseAttachment = {
   createdAt: string
 }
 
+export type ReceiptAnalysisConfidence = 'None' | 'Low' | 'Medium' | 'High'
+
+export type ReceiptAnalysisField<T> = {
+  value: T
+  confidence: ReceiptAnalysisConfidence
+}
+
+export type ReceiptAnalysisResult = {
+  id: string
+  status: 'Succeeded' | 'Failed'
+  provider: string
+  model: string
+  promptVersion: string
+  requestedAt: string
+  completedAt: string
+  merchant: ReceiptAnalysisField<string | null>
+  transactionDate: ReceiptAnalysisField<string | null>
+  totalAmount: ReceiptAnalysisField<number | null>
+  currency: ReceiptAnalysisField<string | null>
+  suggestedCategory: ReceiptAnalysisField<string | null>
+  warnings: string[]
+  failureCode: string | null
+  failureMessage: string | null
+}
+
+export type ReceiptAnalysisTarget = {
+  gigId: string
+  expenseId: string
+  attachmentId: string
+  fileName: string
+}
+
 export type GigExpense = {
   id: string
   sortOrder: number

--- a/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/design.md
+++ b/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/design.md
@@ -1,0 +1,89 @@
+## Context
+
+Glovelly quick receipt capture stores an attachment and an editable `GigExpense` draft, while the standard gig expenses panel lets users attach receipts to any existing expense. Neither path extracts receipt details. The application already calls Vertex AI Gemini through `PredictionServiceClient.GenerateContentAsync` for contextual set-list chart matching, using Application Default Credentials, a regional endpoint, and defensive JSON handling.
+
+Receipt analysis handles sensitive business content and must never block attachment storage or overwrite accounting data. `GigExpense` has no currency or expense-category fields, so those suggestions have no authoritative destination in the current accounting model.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make any persisted expense attachment an explicit, user-selected target for receipt analysis.
+- Use Vertex AI multimodal generation to extract a narrow, validated suggestion set.
+- Retain source receipt, analysis provenance, suggestions, warnings, and failures independently from accepted expense values.
+- Give quick capture and the normal expense panel one shared analysis/review journey.
+- Preserve a fully functional manual receipt workflow under every analysis failure condition.
+
+**Non-Goals:**
+- Automatic expense updates, automatic analysis after upload, or durable background queueing/retry.
+- New canonical expense categories, expense currencies, tax/VAT fields, payment-method fields, line items, duplicate detection, or vendor learning.
+- A cross-provider AI abstraction or a general AI-job framework.
+- Replacing receipt storage, changing the quick-capture gig-matching rules, or resolving the existing unassigned-draft limitation.
+
+## Decisions
+
+### Attachment-level, on-demand analysis is the primary orchestration path
+
+Expose analysis under the existing attachment resource, scoped by `{gigId, expenseId, attachmentId}` and protected by the same owner-visibility lookup as download/delete. The standard expense attachment row is the canonical entry point; after quick capture saves an attachment, its modal invokes that same target and review experience.
+
+The analysis API provides a read of the latest attempt and an explicit request to create a new one. The POST completes synchronously within a configured short timeout and persists a success or safe failure result. A later retry is a new attempt, preserving provenance.
+
+This avoids a second quick-capture-only workflow and avoids prematurely copying the set-list-specific background job infrastructure. A durable worker remains a future option if measured latency or adoption makes post-upload analysis worthwhile.
+
+### A separate attempt entity preserves provenance and financial authority
+
+Introduce `ReceiptAnalysis` with a foreign key to `ExpenseAttachment`; an attachment has many attempts. The record stores status, provider, model, prompt version, request/completion times, validated merchant/date/total/currency/category suggestions, per-field confidence, warnings, bounded raw structured output if retained, and a safe error message.
+
+`GigExpense` is not extended and is never mutated by analysis. Merchant and total are copied only into client-side editable description/amount controls after an explicit user action, then persisted through the existing expense-save path. Date, currency, and category remain view-only analysis output.
+
+This is preferred to nullable AI columns on `GigExpense` because it supports reanalysis after model/prompt changes, preserves failed attempts, and makes clear that model output is not an accepted business record.
+
+### Send supported media inline for the proof
+
+The analysis service opens the already-authorized attachment through `IExpenseAttachmentStore`, then supplies its bytes and MIME type as a Vertex multimodal part alongside a constrained text prompt. Start with JPEG, PNG, WebP, and PDF, plus a distinct configurable analysis size limit below the generic attachment limit. Receipt analysis uses Gemini 3.5 Flash for multimodal media while set-list matching remains on Gemini 3.1 Flash Lite.
+
+Inline content is preferred over a `gs://` reference because it reuses the current authorization/storage seam and introduces no Vertex service-agent bucket access, cross-project, or location dependencies. It also matches the current GCS storage implementation, which downloads attachment content into memory. A storage URI can be reconsidered after the proof if large-document cost or memory pressure justifies its operational complexity.
+
+### Use constrained output plus strict local validation
+
+The prompt requests JSON only, ideally with the Vertex response MIME type and response schema controls supported by the chosen SDK/model. The service still treats provider output as untrusted.
+
+The response is a fixed object with nullable merchant, transaction date, total amount, currency, suggested category, per-field confidence, and warnings. Validation accepts only ISO dates, invariant decimal amounts represented as strings, recognised uppercase ISO currency codes, a small supplied category enum, bounded strings/lists, and known confidence values. Invalid individual fields become warnings while valid independent fields remain reviewable; invalid whole responses produce a failed attempt with no suggestions.
+
+The contextual prompt contains only the receipt, upload date, optional default currency, and the allowed category values. It excludes user identity, client, gig title, and unrelated workspace data.
+
+### One shared review UI adapts application to its caller
+
+A receipt-analysis hook/component owns loading the latest attempt, starting analysis, rendering status, and presenting suggestions. It receives an attachment target and an `onApply` callback. The normal expense panel callback opens/prefills the existing expense editor; the quick-receipt callback fills its amount and description controls. The review UI labels every value as a suggestion, exposes confidence and warnings, and offers reanalysis without silently saving anything.
+
+This is preferred to embedding analysis state in the broad `Gig` response or creating a special quick-capture form. A narrow attachment-analysis GET retrieves persistent results on demand, and POST returns the newly created attempt.
+
+### Privacy, observability, and availability are bounded by default
+
+Analysis is user-triggered. Request logs contain only IDs, configured model, elapsed time, outcome, failure class, and a coarse byte-size measure; they never contain receipt bytes, filename, prompt content, raw model text, merchant, or amount. Provider request/response logging remains disabled unless separately designed with retention and access controls.
+
+The endpoint applies a per-user rate limit and a short cancellation-aware timeout. Unsupported media, absent Vertex configuration, quota/provider failures, empty/malformed/safety-blocked responses, or missing blob content are persisted as safe analysis failures and leave the receipt and expense unchanged. The privacy policy will explicitly describe this optional Vertex AI processing before the feature is enabled in production.
+
+## Risks / Trade-offs
+
+- [Gemini extraction is incorrect or ambiguous] → Persist confidence/warnings, use conservative validation, require explicit user application, and assess quality against consented representative receipts.
+- [A receipt contains sensitive data] → Send minimal context only, provide clear user-triggered disclosure, avoid sensitive logs, and document provider processing.
+- [Inline content increases request memory and latency] → Enforce a lower analysis size limit and supported MIME allowlist; measure latency before considering GCS URI input.
+- [Model output changes over time] → Record provider, model, prompt version, timestamps, and each attempt independently.
+- [A provider outage looks like an empty extraction] → Persist a distinct safe failure status/message and instrument failure categories rather than returning an empty suggestion silently.
+- [Existing expense editing has no category/currency fields] → Present them as review-only analysis information and defer accounting-model expansion.
+- [Analysis retry costs can grow] → Make retries explicit, rate limit per user, and capture model usage/latency metrics for the spike cost model.
+
+## Migration Plan
+
+1. Deploy the `ReceiptAnalysis` schema and indexes before exposing UI actions; existing attachments require no backfill.
+2. Deploy service/API/UI with receipt analysis disabled unless Vertex receipt settings are configured; manual attachment and quick-capture flows continue unchanged.
+3. Enable for a controlled set of users with Vertex IAM, the configured model, rate limits, and privacy-policy update in place.
+4. Evaluate consented sample and live opt-in outcomes for extraction accuracy, latency, failure rate, and cost before considering asynchronous analysis.
+5. Roll back by disabling receipt-analysis configuration or hiding its UI action. Existing analysis records remain isolated from financial records and can be retained/deleted under the agreed policy without data rollback.
+
+## Open Questions
+
+- Which exact Gemini model/version and regional availability will be approved for receipt media, and what are its current supported MIME limits?
+- What analysis file-size limit and per-user rate limit meet the desired mobile experience and budget after the representative-receipt evaluation?
+- Does the initial retention policy require bounded raw structured responses, or are validated fields, warnings, and provenance sufficient?
+- What in-product disclosure wording and privacy-policy retention detail are required before production enablement?

--- a/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/proposal.md
+++ b/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Receipt capture already preserves the evidence and creates an editable expense draft, but users must manually transcribe routine receipt details. Glovelly already has a configured Vertex AI/Gemini integration pattern, so a constrained, review-first receipt analysis can test whether multimodal extraction saves effort without making AI output part of the accounting record automatically.
+
+## What Changes
+
+- Add an on-demand Vertex AI receipt analysis action for any existing expense attachment, including attachments created through quick receipt capture.
+- Persist attachment-bound analysis attempts, validated suggestions, provider/model/prompt provenance, warnings, and safe failure state separately from `GigExpense`.
+- Present a shared review experience that clearly distinguishes AI suggestions from saved expense data and requires explicit user action before copying merchant and total into editable expense fields.
+- Surface transaction date, currency, and suggested category as review-only analysis output; do not expand the expense/accounting data model in this change.
+- Enforce supported analysis media types, an AI-specific size limit, deterministic structured-output validation, rate limiting, privacy-conscious logging, and graceful manual-workflow fallback.
+
+## Capabilities
+
+### New Capabilities
+- `vertex-receipt-analysis`: Analyze a stored expense receipt with Vertex AI and expose validated, reviewable suggestions without automatically changing financial records.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Backend: attachment-level APIs, EF Core persistence/migration, attachment blob reads, Vertex AI request construction, settings, validation, logging, and integration tests.
+- Frontend: attachment actions in the gig expenses panel, shared receipt-analysis review state/UI, quick-receipt hand-off, API types, and styling.
+- Operations and policy: Vertex AI configuration/permissions, provider usage monitoring, and privacy-policy disclosure for user-triggered AI receipt analysis.

--- a/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/specs/vertex-receipt-analysis/spec.md
+++ b/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/specs/vertex-receipt-analysis/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Users can request receipt analysis for any visible expense attachment
+The system SHALL allow an authenticated user to request analysis for any receipt attachment belonging to an expense visible to that user. The quick receipt capture flow SHALL invoke the same attachment-level analysis journey after it has saved an attachment.
+
+#### Scenario: User analyses an existing expense receipt
+- **WHEN** a user selects Analyse receipt for an attachment on a visible existing expense
+- **THEN** the system SHALL analyse that attachment without requiring the attachment to have been created by quick receipt capture
+
+#### Scenario: Quick capture hands off to attachment analysis
+- **WHEN** quick receipt capture has successfully saved its receipt attachment and the user selects Analyse receipt
+- **THEN** the system SHALL open the shared analysis journey for the saved gig, expense, and attachment identifiers
+
+#### Scenario: User cannot analyse another user's attachment
+- **WHEN** a user requests analysis for an attachment outside their visibility scope
+- **THEN** the system SHALL not disclose or analyse the attachment
+
+### Requirement: Receipt analysis preserves independent provenance
+The system SHALL persist each receipt-analysis attempt independently from `GigExpense` and associate it with exactly one expense attachment. Each attempt SHALL retain its status, provider, model, prompt version, requested/completed timestamps, validated suggestions, confidence values, warnings, and safe failure information where applicable.
+
+#### Scenario: Successful analysis is retained
+- **WHEN** receipt analysis returns a valid response
+- **THEN** the system SHALL persist a successful attachment-bound analysis attempt with its validated output and provenance
+
+#### Scenario: Reanalysis preserves history
+- **WHEN** a user analyses an attachment that already has an earlier analysis attempt
+- **THEN** the system SHALL create a new attempt without overwriting the earlier attempt
+
+#### Scenario: Failure is retained safely
+- **WHEN** analysis cannot complete because of a provider, timeout, unsupported-media, missing-content, or invalid-response failure
+- **THEN** the system SHALL persist a failed attempt with a safe user-facing failure message and no unvalidated suggestions
+
+### Requirement: Receipt media is sent to Vertex AI within bounded scope
+The system SHALL load the stored attachment through the attachment storage service and send only supported receipt media bytes, MIME type, and minimal extraction context to the configured Vertex AI model. The system SHALL enforce a receipt-analysis-specific file-size limit and MIME allowlist.
+
+#### Scenario: Supported receipt is analysed inline
+- **WHEN** a supported attachment is within the analysis size limit and Vertex receipt analysis is configured
+- **THEN** the system SHALL send the attachment as inline multimodal content with a constrained extraction request
+
+#### Scenario: Unsupported receipt is not sent to Vertex
+- **WHEN** an attachment MIME type is unsupported for receipt analysis or its size exceeds the analysis limit
+- **THEN** the system SHALL not send its content to Vertex AI and SHALL return a safe failed analysis result
+
+#### Scenario: Vertex receipt analysis is unavailable
+- **WHEN** a user requests analysis while receipt analysis is not configured or the provider is unavailable
+- **THEN** the system SHALL leave the attachment and expense unchanged and SHALL report that analysis is unavailable
+
+### Requirement: Receipt suggestions are constrained and deterministically validated
+The system SHALL request JSON-only receipt suggestions for merchant, transaction date, total amount, currency, suggested category, per-field confidence, and warnings. The system SHALL validate all output before persisting or presenting it.
+
+#### Scenario: Valid structured response is accepted
+- **WHEN** Vertex returns a response with valid merchant, ISO date, invariant decimal total, ISO currency, allowed category, confidence values, and warnings
+- **THEN** the system SHALL persist and present those values as suggestions
+
+#### Scenario: Invalid individual field is isolated
+- **WHEN** Vertex returns a response with one invalid field and other independently valid fields
+- **THEN** the system SHALL omit the invalid field, retain the valid fields, and include a warning requiring review
+
+#### Scenario: Malformed response is rejected
+- **WHEN** Vertex returns empty, malformed, or structurally invalid output
+- **THEN** the system SHALL not persist it as a successful analysis or present it as a suggestion
+
+### Requirement: AI suggestions require explicit user application
+The system SHALL visibly distinguish analysis suggestions from saved expense data and SHALL not automatically update any `GigExpense` value. The system SHALL allow the user to explicitly copy merchant and total suggestions into editable description and amount controls.
+
+#### Scenario: User applies merchant and total suggestions
+- **WHEN** a user explicitly applies valid merchant and total suggestions
+- **THEN** the system SHALL populate the relevant editable expense controls without saving the expense automatically
+
+#### Scenario: User saves applied suggestions
+- **WHEN** a user saves the populated expense controls through the existing expense workflow
+- **THEN** the system SHALL persist the chosen description and amount using normal expense validation and workflow rules
+
+#### Scenario: User does not apply suggestions
+- **WHEN** a user closes the analysis review without applying a suggestion
+- **THEN** the system SHALL leave the saved expense values unchanged
+
+### Requirement: Currency, category, and transaction date remain review-only
+The system SHALL present suggested currency, category, and transaction date as analysis information only and SHALL not add or populate accounting-model fields for them in this change.
+
+#### Scenario: Review-only fields are displayed
+- **WHEN** a successful analysis includes currency, category, or transaction date
+- **THEN** the system SHALL show those values with their confidence and any warnings as review-only suggestions
+
+#### Scenario: Applying editable suggestions does not persist review-only fields
+- **WHEN** a user applies merchant or total and saves the expense
+- **THEN** the system SHALL not persist the analysis currency, category, or transaction date as `GigExpense` fields
+
+### Requirement: Receipt analysis is privacy-conscious and observable
+The system SHALL make analysis user-triggered, rate limit requests per user, apply a cancellation-aware timeout, and emit operational telemetry without sensitive receipt or extraction content. The production privacy disclosure SHALL describe optional Vertex AI receipt processing before the feature is enabled.
+
+#### Scenario: Analysis activity is logged safely
+- **WHEN** an analysis attempt completes or fails
+- **THEN** operational logs SHALL contain only non-sensitive identifiers, model/configuration metadata, outcome, elapsed time, and failure classification
+
+#### Scenario: Sensitive receipt content is excluded from logs
+- **WHEN** the system logs an analysis attempt
+- **THEN** it SHALL not log receipt bytes, filenames, prompts, raw model responses, merchant values, or total amounts
+
+#### Scenario: User exceeds analysis rate limit
+- **WHEN** a user exceeds the configured receipt-analysis request limit
+- **THEN** the system SHALL reject the analysis request safely without changing the attachment or expense

--- a/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/tasks.md
+++ b/openspec/changes/archive/2026-07-29-add-vertex-receipt-analysis/tasks.md
@@ -1,0 +1,38 @@
+## 1. Receipt Analysis Foundation
+
+- [x] 1.1 Add receipt-analysis settings for Vertex project/location/model, supported media types, analysis size limit, timeout, rate limit, and enabled/configured state.
+- [x] 1.2 Add `ReceiptAnalysis` persistence, status enum, attachment relationship, EF configuration, migration, and indexes for attachment history/latest-attempt lookup.
+- [x] 1.3 Define transport/domain contracts for an attachment target, analysis result, field confidence, warnings, and safe failure status without adding fields to `GigExpense`.
+- [x] 1.4 Add a domain receipt-analysis service interface and registration that keeps Vertex client construction narrowly shared with existing Vertex usage where practical.
+
+## 2. Vertex Extraction And Validation
+
+- [x] 2.1 Implement stored-attachment loading and analysis eligibility checks for the configured MIME allowlist and AI-specific size limit.
+- [x] 2.2 Implement the Vertex multimodal inline-media request with minimal context, JSON-only structured output controls, prompt versioning, and cancellation-aware timeout.
+- [x] 2.3 Implement strict response parsing and field-level validation for merchant, ISO transaction date, invariant decimal total, ISO currency, allowed category, confidence values, and bounded warnings.
+- [x] 2.4 Persist successful and failed analysis attempts with provider/model/prompt provenance, safe errors, and bounded raw structured output if approved by retention policy.
+- [x] 2.5 Add privacy-safe structured logging, per-user receipt-analysis rate limiting, and explicit failure classification without recording receipt or extraction content.
+
+## 3. Attachment APIs
+
+- [x] 3.1 Add authenticated attachment-level endpoints to retrieve the latest analysis and create a new analysis attempt using existing attachment visibility rules.
+- [x] 3.2 Return stable API response shapes for successful suggestions, pending request state if applicable, and safe failures without exposing storage keys or raw provider content.
+- [x] 3.3 Ensure analysis failure, retry, invalid response, unavailable configuration, unsupported media, and rate-limit responses leave attachments and `GigExpense` values unchanged.
+
+## 4. Review Experience
+
+- [x] 4.1 Add frontend API types and a shared receipt-analysis hook/modal for loading an attachment's latest analysis, requesting analysis, viewing warnings/confidence, and reanalysing.
+- [x] 4.2 Add an Analyse receipt action to each existing expense attachment in the gig expenses panel and route it through the shared review experience.
+- [x] 4.3 Add quick-receipt hand-off from its saved-attachment state to the same shared review experience.
+- [x] 4.4 Implement explicit merchant/total application callbacks that prefill existing editable description/amount controls but do not save automatically.
+- [x] 4.5 Display transaction date, currency, and category as clearly labelled review-only suggestions with no `GigExpense` persistence path.
+- [x] 4.6 Add responsive and accessible visual states for idle, analysing, successful, failed, and low-confidence/warning results.
+
+## 5. Verification And Operational Readiness
+
+- [x] 5.1 Add backend tests for ownership scope, media/size limits, request shaping, valid and partially valid parsing, malformed/provider failures, provenance, retries, logging-safe behavior, and no automatic expense mutation.
+- [x] 5.2 Add endpoint/integration tests for latest-result retrieval, analysis creation, safe failures, rate limits, and quick-capture attachment hand-off.
+- [x] 5.3 Add frontend build/lint coverage and update relevant browser UAT documentation/tests for analysing both historical and quick-captured attachments.
+- [x] 5.4 Update privacy documentation and deployment/configuration guidance for user-triggered Vertex receipt processing, IAM, logging limits, retention, and cost/usage monitoring.
+- [x] 5.5 Evaluate a consented representative receipt set for extraction accuracy, failure modes, latency, and per-receipt cost; record whether asynchronous post-upload analysis is justified.
+- [x] 5.6 Run `./verify.sh` and resolve all resulting failures.

--- a/openspec/specs/vertex-receipt-analysis/spec.md
+++ b/openspec/specs/vertex-receipt-analysis/spec.md
@@ -1,0 +1,106 @@
+## Purpose
+
+Enable authenticated users to request privacy-conscious, attachment-scoped Vertex AI receipt analysis and review validated suggestions before explicitly applying supported values to an expense.
+
+## Requirements
+
+### Requirement: Users can request receipt analysis for any visible expense attachment
+The system SHALL allow an authenticated user to request analysis for any receipt attachment belonging to an expense visible to that user. The quick receipt capture flow SHALL invoke the same attachment-level analysis journey after it has saved an attachment.
+
+#### Scenario: User analyses an existing expense receipt
+- **WHEN** a user selects Analyse receipt for an attachment on a visible existing expense
+- **THEN** the system SHALL analyse that attachment without requiring the attachment to have been created by quick receipt capture
+
+#### Scenario: Quick capture hands off to attachment analysis
+- **WHEN** quick receipt capture has successfully saved its receipt attachment and the user selects Analyse receipt
+- **THEN** the system SHALL open the shared analysis journey for the saved gig, expense, and attachment identifiers
+
+#### Scenario: User cannot analyse another user's attachment
+- **WHEN** a user requests analysis for an attachment outside their visibility scope
+- **THEN** the system SHALL not disclose or analyse the attachment
+
+### Requirement: Receipt analysis preserves independent provenance
+The system SHALL persist each receipt-analysis attempt independently from `GigExpense` and associate it with exactly one expense attachment. Each attempt SHALL retain its status, provider, model, prompt version, requested/completed timestamps, validated suggestions, confidence values, warnings, and safe failure information where applicable.
+
+#### Scenario: Successful analysis is retained
+- **WHEN** receipt analysis returns a valid response
+- **THEN** the system SHALL persist a successful attachment-bound analysis attempt with its validated output and provenance
+
+#### Scenario: Reanalysis preserves history
+- **WHEN** a user analyses an attachment that already has an earlier analysis attempt
+- **THEN** the system SHALL create a new attempt without overwriting the earlier attempt
+
+#### Scenario: Failure is retained safely
+- **WHEN** analysis cannot complete because of a provider, timeout, unsupported-media, missing-content, or invalid-response failure
+- **THEN** the system SHALL persist a failed attempt with a safe user-facing failure message and no unvalidated suggestions
+
+### Requirement: Receipt media is sent to Vertex AI within bounded scope
+The system SHALL load the stored attachment through the attachment storage service and send only supported receipt media bytes, MIME type, and minimal extraction context to the configured Vertex AI model. The system SHALL enforce a receipt-analysis-specific file-size limit and MIME allowlist.
+
+#### Scenario: Supported receipt is analysed inline
+- **WHEN** a supported attachment is within the analysis size limit and Vertex receipt analysis is configured
+- **THEN** the system SHALL send the attachment as inline multimodal content with a constrained extraction request
+
+#### Scenario: Unsupported receipt is not sent to Vertex
+- **WHEN** an attachment MIME type is unsupported for receipt analysis or its size exceeds the analysis limit
+- **THEN** the system SHALL not send its content to Vertex AI and SHALL return a safe failed analysis result
+
+#### Scenario: Vertex receipt analysis is unavailable
+- **WHEN** a user requests analysis while receipt analysis is not configured or the provider is unavailable
+- **THEN** the system SHALL leave the attachment and expense unchanged and SHALL report that analysis is unavailable
+
+### Requirement: Receipt suggestions are constrained and deterministically validated
+The system SHALL request JSON-only receipt suggestions for merchant, transaction date, total amount, currency, suggested category, per-field confidence, and warnings. The system SHALL validate all output before persisting or presenting it.
+
+#### Scenario: Valid structured response is accepted
+- **WHEN** Vertex returns a response with valid merchant, ISO date, invariant decimal total, ISO currency, allowed category, confidence values, and warnings
+- **THEN** the system SHALL persist and present those values as suggestions
+
+#### Scenario: Invalid individual field is isolated
+- **WHEN** Vertex returns a response with one invalid field and other independently valid fields
+- **THEN** the system SHALL omit the invalid field, retain the valid fields, and include a warning requiring review
+
+#### Scenario: Malformed response is rejected
+- **WHEN** Vertex returns empty, malformed, or structurally invalid output
+- **THEN** the system SHALL not persist it as a successful analysis or present it as a suggestion
+
+### Requirement: AI suggestions require explicit user application
+The system SHALL visibly distinguish analysis suggestions from saved expense data and SHALL not automatically update any `GigExpense` value. The system SHALL allow the user to explicitly copy merchant and total suggestions into editable description and amount controls.
+
+#### Scenario: User applies merchant and total suggestions
+- **WHEN** a user explicitly applies valid merchant and total suggestions
+- **THEN** the system SHALL populate the relevant editable expense controls without saving the expense automatically
+
+#### Scenario: User saves applied suggestions
+- **WHEN** a user saves the populated expense controls through the existing expense workflow
+- **THEN** the system SHALL persist the chosen description and amount using normal expense validation and workflow rules
+
+#### Scenario: User does not apply suggestions
+- **WHEN** a user closes the analysis review without applying a suggestion
+- **THEN** the system SHALL leave the saved expense values unchanged
+
+### Requirement: Currency, category, and transaction date remain review-only
+The system SHALL present suggested currency, category, and transaction date as analysis information only and SHALL not add or populate accounting-model fields for them in this change.
+
+#### Scenario: Review-only fields are displayed
+- **WHEN** a successful analysis includes currency, category, or transaction date
+- **THEN** the system SHALL show those values with their confidence and any warnings as review-only suggestions
+
+#### Scenario: Applying editable suggestions does not persist review-only fields
+- **WHEN** a user applies merchant or total and saves the expense
+- **THEN** the system SHALL not persist the analysis currency, category, or transaction date as `GigExpense` fields
+
+### Requirement: Receipt analysis is privacy-conscious and observable
+The system SHALL make analysis user-triggered, rate limit requests per user, apply a cancellation-aware timeout, and emit operational telemetry without sensitive receipt or extraction content. The production privacy disclosure SHALL describe optional Vertex AI receipt processing before the feature is enabled.
+
+#### Scenario: Analysis activity is logged safely
+- **WHEN** an analysis attempt completes or fails
+- **THEN** operational logs SHALL contain only non-sensitive identifiers, model/configuration metadata, outcome, elapsed time, and failure classification
+
+#### Scenario: Sensitive receipt content is excluded from logs
+- **WHEN** the system logs an analysis attempt
+- **THEN** it SHALL not log receipt bytes, filenames, prompts, raw model responses, merchant values, or total amounts
+
+#### Scenario: User exceeds analysis rate limit
+- **WHEN** a user exceeds the configured receipt-analysis request limit
+- **THEN** the system SHALL reject the analysis request safely without changing the attachment or expense


### PR DESCRIPTION
## Summary
- add attachment-scoped Vertex AI receipt analysis with validated, review-first suggestions
- add Analyse actions for gig expenses and quick receipt capture, including explicit merchant/total application
- migrate Gemini calls to Google.GenAI, use the `eu` multi-region, and document/deploy the feature

## Verification
- `dotnet test glovelly.sln -m:1`
- `npm --prefix frontend/glovelly-web run lint`
- `npm --prefix frontend/glovelly-web run build`
- `openspec validate --specs --strict --json`