### PR TITLE
Improve gig navigation and cloning

### DIFF
--- a/docs/uat/expenses.md
+++ b/docs/uat/expenses.md
@@ -49,7 +49,7 @@ Receipt analysis augments, but never blocks or silently changes, the manual expe
 
 ## Quick Receipt Journey
 
-> **Automation:** Backend automated; manual UAT: `Glovelly.Api.Tests.GigEndpointsTests.QuickReceiptDraft_*` covers draft creation, candidate matching, updates, and reassignment; browser capture remains manual.
+> **Automation:** Backend and browser automated: `Glovelly.Api.Tests.GigEndpointsTests.QuickReceiptDraft_*` covers draft creation, candidate matching, updates, and reassignment; `Glovelly.Uat.Tests.UploadAndQuickCaptureWorkflowTests.QuickReceiptFlowOpensTargetGigInViewport` covers quick-capture navigation. Receipt analysis and visual capture variants remain manual.
 
 ### Steps
 
@@ -57,7 +57,7 @@ Receipt analysis augments, but never blocks or silently changes, the manual expe
 2. If the app suggests a nearby gig, accept it or choose a different gig.
 3. Fill in the receipt draft description and amount.
 4. Save it.
-5. Open the target gig.
+5. Click `Go to gig` and confirm the target Gig overview scrolls into view and remains selected.
 
 ### Expected Results
 

--- a/docs/uat/gig-external-resources.md
+++ b/docs/uat/gig-external-resources.md
@@ -30,7 +30,7 @@ The attachment is added to the selected gig only, appears without refreshing, pr
 
 ## Quick Add Attachment Journey
 
-> **Automation:** Partially automated UAT: `Glovelly.Uat.Tests.UploadAndQuickCaptureWorkflowTests.QuickAttachmentMobileFlowSavesDraftAndOpensTargetGig` covers the mobile-sized quick attachment link flow; backend tests cover file draft matching, no-candidate handling, type inference, moves, and primary updates.
+> **Automation:** Partially automated UAT: `Glovelly.Uat.Tests.UploadAndQuickCaptureWorkflowTests.QuickAttachmentMobileFlowSavesDraftAndOpensTargetGig` covers the mobile-sized quick attachment link flow and confirms `Go to gig` scrolls the target Gig overview into view; backend tests cover file draft matching, no-candidate handling, type inference, moves, and primary updates.
 
 ### Steps
 
@@ -38,7 +38,7 @@ The attachment is added to the selected gig only, appears without refreshing, pr
 2. Click `+` and choose `Upload file`.
 3. Upload a PDF or image when a gig exists within the quick capture window.
 4. Confirm the attachment is saved to the nearest gig and the modal shows editable title, type, purpose, URL, notes, and primary fields.
-5. Save details, then click `Go to gig` and confirm the attachment appears in the gig detail panel.
+5. Save details, then click `Go to gig` and confirm the target Gig overview scrolls into view and shows the attachment.
 6. Click `+` again, choose `Add link`, paste a Google Doc or Google Sheet URL, and save.
 
 ### Expected Results

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -251,17 +251,17 @@ Expected result: only planned gigs with no linked invoice can be deleted. Linked
 3. Click `Clone gig`.
 4. If the gig has expenses, decline the expenses prompt.
 5. Confirm a new gig is created and immediately opens in the edit pane.
-6. Confirm the cloned gig has the same core details as the original, has no linked invoice, and has no copied expenses.
+6. Confirm the cloned gig has the same core details as the original, starts in `Draft` status, has no linked invoice, and has no copied expenses.
 7. Change at least one identifying detail, such as date or title, then save.
 
-Expected result: cloning creates a separate gig record, opens it for editing straight away, and never copies invoice linkage.
+Expected result: cloning creates a separate `Draft` gig record, opens it for editing straight away, and never copies invoice linkage.
 
 ### With Expenses
 
 1. Select a saved gig with at least one expense and, ideally, at least one receipt attachment.
 2. Click `Clone gig`.
 3. Accept the expenses prompt.
-4. Confirm the cloned gig opens in the edit pane with copied expense descriptions and amounts.
+4. Confirm the cloned gig opens in the edit pane in `Draft` status with copied expense descriptions and amounts.
 5. Confirm copied expenses have no receipt attachments.
 6. Save the cloned gig, then generate an invoice from it.
 

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -228,6 +228,7 @@ function App({ appMetadata }: AppProps) {
     externalResourceMode,
     filteredGigs,
     gigForm,
+    gigOverviewScrollRequest,
     gigMode,
     gigQuickFilter,
     gigTypeFilter,
@@ -395,7 +396,7 @@ function App({ appMetadata }: AppProps) {
   } = useQuickReceipt({
     getGigById: (gigId) => gigsById.get(gigId),
     onMergeSavedGig: (gig) => mergeSavedGig(gig),
-    onOpenReceiptDraft: (gig) => openGigReceiptDraft(gig),
+    onOpenReceiptDraft: (gig, scrollToGig) => openGigReceiptDraft(gig, scrollToGig),
     onSelectGig: selectGig,
     onSessionExpired: expireSession,
     setGigStatus,
@@ -474,7 +475,7 @@ function App({ appMetadata }: AppProps) {
     getGigById: (gigId) => gigsById.get(gigId),
     getQuickCaptureCandidates,
     onMergeSavedGig: (gig) => mergeSavedGig(gig),
-    onOpenAttachmentDraft: (gig) => openGigReceiptDraft(gig),
+    onOpenAttachmentDraft: (gig, scrollToGig) => openGigReceiptDraft(gig, scrollToGig),
     onSelectGig: selectGig,
     onSessionExpired: expireSession,
     setGigStatus,
@@ -1703,6 +1704,7 @@ function App({ appMetadata }: AppProps) {
         externalResourceForm={externalResourceForm}
         externalResourceMode={externalResourceMode}
         gigForm={gigForm}
+        scrollToGigOverviewRequest={gigOverviewScrollRequest}
         isEditorOpen={isGigEditorOpen}
         gigMode={gigMode}
         gigQuickFilter={gigQuickFilter}

--- a/frontend/glovelly-web/src/components/GigsSection.tsx
+++ b/frontend/glovelly-web/src/components/GigsSection.tsx
@@ -30,6 +30,7 @@ type GigsSectionProps = {
   externalResourceForm: GigExternalResourceForm
   externalResourceMode: 'create' | 'edit'
   gigForm: GigForm
+  scrollToGigOverviewRequest: number
   isEditorOpen: boolean
   gigMode: 'create' | 'edit'
   gigQuickFilter: GigQuickFilter
@@ -110,6 +111,7 @@ export function GigsSection({
   externalResourceForm,
   externalResourceMode,
   gigForm,
+  scrollToGigOverviewRequest,
   isEditorOpen,
   gigMode,
   gigQuickFilter,
@@ -198,6 +200,18 @@ export function GigsSection({
       editorSlotRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }, 80)
   }, [isEditorOpen])
+
+  useEffect(() => {
+    if (!scrollToGigOverviewRequest || !selectedGig) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      detailPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 80)
+
+    return () => window.clearTimeout(timer)
+  }, [detailPanelRef, scrollToGigOverviewRequest, selectedGig])
 
   return (
     <section className="section-layout">

--- a/frontend/glovelly-web/src/components/QuickReceiptModal.tsx
+++ b/frontend/glovelly-web/src/components/QuickReceiptModal.tsx
@@ -64,6 +64,7 @@ export function QuickReceiptModal({
       <section
         aria-labelledby="quick-receipt-title"
         className="settings-modal quick-receipt-modal panel"
+        data-testid="quick-receipt-modal"
         role="dialog"
         aria-modal="true"
       >

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -605,7 +605,7 @@ export function useGigsWorkspace({
           notes: selectedGig.notes,
           wasDriving: selectedGig.wasDriving,
           type: selectedGig.type,
-          status: selectedGig.status,
+          status: 'Draft',
           invoiceId: null,
           expenses: includeExpenses
             ? selectedGig.expenses

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -76,6 +76,7 @@ export function useGigsWorkspace({
   const [gigTypeFilter, setGigTypeFilter] = useState<GigType | 'all'>('all')
   const [showPastGigs, setShowPastGigs] = useState(false)
   const [gigSort, setGigSort] = useState<GigSort>({ key: 'priority', direction: 'asc' })
+  const [gigOverviewScrollRequest, setGigOverviewScrollRequest] = useState(0)
   const [isGigEditorOpen, setIsGigEditorOpen] = useState(false)
   const [gigMode, setGigMode] = useState<'create' | 'edit'>('create')
   const [gigForm, setGigForm] = useState<GigForm>(emptyGigForm)
@@ -1049,13 +1050,16 @@ export function useGigsWorkspace({
     }
   }
 
-  const openGigReceiptDraft = (savedGig: Gig) => {
+  const openGigReceiptDraft = (savedGig: Gig, scrollToGig = false) => {
     mergeSavedGig(savedGig)
     revealGig(savedGig, [savedGig, ...gigs.filter((gig) => gig.id !== savedGig.id)])
     onOpenSection('gigs')
     setGigMode('edit')
     setGigForm(toEditableGigForm(savedGig))
     setIsGigEditorOpen(true)
+    if (scrollToGig) {
+      setGigOverviewScrollRequest((current) => current + 1)
+    }
   }
 
   const handleLinkedInvoiceAfterGigSave = async (
@@ -1440,6 +1444,7 @@ export function useGigsWorkspace({
     externalResourceMode,
     gigForm,
     gigMode,
+    gigOverviewScrollRequest,
     gigQuickFilter,
     gigTypeFilter,
     gigSearchQuery,

--- a/frontend/glovelly-web/src/hooks/useQuickAttachment.ts
+++ b/frontend/glovelly-web/src/hooks/useQuickAttachment.ts
@@ -19,7 +19,7 @@ type UseQuickAttachmentOptions = {
   getGigById: (gigId: string) => Gig | undefined
   getQuickCaptureCandidates: () => QuickGigCandidate[]
   onMergeSavedGig: (gig: Gig) => void
-  onOpenAttachmentDraft: (gig: Gig) => void
+  onOpenAttachmentDraft: (gig: Gig, scrollToGig?: boolean) => void
   onSelectGig: (gigId: string) => void
   onSessionExpired: (message: string) => void
   setGigStatus: (status: string) => void
@@ -389,7 +389,7 @@ export function useQuickAttachment({
       return
     }
 
-    onOpenAttachmentDraft(targetGig)
+    onOpenAttachmentDraft(targetGig, true)
     clearQuickAttachmentDialog()
   }
 

--- a/frontend/glovelly-web/src/hooks/useQuickReceipt.ts
+++ b/frontend/glovelly-web/src/hooks/useQuickReceipt.ts
@@ -16,7 +16,7 @@ import type {
 type UseQuickReceiptOptions = {
   getGigById: (gigId: string) => Gig | undefined
   onMergeSavedGig: (gig: Gig) => void
-  onOpenReceiptDraft: (gig: Gig) => void
+  onOpenReceiptDraft: (gig: Gig, scrollToGig?: boolean) => void
   onSelectGig: (gigId: string) => void
   onSessionExpired: (message: string) => void
   setGigStatus: (status: string) => void
@@ -246,7 +246,7 @@ export function useQuickReceipt({
       return
     }
 
-    onOpenReceiptDraft(targetGig)
+    onOpenReceiptDraft(targetGig, true)
     clearQuickReceiptDialog()
   }
 

--- a/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/design.md
+++ b/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Gig cloning is a frontend workflow, not a dedicated API operation. The workspace constructs a new `POST /gigs` request from the selected gig, clears invoice fields, and optionally maps expenses without their attachments. It currently passes through the selected gig's status, so the regular create endpoint correctly persists the wrong lifecycle state for a clone.
+
+The API intentionally permits callers to create gigs in supported lifecycle states. Changing that general create contract would affect imports, MCP, and other creation flows beyond cloning.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure every clone request created by the Gigs workspace uses `Draft` status.
+- Retain the existing copied core fields, optional expense mapping, invoice clearing, selection, and editor-opening behaviour.
+- Exercise the browser workflow for every supported source status.
+
+**Non-Goals:**
+- Introduce a clone-specific API endpoint or alter the general `POST /gigs` lifecycle contract.
+- Change lifecycle transition validation, source gigs, invoice handling, receipt handling, or clone field selection.
+- Change the default status for normal new-gig creation.
+
+## Decisions
+
+### Set the lifecycle status in the frontend clone payload
+
+The clone operation will submit the literal `Draft` status instead of reading the status from the selected source gig. This is the smallest change at the sole point where clone semantics are defined and leaves the API's reusable create contract unchanged.
+
+Alternative considered: force `Draft` in `POST /gigs`. Rejected because the endpoint serves non-clone creation paths which legitimately supply their chosen status.
+
+Alternative considered: add `POST /gigs/{id}/clone`. Rejected because cloning has no server-only requirements and a new endpoint would duplicate existing creation validation and persistence work for a one-field behavioural correction.
+
+### Cover the complete UI-to-API clone path with parameterized browser UAT
+
+A Playwright theory will create a source gig for each status, clone it, and assert the opened clone editor has `Draft` selected. This directly verifies the payload transformation, persistence result, and required review destination.
+
+Alternative considered: backend endpoint tests. Rejected as they can test general gig creation but cannot establish how the frontend builds a clone request.
+
+## Risks / Trade-offs
+
+- [A source status might be accidentally reintroduced into the clone payload] → Parameterize the UAT test over Planned, Completed, Cancelled, and Draft sources.
+- [Browser tests rely on a shared staging-style environment] → Use the existing UAT helpers, unique run identifiers, and response waits.
+- [The UI calls `Confirmed` a planned gig while the API uses `Confirmed`] → Use the user-facing `Planned` label only for test selection and documentation; assert the clone UI's `Draft` value.
+
+## Migration Plan
+
+No data migration is required. The change affects only future clones; existing gigs retain their stored lifecycle status. Rollback is a frontend deployment rollback if necessary.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/proposal.md
+++ b/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Cloning currently copies the source gig's lifecycle status, which can make a newly created gig appear already planned, completed, or cancelled. A clone is a starting point for new work and must be reviewed as a draft before it progresses through its lifecycle.
+
+## What Changes
+
+- Make every gig clone start with the `Draft` lifecycle status, regardless of the source status.
+- Preserve the existing clone behaviour for reusable gig details, optional expenses, and cleared invoice linkage.
+- Verify cloning from Planned, Completed, Cancelled, and Draft source gigs produces a Draft clone opened for review.
+- Document the Draft-status expectation in the gig-cloning regression guidance.
+
+## Capabilities
+
+### New Capabilities
+- `gig-cloning`: Defines how users create a new draft gig from an existing gig while preserving only reusable details.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Frontend clone request construction in `frontend/glovelly-web/src/hooks/useGigsWorkspace.ts`.
+- Browser UAT coverage in `tests/Glovelly.Uat.Tests`.
+- Manual regression guidance in `docs/uat/pre-merge-regression.md`.

--- a/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/specs/gig-cloning/spec.md
+++ b/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/specs/gig-cloning/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Cloned gigs start as drafts
+The system SHALL create every gig cloned through the Gigs workspace with lifecycle status `Draft`, regardless of the source gig's lifecycle status.
+
+#### Scenario: Clone a planned gig
+- **WHEN** a user clones a gig whose status is `Confirmed` (shown as Planned)
+- **THEN** the newly created and opened clone has status `Draft`
+
+#### Scenario: Clone a completed gig
+- **WHEN** a user clones a gig whose status is `Completed`
+- **THEN** the newly created and opened clone has status `Draft`
+
+#### Scenario: Clone a cancelled gig
+- **WHEN** a user clones a gig whose status is `Cancelled`
+- **THEN** the newly created and opened clone has status `Draft`
+
+#### Scenario: Clone a draft gig
+- **WHEN** a user clones a gig whose status is `Draft`
+- **THEN** the newly created and opened clone has status `Draft`
+
+### Requirement: Cloning preserves reusable gig details without changing the source
+The system SHALL preserve the existing cloning behaviour for reusable gig details and optional expenses, SHALL omit invoice linkage and receipt attachments from the clone, and SHALL NOT modify the source gig.
+
+#### Scenario: Clone a gig with copied expenses
+- **WHEN** a user chooses to include expenses while cloning a gig
+- **THEN** the clone retains the source gig's reusable details and expense descriptions and amounts, has no invoice linkage or receipt attachments, and the source gig remains unchanged
+
+#### Scenario: Clone a gig without copied expenses
+- **WHEN** a user declines to include expenses while cloning a gig
+- **THEN** the clone retains the source gig's reusable core details, has no expenses or invoice linkage, and the source gig remains unchanged

--- a/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/tasks.md
+++ b/openspec/changes/archive/2026-08-02-clone-gigs-as-drafts/tasks.md
@@ -1,0 +1,14 @@
+## 1. Clone Lifecycle Behaviour
+
+- [x] 1.1 Update the Gigs workspace clone request to create the new gig with `Draft` status rather than the selected source status.
+- [x] 1.2 Preserve the existing copied-field, optional-expense, invoice-clearing, selection, and editor-opening clone behaviour.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add parameterized Playwright UAT coverage that clones Planned, Completed, Cancelled, and Draft source gigs and verifies each opened clone is a Draft.
+- [x] 2.2 Update the manual gig-cloning regression guidance to state that every clone begins as Draft.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused browser UAT coverage in an environment configured with `GLOVELLY_UAT_SECRET`.
+- [x] 3.2 Run frontend lint and build checks.

--- a/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/design.md
+++ b/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Quick receipt and quick attachment flows both call the gig workspace's `openGigReceiptDraft` callback when their `Go to gig` action is selected. That callback already merges the saved gig, reveals it through active filters, selects it, opens the Gigs workspace, and opens the editor. The gig-list component has no signal that this navigation should also move the selected Gig overview into the viewport.
+
+The same callback is used immediately after automatic draft saves. Automatically scrolling in those cases would be disruptive, so scrolling must be limited to the explicit `Go to gig` action.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make explicit `Go to gig` navigation from quick receipts and attachments visibly locate the selected Gig overview.
+- Preserve existing filter clearing, historical-gig reveal, selected state, and gig-editor behavior.
+- Use the gig workspace's established smooth, start-aligned scrolling behavior.
+- Make browser coverage observe the result of `Go to gig` directly.
+
+**Non-Goals:**
+
+- Change quick-capture matching, receipt or attachment persistence, or gig-list ordering.
+- Scroll after every gig selection or every draft save.
+- Add API endpoints, persisted UI state, or new dependencies.
+
+## Decisions
+
+### Use an explicit, one-shot Gig overview scroll request
+
+The gig workspace will expose state representing a requested Gig overview reveal. `openGigReceiptDraft` will request it only when called for explicit quick-add navigation; both quick-capture hooks will identify their `Go to gig` invocation accordingly.
+
+`GigsSection` will consume the request after React renders the selected gig and call `scrollIntoView` on the Gig overview panel with smooth, start-aligned positioning.
+
+This keeps navigation intent and list rendering separate, rather than passing DOM references into hooks or making quick-capture hooks manipulate the document directly.
+
+Alternative considered: scroll whenever the selected gig changes. Rejected because normal list selection, data refreshes, and automatic draft saves would unexpectedly move the viewport.
+
+### Retain existing filter reveal before scrolling
+
+The existing `revealGig` path remains the authority for clearing incompatible filters and showing historical gigs. The scroll effect runs only after that state has produced the selected Gig overview.
+
+Alternative considered: scroll before opening the Gigs workspace. Rejected because the target row may not exist yet, especially when the current section differs or filters must be reset.
+
+### Verify navigation without reopening the gig in UAT
+
+The quick-attachment browser test will assert the Gig overview following `Go to gig` directly. Equivalent quick-receipt navigation coverage will verify the same result. Documentation will describe the expanded coverage.
+
+Alternative considered: retain the existing follow-up `OpenGigAsync` assertion. Rejected because it independently selects the target and therefore cannot detect broken quick-add navigation.
+
+## Risks / Trade-offs
+
+- [The overview can render after filters or section state update] -> Trigger scrolling from a post-render effect keyed by a one-shot request and target selection.
+- [A delayed scroll can fire after a newer navigation] -> Clean up any pending timer/effect work when the request changes or the component unmounts.
+- [Browser visibility assertions do not prove pixel-perfect positioning] -> Assert the target overview is visible after `Go to gig`; retain manual UAT for visual animation judgement.

--- a/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/proposal.md
+++ b/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+After saving a quick receipt or attachment, `Go to gig` selects and opens the matching gig but can leave its list row outside the viewport. This makes the navigation appear incomplete and obscures which gig received the new item.
+
+## What Changes
+
+- Scroll the selected Gig overview into view when `Go to gig` is chosen from a quick receipt.
+- Scroll the selected Gig overview into view when `Go to gig` is chosen from a quick attachment.
+- Preserve the existing selected-gig, filter-reveal, and gig-editor behavior.
+- Cover the navigation result in the browser/UAT journey rather than reopening the gig in the test.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `gig-list-visibility`: Explicit quick-add navigation must reveal the selected gig row in the viewport.
+- `uat-browser-automation`: Browser coverage must verify quick-add navigation opens the target gig without a follow-up manual selection.
+
+## Impact
+
+- Frontend gig workspace state and gig-list rendering.
+- Quick receipt and quick attachment navigation callbacks.
+- Playwright UAT coverage and quick-capture UAT documentation.
+- No API, persistence, or dependency changes.

--- a/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/specs/gig-list-visibility/spec.md
+++ b/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/specs/gig-list-visibility/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Explicit gig navigation reveals its target
+The system SHALL treat an explicit request to select a gig that is not in the visible list as intent to reveal that gig. It SHALL clear active search, type, and quick filters; SHALL enable `Show past gigs` when the target is a normally hidden historical gig; SHALL preserve sort order; and SHALL display a workspace message explaining the changed view. When the explicit navigation is initiated by `Go to gig` after quick receipt or quick attachment capture, the system SHALL scroll the selected Gig overview into the viewport using smooth, start-aligned positioning while keeping that gig selected.
+
+#### Scenario: Invoice-line navigation opens a hidden historical gig
+- **WHEN** a user follows an invoice-line link to a past `Completed` or `Cancelled` gig hidden by the current view
+- **THEN** the workspace enables `Show past gigs`, clears incompatible filters, selects the target, and displays an explanation
+
+#### Scenario: Saved gig is hidden by active filters
+- **WHEN** a newly saved gig is intentionally selected but is excluded by the current list filters
+- **THEN** the workspace clears incompatible filters, reveals and selects the saved gig, and displays an explanation
+
+#### Scenario: Explicit selection preserves sort order
+- **WHEN** explicit navigation reveals a gig that was hidden by filters
+- **THEN** the target is shown at its position in the existing sort order
+
+#### Scenario: Quick receipt navigation scrolls to its selected gig
+- **WHEN** a user chooses `Go to gig` after saving a quick receipt
+- **THEN** the Gigs workspace opens with the receipt's associated gig selected and its Gig overview scrolled into the viewport
+
+#### Scenario: Quick attachment navigation scrolls to its selected gig
+- **WHEN** a user chooses `Go to gig` after saving a quick attachment
+- **THEN** the Gigs workspace opens with the attachment's associated gig selected and its Gig overview scrolled into the viewport

--- a/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/specs/uat-browser-automation/spec.md
+++ b/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/specs/uat-browser-automation/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Browser upload and quick capture journeys are automated
+The UAT browser suite SHALL verify representative receipt and gig attachment upload/download/delete journeys through the browser, including quick-capture navigation to the selected target gig.
+
+#### Scenario: User manages an expense receipt in the browser
+- **WHEN** an authenticated UAT browser test uploads a small receipt file to a gig expense, downloads it, and deletes it
+- **THEN** receipt metadata SHALL appear and disappear in the browser as expected, the download SHALL be non-empty, and the expense reimbursement state SHALL remain unchanged
+
+#### Scenario: User manages a file-only gig attachment in the browser
+- **WHEN** an authenticated UAT browser test creates a file-only gig attachment, uploads a small file, downloads it, and deletes the uploaded file
+- **THEN** the attachment SHALL remain scoped to the selected gig, the download SHALL be non-empty, and deleting the file SHALL NOT delete the attachment shell
+
+#### Scenario: User quick-adds a gig attachment in a mobile-sized viewport
+- **WHEN** an authenticated UAT browser test uses the floating quick attachment action in a mobile-sized viewport and chooses `Go to gig` after saving the attachment
+- **THEN** the target Gig overview SHALL be visible without the test manually selecting the gig after the action
+
+#### Scenario: User quick-adds a receipt and opens its target gig
+- **WHEN** an authenticated UAT browser test saves a quick receipt and chooses `Go to gig`
+- **THEN** the target Gig overview SHALL be visible without the test manually selecting the gig after the action

--- a/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/tasks.md
+++ b/openspec/changes/archive/2026-08-02-scroll-quick-add-gig-into-view/tasks.md
@@ -1,0 +1,12 @@
+## 1. Gig Navigation
+
+- [x] 1.1 Add an opt-in Gig overview scroll request to the gig workspace and trigger it only for explicit quick-capture `Go to gig` navigation.
+- [x] 1.2 Make the gig-list component scroll the selected Gig overview into view with the established smooth, start-aligned behavior, cleaning up pending scroll work.
+- [x] 1.3 Wire both quick receipt and quick attachment `Go to gig` handlers to request the selected-row reveal without changing automatic draft-save behavior.
+
+## 2. Verification
+
+- [x] 2.1 Update the quick-attachment Playwright UAT to verify `Go to gig` directly reveals the target Gig overview rather than reopening the gig in the test.
+- [x] 2.2 Add or extend browser coverage for quick-receipt `Go to gig` navigation and target overview visibility.
+- [x] 2.3 Update quick receipt and attachment UAT documentation to describe the navigation visibility check and coverage.
+- [x] 2.4 Run the relevant frontend checks and targeted UAT coverage.

--- a/openspec/specs/gig-cloning/spec.md
+++ b/openspec/specs/gig-cloning/spec.md
@@ -1,0 +1,35 @@
+## Purpose
+
+Define the behaviour for creating draft copies of existing gigs.
+
+## Requirements
+
+### Requirement: Cloned gigs start as drafts
+The system SHALL create every gig cloned through the Gigs workspace with lifecycle status `Draft`, regardless of the source gig's lifecycle status.
+
+#### Scenario: Clone a planned gig
+- **WHEN** a user clones a gig whose status is `Confirmed` (shown as Planned)
+- **THEN** the newly created and opened clone has status `Draft`
+
+#### Scenario: Clone a completed gig
+- **WHEN** a user clones a gig whose status is `Completed`
+- **THEN** the newly created and opened clone has status `Draft`
+
+#### Scenario: Clone a cancelled gig
+- **WHEN** a user clones a gig whose status is `Cancelled`
+- **THEN** the newly created and opened clone has status `Draft`
+
+#### Scenario: Clone a draft gig
+- **WHEN** a user clones a gig whose status is `Draft`
+- **THEN** the newly created and opened clone has status `Draft`
+
+### Requirement: Cloning preserves reusable gig details without changing the source
+The system SHALL preserve the existing cloning behaviour for reusable gig details and optional expenses, SHALL omit invoice linkage and receipt attachments from the clone, and SHALL NOT modify the source gig.
+
+#### Scenario: Clone a gig with copied expenses
+- **WHEN** a user chooses to include expenses while cloning a gig
+- **THEN** the clone retains the source gig's reusable details and expense descriptions and amounts, has no invoice linkage or receipt attachments, and the source gig remains unchanged
+
+#### Scenario: Clone a gig without copied expenses
+- **WHEN** a user declines to include expenses while cloning a gig
+- **THEN** the clone retains the source gig's reusable core details, has no expenses or invoice linkage, and the source gig remains unchanged

--- a/openspec/specs/gig-list-visibility/spec.md
+++ b/openspec/specs/gig-list-visibility/spec.md
@@ -48,7 +48,7 @@ The system SHALL derive initial and fallback gig selection from the same filtere
 - **THEN** the system selects the first remaining visible gig or clears selection if the result is empty
 
 ### Requirement: Explicit gig navigation reveals its target
-The system SHALL treat an explicit request to select a gig that is not in the visible list as intent to reveal that gig. It SHALL clear active search, type, and quick filters; SHALL enable `Show past gigs` when the target is a normally hidden historical gig; SHALL preserve sort order; and SHALL display a workspace message explaining the changed view.
+The system SHALL treat an explicit request to select a gig that is not in the visible list as intent to reveal that gig. It SHALL clear active search, type, and quick filters; SHALL enable `Show past gigs` when the target is a normally hidden historical gig; SHALL preserve sort order; and SHALL display a workspace message explaining the changed view. When the explicit navigation is initiated by `Go to gig` after quick receipt or quick attachment capture, the system SHALL scroll the selected Gig overview into the viewport using smooth, start-aligned positioning while keeping that gig selected.
 
 #### Scenario: Invoice-line navigation opens a hidden historical gig
 - **WHEN** a user follows an invoice-line link to a past `Completed` or `Cancelled` gig hidden by the current view
@@ -61,3 +61,11 @@ The system SHALL treat an explicit request to select a gig that is not in the vi
 #### Scenario: Explicit selection preserves sort order
 - **WHEN** explicit navigation reveals a gig that was hidden by filters
 - **THEN** the target is shown at its position in the existing sort order
+
+#### Scenario: Quick receipt navigation scrolls to its selected gig
+- **WHEN** a user chooses `Go to gig` after saving a quick receipt
+- **THEN** the Gigs workspace opens with the receipt's associated gig selected and its Gig overview scrolled into the viewport
+
+#### Scenario: Quick attachment navigation scrolls to its selected gig
+- **WHEN** a user chooses `Go to gig` after saving a quick attachment
+- **THEN** the Gigs workspace opens with the attachment's associated gig selected and its Gig overview scrolled into the viewport

--- a/openspec/specs/uat-browser-automation/spec.md
+++ b/openspec/specs/uat-browser-automation/spec.md
@@ -60,7 +60,7 @@ The UAT browser suite SHALL verify deterministic imported-gig review behavior th
 - **THEN** accepted rows SHALL become real gigs, rejected rows SHALL be removed from the batch, and pending rows SHALL remain available for a later pass
 
 ### Requirement: Browser upload and quick capture journeys are automated
-The UAT browser suite SHALL verify representative receipt and gig attachment upload/download/delete journeys through the browser.
+The UAT browser suite SHALL verify representative receipt and gig attachment upload/download/delete journeys through the browser, including quick-capture navigation to the selected target gig.
 
 #### Scenario: User manages an expense receipt in the browser
 - **WHEN** an authenticated UAT browser test uploads a small receipt file to a gig expense, downloads it, and deletes it
@@ -71,8 +71,12 @@ The UAT browser suite SHALL verify representative receipt and gig attachment upl
 - **THEN** the attachment SHALL remain scoped to the selected gig, the download SHALL be non-empty, and deleting the file SHALL NOT delete the attachment shell
 
 #### Scenario: User quick-adds a gig attachment in a mobile-sized viewport
-- **WHEN** an authenticated UAT browser test uses the floating quick attachment action in a mobile-sized viewport
-- **THEN** the quick attachment modal SHALL allow the matched gig to be reviewed or changed and the saved attachment SHALL appear on the target gig
+- **WHEN** an authenticated UAT browser test uses the floating quick attachment action in a mobile-sized viewport and chooses `Go to gig` after saving the attachment
+- **THEN** the target Gig overview SHALL be visible without the test manually selecting the gig after the action
+
+#### Scenario: User quick-adds a receipt and opens its target gig
+- **WHEN** an authenticated UAT browser test saves a quick receipt and chooses `Go to gig`
+- **THEN** the target Gig overview SHALL be visible without the test manually selecting the gig after the action
 
 ### Requirement: Expense statement variants are automated
 The UAT browser suite SHALL extend expense statement coverage beyond the main preview/download path to include deterministic selection and projection rules.

--- a/tests/Glovelly.Uat.Tests/GigCloningTests.cs
+++ b/tests/Glovelly.Uat.Tests/GigCloningTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Playwright;
+using System.Text.Json;
+using Xunit;
+
+namespace Glovelly.Uat.Tests;
+
+public sealed class GigCloningTests : InvoiceUatTestBase
+{
+    [Theory]
+    [InlineData("Confirmed")]
+    [InlineData("Completed")]
+    [InlineData("Cancelled")]
+    [InlineData("Draft")]
+    public Task CloningGig_CreatesDraftRegardlessOfSourceStatus(string sourceStatus) => RunWithDiagnosticsAsync(
+        nameof(CloningGig_CreatesDraftRegardlessOfSourceStatus),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Clone Client";
+            var gigTitle = $"{runId} {sourceStatus} Source Gig";
+
+            await AuthenticateWithUatSecretAsync();
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(
+                clientName,
+                gigTitle,
+                DateTime.UtcNow.AddDays(14).ToString("yyyy-MM-dd"),
+                status: sourceStatus);
+
+            var response = await Page.RunAndWaitForResponseAsync(
+                async () => await Page.GetByRole(AriaRole.Button, new() { Name = "Clone gig" }).ClickAsync(),
+                value => value.Request.Method == "POST" && new Uri(value.Url).AbsolutePath == "/gigs");
+
+            Assert.True(response.Ok, $"Expected gig clone to succeed, got HTTP {response.Status} for {response.Url}.");
+            var clonedGig = JsonDocument.Parse(await response.TextAsync()).RootElement;
+            Assert.Equal("Draft", clonedGig.GetProperty("status").GetString());
+            await Assertions.Expect(Page.GetByTestId("gig-form")).ToBeVisibleAsync();
+            await Assertions.Expect(Page.GetByTestId("gig-status-select")).ToHaveValueAsync("Draft");
+        });
+}

--- a/tests/Glovelly.Uat.Tests/UploadAndQuickCaptureWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/UploadAndQuickCaptureWorkflowTests.cs
@@ -109,8 +109,7 @@ public sealed class UploadAndQuickCaptureWorkflowTests : InvoiceUatTestBase
                 Timeout = 30_000,
             });
             await Page.GetByTestId("quick-attachment-go-to-gig-button").ClickAsync();
-            await OpenGigAsync(gigTitle);
-            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = gigTitle })).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions
+            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = gigTitle })).ToBeInViewportAsync(new LocatorAssertionsToBeInViewportOptions
             {
                 Timeout = 30_000,
             });
@@ -118,5 +117,48 @@ public sealed class UploadAndQuickCaptureWorkflowTests : InvoiceUatTestBase
             {
                 HasText = attachmentTitle,
             })).ToBeVisibleAsync();
+        });
+
+    [Fact]
+    public Task QuickReceiptFlowOpensTargetGigInViewport() => RunWithDiagnosticsAsync(
+        nameof(QuickReceiptFlowOpensTargetGigInViewport),
+        async () =>
+        {
+            var runId = CreateRunId();
+            var clientName = $"{runId} Quick Receipt Client";
+            var gigTitle = $"!!! 0 {runId} Quick Receipt Gig";
+            var fixture = await CreateTinyPdfFixtureAsync(runId);
+
+            await AuthenticateWithUatSecretAsync();
+            await Page.SetViewportSizeAsync(390, 844);
+            await CreateClientAsync(clientName);
+            await CreateGigAsync(clientName, gigTitle, DateTime.UtcNow.ToString("yyyy-MM-dd"));
+
+            await Page.GetByTitle("Quick add expense receipt").Locator("input[type=file]").SetInputFilesAsync(fixture);
+            await Page.GetByRole(AriaRole.Heading, new() { Name = "Receipt saved" }).WaitForAsync(new LocatorWaitForOptions
+            {
+                State = WaitForSelectorState.Visible,
+                Timeout = 30_000,
+            });
+            var gigSelect = Page.GetByTestId("quick-capture-gig-select");
+            var optionValue = await gigSelect.Locator("option").Filter(new LocatorFilterOptions
+            {
+                HasText = gigTitle,
+            }).GetAttributeAsync("value");
+            Assert.False(string.IsNullOrWhiteSpace(optionValue), $"Expected quick receipt candidates to include '{gigTitle}'.");
+            await gigSelect.SelectOptionAsync(optionValue);
+            var quickReceiptModal = Page.GetByTestId("quick-receipt-modal");
+            await quickReceiptModal.GetByLabel("Description").FillAsync($"{runId} Receipt draft");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save details" }).ClickAsync();
+            await Assertions.Expect(quickReceiptModal).ToContainTextAsync("details saved", new LocatorAssertionsToContainTextOptions
+            {
+                Timeout = 30_000,
+            });
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Go to gig" }).ClickAsync();
+
+            await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = gigTitle })).ToBeInViewportAsync(new LocatorAssertionsToBeInViewportOptions
+            {
+                Timeout = 30_000,
+            });
         });
 }


### PR DESCRIPTION
## Summary
- scroll the selected gig into view after quick-add navigation
- make cloned gigs start as Draft regardless of source status
- add browser coverage for cloning from every supported lifecycle status
- document and archive the gig-cloning OpenSpec change

Closes #210

## Testing
- `npm --prefix frontend/glovelly-web run lint`
- `npm --prefix frontend/glovelly-web run build`
- `dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj --filter FullyQualifiedName~GigCloningTests` *(blocked locally: `GLOVELLY_UAT_BASE_URL` is not configured)*