### PR TITLE
Add self-service display names and maintenance updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-ef": {
-      "version": "10.0.8",
+      "version": "10.0.11",
       "commands": [
         "dotnet-ef"
       ]

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: 'Extract command'
         id: 'extract_command'
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8
         env:
           EVENT_TYPE: '${{ github.event_name }}.${{ github.event.action }}'
           REQUEST: '${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}'

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -38,7 +38,7 @@ jobs:
           permission-pull-requests: 'write'
 
       - name: 'Checkout Code'
-        uses: 'actions/checkout@v4' # ratchet:exclude
+        uses: 'actions/checkout@v6' # ratchet:exclude
 
       - name: 'Run Gemini CLI'
         id: 'run_gemini'

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -40,7 +40,7 @@ jobs:
           permission-pull-requests: 'write'
 
       - name: 'Checkout Code'
-        uses: 'actions/checkout@v4' # ratchet:exclude
+        uses: 'actions/checkout@v6' # ratchet:exclude
 
       - name: 'Run Gemini CLI'
         id: 'run_gemini'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
         run: bash .github/scripts/validate-ef-migrations.sh
 
       - name: Run backend tests
-        run: dotnet test glovelly.sln --no-restore -m:1
+        run: dotnet test --solution glovelly.sln --no-restore --max-parallel-test-modules 1
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,10 +95,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -114,7 +114,7 @@ jobs:
         run: dotnet test --solution glovelly.sln --no-restore --max-parallel-test-modules 1
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: npm
@@ -143,10 +143,10 @@ jobs:
 
       - name: Set up gcloud
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Capture build timestamp
         id: build_time
@@ -154,7 +154,7 @@ jobs:
 
       - name: Log in to Artifact Registry
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.GAR_HOST }}
           username: oauth2accesstoken
@@ -162,7 +162,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_URI }}
           tags: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: Build and optionally push container image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -201,7 +201,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -212,7 +212,7 @@ jobs:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Run database migrations staging
         env:
@@ -235,7 +235,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -246,11 +246,11 @@ jobs:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Deploy to Cloud Run staging
         id: deploy_staging
-        uses: google-github-actions/deploy-cloudrun@v2
+        uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
           region: ${{ env.GCP_REGION }}
@@ -332,7 +332,7 @@ jobs:
 
       - name: Comment staging URL on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           STAGING_URL: ${{ steps.deploy_staging.outputs.url }}
         with:
@@ -388,7 +388,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -399,7 +399,7 @@ jobs:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Run database migrations production
         env:
@@ -425,7 +425,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -436,11 +436,11 @@ jobs:
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Deploy to Cloud Run production
         id: deploy_production
-        uses: google-github-actions/deploy-cloudrun@v2
+        uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
           region: ${{ env.GCP_REGION }}

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         if: inputs.require_uat_secret != false
@@ -97,7 +97,7 @@ jobs:
 
       - name: Set up gcloud
         if: inputs.require_uat_secret != false
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Load UAT secret from Secret Manager
         if: inputs.require_uat_secret != false
@@ -115,7 +115,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -158,7 +158,7 @@ jobs:
 
       - name: Publish UAT test results
         if: always()
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: Playwright UAT Results
           path: ${{ env.GLOVELLY_UAT_ARTIFACT_DIR }}/test-results/*.trx
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload UAT diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: |

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       test_filter:
-        description: Optional dotnet test filter
+        description: Optional xUnit trait filter
         required: false
         type: string
         default: ""
@@ -38,7 +38,7 @@ on:
           - staging
           - production
       test_filter:
-        description: Optional dotnet test filter, for example Suite=Smoke
+        description: Optional xUnit trait filter, for example Suite=Smoke
         required: false
         default: ""
         type: string
@@ -145,19 +145,16 @@ jobs:
 
       - name: Run Playwright UAT suite
         run: |
+          mkdir -p "$GLOVELLY_UAT_ARTIFACT_DIR/test-results"
           test_args=(
-            tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
-            --no-build
-            --configuration Release
-            --logger "console;verbosity=normal"
-            --logger "trx;LogFileName=uat-test-results.trx"
-            --logger "html;LogFileName=uat-test-report.html"
-            --results-directory "$GLOVELLY_UAT_ARTIFACT_DIR/test-results"
+            -reporter verbose
+            -result-trx "$GLOVELLY_UAT_ARTIFACT_DIR/test-results/uat-test-results.trx"
+            -result-html "$GLOVELLY_UAT_ARTIFACT_DIR/test-results/uat-test-report.html"
           )
           if [ -n "$GLOVELLY_UAT_TEST_FILTER" ]; then
-            test_args+=(--filter "$GLOVELLY_UAT_TEST_FILTER")
+            test_args+=(-trait "$GLOVELLY_UAT_TEST_FILTER")
           fi
-          dotnet test "${test_args[@]}"
+          dotnet tests/Glovelly.Uat.Tests/bin/Release/net10.0/Glovelly.Uat.Tests.dll "${test_args[@]}"
 
       - name: Publish UAT test results
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Run from repo root unless noted.
 
 ```bash
 ./run-dev.sh                                    # backend :5153 + Vite :5173; sources .glovelly.dev.local
-dotnet test glovelly.sln -m:1                  # backend suite; keep -m:1 for shared in-memory/factory state
-dotnet test glovelly.sln -m:1 --filter FullyQualifiedName~GigEndpointsTests
+dotnet test --solution glovelly.sln --max-parallel-test-modules 1  # backend suite; keep modules serial for shared in-memory/factory state
+dotnet test --project backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj -- --filter-class '*GigEndpointsTests'
 npm --prefix frontend/glovelly-web run lint
 npm --prefix frontend/glovelly-web run build
 ./verify.sh                                    # dotnet test, frontend lint, frontend build
@@ -24,7 +24,7 @@ dotnet tool restore && dotnet tool run docfx docs/docfx.json
 dotnet tool run docfx docs/docfx.json --serve  # local handbook
 ```
 
-- Use `./verify.sh` before handing over broad changes. For backend-only changes, `dotnet test glovelly.sln -m:1` is the best first check.
+- Use `./verify.sh` before handing over broad changes. For backend-only changes, `dotnet test --solution glovelly.sln --max-parallel-test-modules 1` is the best first check.
 - Frontend has lint/build checks only; no unit/e2e runner is configured.
 
 ## Backend Map

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,21 +6,21 @@
   <ItemGroup>
     <PackageVersion Include="Google.GenAI" Version="1.16.0" />
     <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.62.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="plist-cil" Version="2.3.1" />
     <PackageVersion Include="Resend" Version="0.5.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.11" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Google.GenAI" Version="1.16.0" />
-    <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.14.0" />
+    <PackageVersion Include="Google.GenAI" Version="1.19.0" />
+    <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.15.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.22.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.62.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Resend" Version="0.11.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.11" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.62.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="plist-cil" Version="2.3.1" />
-    <PackageVersion Include="Resend" Version="0.5.1" />
+    <PackageVersion Include="Resend" Version="0.11.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.11" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 COPY frontend/glovelly-web/ ./
 RUN npm run build
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS backend-build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400 AS backend-build
 WORKDIR /src
 
 COPY glovelly.sln ./
@@ -36,7 +36,7 @@ RUN dotnet tool run dotnet-ef migrations bundle \
 
 COPY --from=frontend-build /src/frontend/glovelly-web/dist/ /app/api/wwwroot/
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.11 AS runtime
 WORKDIR /app
 
 ARG BUILD_COMMIT_ID=unknown

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The MCP tool catalog is treated as a public integration contract. Intentional to
 When you intentionally change MCP tool names, descriptions, safety metadata, input schemas, or output schemas, run:
 
 ```bash
-UPDATE_MCP_SNAPSHOT=1 UPDATE_MCP_DOCS=1 dotnet test glovelly.sln -m:1 --filter FullyQualifiedName~McpToolCatalog
+UPDATE_MCP_SNAPSHOT=1 UPDATE_MCP_DOCS=1 dotnet test --project backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj -- --filter-class '*McpToolCatalog*'
 ```
 
 This refreshes:
@@ -43,7 +43,7 @@ This refreshes:
 After regenerating, review the diff carefully. These files should only change when the MCP public contract has intentionally changed. Then run the MCP-focused tests:
 
 ```bash
-dotnet test glovelly.sln -m:1 --filter FullyQualifiedName~Mcp
+dotnet test --project backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj -- --filter-class '*Mcp*'
 ```
 
 ## Current Scope (v1)

--- a/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/AuthEndpointsTests.cs
@@ -39,6 +39,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         var updateResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             travelOriginPostcode = "BS1 1AA",
@@ -154,6 +155,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
 
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             defaultPaymentWindowDays = 14,
@@ -177,6 +179,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             defaultPaymentWindowDays = 14,
@@ -198,6 +201,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             travelOriginPostcode = "  BS2 2BB  ",
@@ -235,10 +239,127 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     }
 
     [Fact]
+    public async Task UpdateSettings_PersistsTrimmedDisplayNameAndMeReturnsSavedName()
+    {
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            displayName = "  Updated Admin  ",
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("Updated Admin", payload.GetProperty("displayName").GetString());
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var savedUser = await dbContext.Users.FindAsync([TestAuthContext.UserId], TestContext.Current.CancellationToken);
+            Assert.NotNull(savedUser);
+            Assert.Equal("Updated Admin", savedUser.DisplayName);
+        }
+
+        var meResponse = await _client.GetAsync("/auth/me", TestContext.Current.CancellationToken);
+        var me = await meResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("Updated Admin", me.GetProperty("name").GetString());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UpdateSettings_WithBlankDisplayName_ReturnsValidationProblemAndPreservesExistingName(string displayName)
+    {
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            displayName,
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(
+            "Display name cannot be empty or whitespace.",
+            problem.GetProperty("errors").GetProperty("displayName")[0].GetString());
+
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var savedUser = await dbContext.Users.FindAsync([TestAuthContext.UserId], TestContext.Current.CancellationToken);
+        Assert.NotNull(savedUser);
+        Assert.Equal("Test Admin", savedUser.DisplayName);
+    }
+
+    [Fact]
+    public async Task UpdateSettings_WithOverlongDisplayName_ReturnsValidationProblemAndPreservesExistingName()
+    {
+        var response = await _client.PutAsJsonAsync("/auth/me/settings", new
+        {
+            displayName = new string('a', 201),
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal(
+            "Display name must be 200 characters or fewer.",
+            problem.GetProperty("errors").GetProperty("displayName")[0].GetString());
+
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var savedUser = await dbContext.Users.FindAsync([TestAuthContext.UserId], TestContext.Current.CancellationToken);
+        Assert.NotNull(savedUser);
+        Assert.Equal("Test Admin", savedUser.DisplayName);
+    }
+
+    [Fact]
+    public async Task UpdateSettings_AsStandardUser_UpdatesOnlyAuthenticatedUsersDisplayName()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            dbContext.Users.Add(new User
+            {
+                Id = TestAuthContext.AlternateUserId,
+                GoogleSubject = "google-sub-alternate",
+                Email = "alternate@glovelly.local",
+                DisplayName = "Alternate User",
+                Role = UserRole.User,
+                IsActive = true,
+                CreatedUtc = DateTime.UtcNow,
+            });
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Put, "/auth/me/settings")
+        {
+            Content = JsonContent.Create(new
+            {
+                displayName = "Updated Alternate",
+                userId = TestAuthContext.UserId,
+            }),
+        };
+        request.Headers.Add("X-Test-UserId", TestAuthContext.AlternateUserId.ToString());
+        request.Headers.Add("X-Test-Role", UserRole.User.ToString());
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var verificationScope = _factory.Services.CreateScope();
+        var verificationDb = verificationScope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var alternateUser = await verificationDb.Users.FindAsync([TestAuthContext.AlternateUserId], TestContext.Current.CancellationToken);
+        var originalUser = await verificationDb.Users.FindAsync([TestAuthContext.UserId], TestContext.Current.CancellationToken);
+        Assert.NotNull(alternateUser);
+        Assert.NotNull(originalUser);
+        Assert.Equal("Updated Alternate", alternateUser.DisplayName);
+        Assert.Equal("Test Admin", originalUser.DisplayName);
+    }
+
+    [Fact]
     public async Task UpdateSettings_WithTooLongTravelOriginPostcode_ReturnsValidationProblem()
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             travelOriginPostcode = "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -259,6 +380,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = "{InvoiceNumber}",
@@ -279,6 +401,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = "   ",
@@ -298,6 +421,7 @@ public sealed class AuthEndpointsTests : IClassFixture<GlovellyApiFactory>
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = "{InvoiceNumber}",

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -186,6 +186,7 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
 
         var settingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             travelOriginPostcode = "  BS9 9ZZ  ",

--- a/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
+++ b/backend/Glovelly.Api.Tests/GigInvoiceGenerationTests.cs
@@ -166,6 +166,7 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
     {
         var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             defaultPaymentWindowDays = 30,
@@ -209,6 +210,7 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
     {
         var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = (decimal?)null,
             passengerMileageRate = (decimal?)null,
             defaultPaymentWindowDays = 14,
@@ -636,6 +638,7 @@ public sealed class GigInvoiceGenerationTests : IClassFixture<GlovellyApiFactory
 
         var updateUserSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = "{MonthName} {Year} {InvoiceNumber}",

--- a/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceDeliveryEndpointsTests.cs
@@ -34,6 +34,7 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
     {
         var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = (string?)null,
@@ -199,6 +200,7 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
     {
         var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = (string?)null,
@@ -230,6 +232,7 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
     {
         var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = (string?)null,
@@ -281,6 +284,7 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
     {
         var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = (string?)null,
@@ -324,6 +328,7 @@ public sealed class InvoiceDeliveryEndpointsTests : IClassFixture<GlovellyApiFac
     {
         var response = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             invoiceFilenamePattern = (string?)null,

--- a/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/InvoiceStatusEndpointsTests.cs
@@ -139,6 +139,7 @@ public sealed class InvoiceStatusEndpointsTests : IClassFixture<GlovellyApiFacto
     {
         var updateSettingsResponse = await _client.PutAsJsonAsync("/auth/me/settings", new
         {
+            displayName = "Test Admin",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             defaultPaymentWindowDays = 30,

--- a/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/AuthEndpoints.cs
@@ -126,6 +126,7 @@ internal static class AuthEndpoints
 
             localUser.MileageRate = request.MileageRate;
             localUser.PassengerMileageRate = request.PassengerMileageRate;
+            localUser.DisplayName = request.DisplayName!.Trim();
             localUser.TravelOriginPostcode = NormalizeOptionalText(request.TravelOriginPostcode);
             localUser.DefaultPaymentWindowDays = request.DefaultPaymentWindowDays;
             localUser.InvoiceFilenamePattern = request.InvoiceFilenamePattern?.Trim();
@@ -179,6 +180,7 @@ internal static class AuthEndpoints
 
             return Results.Ok(new
             {
+                displayName = localUser.DisplayName,
                 mileageRate = localUser.MileageRate,
                 passengerMileageRate = localUser.PassengerMileageRate,
                 travelOriginPostcode = localUser.TravelOriginPostcode,
@@ -238,6 +240,14 @@ internal static class AuthEndpoints
 
     private static Dictionary<string, string[]>? ValidateUserSettingsRequest(UserSettingsRequest request)
     {
+        if (string.IsNullOrWhiteSpace(request.DisplayName))
+        {
+            return new Dictionary<string, string[]>
+            {
+                ["displayName"] = ["Display name cannot be empty or whitespace."]
+            };
+        }
+
         if (EndpointSupport.TryValidateInvoiceFilenamePattern(
                 request.InvoiceFilenamePattern,
                 out var patternErrors))
@@ -306,6 +316,8 @@ internal static class AuthEndpoints
     }
 
     internal sealed record UserSettingsRequest(
+        [property: StringLength(200, ErrorMessage = "Display name must be 200 characters or fewer.")]
+        string? DisplayName,
         [Range(0, double.MaxValue, ErrorMessage = "Mileage rate cannot be negative.")]
         decimal? MileageRate,
         [Range(0, double.MaxValue, ErrorMessage = "Passenger mileage rate cannot be negative.")]

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -25,7 +25,7 @@ These are the working conventions that save future agents from rediscovering loc
 - Use `TestAuthContext` for seeded/authenticated user details.
 - Use `factory.Emails` for email assertions.
 - Add direct service tests when behavior is mostly pure or when endpoint setup would obscure the scenario.
-- Run `dotnet test glovelly.sln -m:1` after backend changes.
+- Run `dotnet test --solution glovelly.sln --max-parallel-test-modules 1` after backend changes.
 
 ## Frontend
 

--- a/docs/engineering/deployment-pipeline.md
+++ b/docs/engineering/deployment-pipeline.md
@@ -83,7 +83,7 @@ It currently:
 2. sets up .NET
 3. restores dependencies
 4. validates EF migrations against a disposable PostgreSQL database once a baseline snapshot exists
-5. runs backend tests with `dotnet test glovelly.sln --no-restore -m:1`
+5. runs backend tests with `dotnet test --solution glovelly.sln --no-restore --max-parallel-test-modules 1`
 6. authenticates to Google Cloud through Workload Identity Federation
 7. sets up Docker Buildx
 8. builds and optionally pushes the image

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ From the repo root:
 That script runs:
 
 ```bash
-dotnet test glovelly.sln -m:1
+dotnet test --solution glovelly.sln --max-parallel-test-modules 1
 npm --prefix frontend/glovelly-web run lint
 npm --prefix frontend/glovelly-web run build
 ```
@@ -33,15 +33,15 @@ Important support files:
 Run backend tests:
 
 ```bash
-dotnet test glovelly.sln -m:1
+dotnet test --solution glovelly.sln --max-parallel-test-modules 1
 ```
 
-Use `-m:1` because the test setup uses shared web application factory patterns and in-memory state; serial execution avoids noisy cross-test behavior.
+Use `--max-parallel-test-modules 1` because the test setup uses shared web application factory patterns and in-memory state; serial execution avoids noisy cross-test behavior.
 
 Focused Calendar sync checks can be run with:
 
 ```bash
-dotnet test glovelly.sln -m:1 --filter FullyQualifiedName~GoogleCalendarIntegrationModelTests
+dotnet test --project backend/Glovelly.Api.Tests/Glovelly.Api.Tests.csproj -- --filter-class '*GoogleCalendarIntegrationModelTests'
 ```
 
 Worker smoke checks can be run locally with:

--- a/docs/uat/enrolment.md
+++ b/docs/uat/enrolment.md
@@ -50,14 +50,18 @@ The invoice PDF reflects seller profile and payment details. Missing profile det
 ### Steps
 
 1. Open user settings.
-2. Change default invoice or mileage settings.
-3. Save.
-4. Create a new client or gig that uses defaults.
-5. Generate an invoice where those defaults should apply.
+2. Change the display name and save.
+3. Confirm the profile menu shows the new name immediately.
+4. As an administrator, open the Admin section and confirm the matching user row shows the new name without a browser refresh.
+5. Refresh the page or sign in again and confirm the name remains saved.
+6. Change default invoice or mileage settings.
+7. Save.
+8. Create a new client or gig that uses defaults.
+9. Generate an invoice where those defaults should apply.
 
 ### Expected Results
 
-Saved defaults are reused in later client, gig, or invoice workflows where expected. Existing records are not unexpectedly overwritten.
+The display name updates immediately in the profile menu and Administrator user list, and remains saved after refresh or a new sign-in. Saved defaults are reused in later client, gig, or invoice workflows where expected. Existing records are not unexpectedly overwritten.
 
 ## Admin Access
 
@@ -78,10 +82,12 @@ Saved defaults are reused in later client, gig, or invoice workflows where expec
 11. Edit a user record.
 12. Toggle active state or role.
 13. Save.
+14. Edit your own display name and save.
+15. Confirm the avatar dropdown updates to the saved name without a browser refresh.
 
 ### Expected Results
 
-Admin changes persist and non-admin users cannot access admin workflows. New users can accept an email invitation only by signing in with the provisioned verified Google email, after which Glovelly enrols that Google identity. Admins can choose not to send the invitation when needed.
+Admin changes persist and non-admin users cannot access admin workflows. An administrator editing their own account sees the updated display name immediately in the avatar dropdown. New users can accept an email invitation only by signing in with the provisioned verified Google email, after which Glovelly enrols that Google identity. Admins can choose not to send the invitation when needed.
 
 ## Access-Request Approval
 

--- a/frontend/glovelly-web/package-lock.json
+++ b/frontend/glovelly-web/package-lock.json
@@ -1425,16 +1425,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2455,9 +2455,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2622,9 +2622,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2642,7 +2642,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -53,6 +53,7 @@ import { useWorkspaceEvents } from './hooks/useWorkspaceEvents'
 import type {
   AppMetadata,
   AppSection,
+  AdminUser,
   AuthUser,
   Client,
   ForScoreLibrarySnapshot,
@@ -125,6 +126,18 @@ function App({ appMetadata }: AppProps) {
     },
     [clearSession]
   )
+  const syncCurrentUserFromAdmin = useCallback((savedUser: AdminUser) => {
+    setAuthUser((current) =>
+      current?.userId === savedUser.id
+        ? {
+            ...current,
+            email: savedUser.email,
+            name: savedUser.displayName ?? savedUser.email,
+            role: savedUser.role,
+          }
+        : current
+    )
+  }, [])
 
   const {
     activeUsersCount,
@@ -150,8 +163,10 @@ function App({ appMetadata }: AppProps) {
     startAdminCreate,
     startAdminEdit,
     totalAdmins,
+    updateAdminUserDisplayName,
     updateAdminField,
   } = useAdminWorkspace({
+    onAdminUserSaved: syncCurrentUserFromAdmin,
     onSessionExpired: expireSession,
   })
   const {
@@ -506,6 +521,7 @@ function App({ appMetadata }: AppProps) {
   } = useUserSettings({
     authUser,
     onCloseProfileMenu: closeProfileMenu,
+    onDisplayNameSaved: updateAdminUserDisplayName,
     onSessionExpired: expireSession,
     setAuthUser,
   })

--- a/frontend/glovelly-web/src/components/UserSettingsModal.tsx
+++ b/frontend/glovelly-web/src/components/UserSettingsModal.tsx
@@ -36,7 +36,9 @@ export function UserSettingsModal({
   const [focusedField, setFocusedField] = useState<keyof UserSettingsForm | null>(null)
   const travelOriginPlaceholder = sellerProfilePostcode?.trim() || 'BS1 1AA'
   const settingsNote =
-    focusedField === 'mileageRate'
+    focusedField === 'displayName'
+      ? 'Shown in your profile menu and used as your personal account name.'
+      : focusedField === 'mileageRate'
       ? 'Leave blank if you do not want a personal mileage default.'
       : focusedField === 'passengerMileageRate'
         ? 'Leave blank if you do not want a personal passenger mileage default.'
@@ -92,10 +94,24 @@ export function UserSettingsModal({
           <section className="settings-section">
             <div className="settings-section-heading">
               <p className="section-label">Personal defaults</p>
-              <h3>Rates and payment timing</h3>
+              <h3>Profile, rates and payment timing</h3>
             </div>
 
             <div className="form-grid">
+              <label>
+                <span>Display name</span>
+                <input
+                  autoComplete="name"
+                  data-testid="user-settings-display-name-input"
+                  maxLength={200}
+                  required
+                  type="text"
+                  value={form.displayName}
+                  onFocus={() => handleFocus('displayName')}
+                  onChange={(event) => onUpdateField('displayName', event.target.value)}
+                />
+              </label>
+
               <label>
                 <span>Mileage rate</span>
                 <input

--- a/frontend/glovelly-web/src/forms.ts
+++ b/frontend/glovelly-web/src/forms.ts
@@ -31,6 +31,7 @@ export const emptyAdminForm = (): AdminUserForm => ({
 })
 
 export const emptyUserSettingsForm = (): UserSettingsForm => ({
+  displayName: '',
   mileageRate: '',
   passengerMileageRate: '',
   travelOriginPostcode: '',

--- a/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
@@ -12,6 +12,7 @@ import { defaultAdminStatus, emptyAdminForm } from '../forms'
 import type { AdminSort, AdminUser, AdminUserForm } from '../types'
 
 type UseAdminWorkspaceOptions = {
+  onAdminUserSaved: (user: AdminUser) => void
   onSessionExpired: (message: string) => void
 }
 
@@ -34,7 +35,10 @@ function toEditableAdminForm(user: AdminUser): AdminUserForm {
   }
 }
 
-export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions) {
+export function useAdminWorkspace({
+  onAdminUserSaved,
+  onSessionExpired,
+}: UseAdminWorkspaceOptions) {
   const [adminUsers, setAdminUsers] = useState<AdminUser[]>([])
   const [selectedAdminUserId, setSelectedAdminUserId] = useState<string>('')
   const [adminSearchQuery, setAdminSearchQuery] = useState('')
@@ -150,6 +154,24 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
         : emptyAdminForm()
 
     return JSON.stringify(adminForm) !== JSON.stringify(baseline)
+  }
+
+  const updateAdminUserDisplayName = (userId: string, displayName: string) => {
+    const shouldUpdateEditor =
+      isAdminEditorOpen &&
+      adminMode === 'edit' &&
+      selectedAdminUserId === userId &&
+      !hasUnsavedAdminEditorChanges()
+
+    setAdminUsers((current) =>
+      current.map((user) =>
+        user.id === userId ? { ...user, displayName } : user
+      )
+    )
+
+    if (shouldUpdateEditor) {
+      setAdminForm((current) => ({ ...current, displayName }))
+    }
   }
 
   useEffect(() => {
@@ -299,6 +321,7 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
 
         return [savedUser, ...current]
       })
+      onAdminUserSaved(savedUser)
 
       setSelectedAdminUserId(savedUser.id)
       setAdminMode('edit')
@@ -442,6 +465,7 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
     startAdminCreate,
     startAdminEdit,
     totalAdmins,
+    updateAdminUserDisplayName,
     updateAdminField,
   }
 }

--- a/frontend/glovelly-web/src/hooks/useUserSettings.ts
+++ b/frontend/glovelly-web/src/hooks/useUserSettings.ts
@@ -11,6 +11,7 @@ import { emptyUserSettingsForm } from '../forms'
 import type { AuthUser, GoogleCalendarStatus, UserSettingsForm } from '../types'
 
 type SavedUserSettings = {
+  displayName: string
   mileageRate: number | null
   passengerMileageRate: number | null
   travelOriginPostcode: string | null
@@ -25,6 +26,7 @@ type SavedUserSettings = {
 type UseUserSettingsOptions = {
   authUser: AuthUser | null
   onCloseProfileMenu: () => void
+  onDisplayNameSaved: (userId: string, displayName: string) => void
   onSessionExpired: (message: string) => void
   setAuthUser: Dispatch<SetStateAction<AuthUser | null>>
 }
@@ -34,6 +36,7 @@ const defaultUserSettingsStatus =
 
 function toUserSettingsForm(settings: SavedUserSettings): UserSettingsForm {
   return {
+    displayName: settings.displayName,
     mileageRate: settings.mileageRate === null ? '' : String(settings.mileageRate),
     passengerMileageRate:
       settings.passengerMileageRate === null
@@ -65,6 +68,7 @@ function parseOptionalDecimal(value: string) {
 export function useUserSettings({
   authUser,
   onCloseProfileMenu,
+  onDisplayNameSaved,
   onSessionExpired,
   setAuthUser,
 }: UseUserSettingsOptions) {
@@ -123,6 +127,7 @@ export function useUserSettings({
   const openUserSettings = () => {
     setUserSettingsForm(
       toUserSettingsForm({
+        displayName: authUser?.name ?? '',
         mileageRate: authUser?.mileageRate ?? null,
         passengerMileageRate: authUser?.passengerMileageRate ?? null,
         travelOriginPostcode: authUser?.travelOriginPostcode ?? null,
@@ -306,6 +311,7 @@ export function useUserSettings({
     event.preventDefault()
 
     const mileageRate = parseOptionalDecimal(userSettingsForm.mileageRate)
+    const displayName = userSettingsForm.displayName.trim()
     const passengerMileageRate = parseOptionalDecimal(
       userSettingsForm.passengerMileageRate
     )
@@ -317,6 +323,11 @@ export function useUserSettings({
     const invoiceEmailBodyTemplate = userSettingsForm.invoiceEmailBodyTemplate.trim()
     const invoiceReplyToEmail = userSettingsForm.invoiceReplyToEmail.trim()
     const invoiceUploadFolderId = userSettingsForm.invoiceUploadFolderId.trim()
+
+    if (!displayName) {
+      setUserSettingsStatus('Display name cannot be empty.')
+      return
+    }
 
     if (Number.isNaN(mileageRate) || Number.isNaN(passengerMileageRate)) {
       setUserSettingsStatus('Rates must be valid numbers, for example 0.45.')
@@ -340,6 +351,7 @@ export function useUserSettings({
       const response = await fetchWithSession(
         buildApiUrl('/auth/me/settings'),
         jsonRequestInit('PUT', {
+          displayName,
           mileageRate,
           passengerMileageRate,
           travelOriginPostcode: travelOriginPostcode || null,
@@ -375,8 +387,9 @@ export function useUserSettings({
       setAuthUser((current) =>
         current
           ? {
-              ...current,
-              mileageRate: savedSettings.mileageRate,
+            ...current,
+            name: savedSettings.displayName,
+            mileageRate: savedSettings.mileageRate,
               passengerMileageRate: savedSettings.passengerMileageRate,
               travelOriginPostcode: savedSettings.travelOriginPostcode,
               defaultPaymentWindowDays: savedSettings.defaultPaymentWindowDays,
@@ -390,6 +403,9 @@ export function useUserSettings({
             }
           : current
       )
+      if (authUser) {
+        onDisplayNameSaved(authUser.userId, savedSettings.displayName)
+      }
       setUserSettingsForm(toUserSettingsForm(savedSettings))
       setUserSettingsStatus('Settings updated.')
     } catch (error) {

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -187,6 +187,7 @@ export type AccessRequestDeclineResult = {
 }
 
 export type UserSettingsForm = {
+  displayName: string
   mileageRate: string
   passengerMileageRate: string
   travelOriginPostcode: string

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/openspec/changes/archive/2026-08-21-update-own-display-name/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-21-update-own-display-name/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/archive/2026-08-21-update-own-display-name/design.md
+++ b/openspec/changes/archive/2026-08-21-update-own-display-name/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`User.DisplayName` is already persisted and constrained to 200 characters. Administrators can edit it through `/admin/users/{id}`, while authenticated users manage personal defaults through the protected `/auth/me/settings` endpoint. That endpoint identifies the record from the authenticated principal and is the appropriate self-service boundary.
+
+The frontend keeps the current `/auth/me` response in `AuthUser`. `AppShell` renders the profile name and initials from `AuthUser.name`; `useUserSettings` owns the modal form, settings request, and authenticated-user updates.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let active users view, validate, save, and immediately see their own display name.
+- Maintain server-side ownership by deriving the target user only from authentication.
+- Reuse the existing settings endpoint, error presentation, form lifecycle, and data model.
+- Preserve a saved name across `/auth/me` refreshes and later authenticated sessions.
+
+**Non-Goals:**
+- Editing email addresses, Google subjects, roles, activation status, or any other user's profile.
+- Changing the administrator user-management API or UI.
+- Adding profile images, public profiles, audit history, or a database migration.
+
+## Decisions
+
+### Extend the existing self settings contract
+
+Add `displayName` to `PUT /auth/me/settings`, the saved settings response, and the `/auth/me` representation. The server will trim and validate the supplied value, then assign it to the `User` record found with the authenticated user ID.
+
+This keeps all personal account preferences in one user-facing dialog and retains the established ownership mechanism. A separate profile endpoint would add a second request and validation path without a different authorization model.
+
+### Require a nonblank display name within the existing persistence bound
+
+The self-service request will reject blank or whitespace-only names and values longer than 200 characters before saving. The UI will present the API's standard problem-details message and retain the previously saved state after rejection.
+
+The existing nullable storage remains unchanged to accommodate historical or externally provisioned records; the self-service operation itself produces a nonblank value.
+
+### Update the client session model from the response
+
+On a successful settings request, `useUserSettings` will put the returned name into `AuthUser.name` alongside the saved defaults. `AppShell` already derives the visible profile summary and initials from that state, so no reload or separate user fetch is needed.
+
+The administrator workspace holds a separate cached list of `AdminUser` records. Expose a narrow cache-update action from that workspace and call it after a successful settings save. It will update only the matching user row and will synchronize an open self-editor only when it has no unsaved administrative changes.
+
+Conversely, an administrator save returns the persisted `AdminUser`. The workspace will notify `App` after that save; `App` updates `AuthUser` only when the response belongs to the current user, using the saved display name and email. This keeps the avatar dropdown synchronized without giving the workspace ownership of session state.
+
+### Cover ownership using two persisted users
+
+Endpoint tests will seed an active standard user, send a request authenticated as that user, and assert the standard user's name changes while the original user's name remains unchanged. The request payload will not offer a supported target-user field; a stray client-supplied identifier must not alter server-side target selection.
+
+## Risks / Trade-offs
+
+- [Existing API callers omit the new field] → Update the frontend and affected integration fixtures together; validate that all settings calls include the pre-populated value.
+- [An initial user has no display name] → Use the current `/auth/me` fallback name (email) to pre-populate the form, allowing the user to establish an explicit display name.
+- [A stale authentication cookie has an old name claim] → The app renders the database-backed `/auth/me` value, and claims transformation reloads the local user on authenticated requests.
+- [Self-service scope broadens accidentally] → Use a narrow request shape containing only display name and existing personal defaults; do not accept account identifiers or administrative fields.
+
+## Migration Plan
+
+No schema migration is required. Deploy the API and frontend together so the Settings form sends the new field and applies the returned name. Rollback is safe because the database column and prior admin workflow already support display names; saved values remain valid if the frontend is reverted.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-21-update-own-display-name/proposal.md
+++ b/openspec/changes/archive/2026-08-21-update-own-display-name/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Active standard users can currently see their account name but cannot correct or maintain it without an administrator. They need a safe self-service profile setting that does not expose account-administration controls.
+
+## What Changes
+
+- Add a display-name field to the signed-in user's Settings dialog, pre-populated with the current value.
+- Allow an active user to save a validated display name for only their own account.
+- Update the in-memory authenticated-user state after a successful save so name-bearing UI updates immediately.
+- Synchronize an administrator's cached user-list entry after a self-service name change.
+- Synchronize the signed-in user's profile state after an administrator edits their own account.
+- Preserve the existing administrator user-management journey and prevent self-service changes to email, role, activation status, or another user.
+- Add authorization, validation, persistence, and manual UAT coverage.
+
+## Capabilities
+
+### New Capabilities
+- `self-service-profile`: Active users can maintain their own display name through the authenticated profile settings surface.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Backend: `/auth/me` and `/auth/me/settings` contracts and validation in `AuthEndpoints`.
+- Frontend: authenticated-user and settings form types, settings hook, settings modal, and profile menu state.
+- Tests: `AuthEndpointsTests` self-service ownership, validation, and persistence coverage.
+- Documentation: enrolment/settings UAT checklist.

--- a/openspec/changes/archive/2026-08-21-update-own-display-name/specs/self-service-profile/spec.md
+++ b/openspec/changes/archive/2026-08-21-update-own-display-name/specs/self-service-profile/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Users can view and update their own display name
+The system SHALL show an active authenticated user's current display name in user Settings and SHALL allow that user to save a new display name for their own account.
+
+#### Scenario: Settings pre-populates the display name
+- **WHEN** an active authenticated user opens user Settings
+- **THEN** the display-name field contains the current name used by the application for that user
+
+#### Scenario: User saves a valid display name
+- **WHEN** an active authenticated user submits a nonblank display name of 200 characters or fewer
+- **THEN** the system trims and persists that name on the authenticated user's account
+- **AND THEN** the response returns the saved name
+
+#### Scenario: Saved name remains available after refresh
+- **WHEN** an active authenticated user has saved a display name and the application loads the current authenticated user again
+- **THEN** the current-user representation contains the saved display name
+
+### Requirement: Display-name changes update the active interface
+The system SHALL update the active client-side user state with the saved display name without requiring a browser reload.
+
+#### Scenario: Profile menu reflects a saved name
+- **WHEN** a user successfully saves a new display name
+- **THEN** user-facing profile menus and headers that render the current user's name show the saved name immediately
+
+#### Scenario: Administrator user list reflects a self-service name change
+- **WHEN** an administrator successfully saves a new display name and opens the Administrator user list
+- **THEN** the matching cached user entry shows the saved name without a browser refresh
+
+#### Scenario: Profile menu reflects an administrator self-edit
+- **WHEN** an administrator saves a display-name update for their own account through the Administrator user list
+- **THEN** the profile menu shows the saved name without a browser refresh
+
+### Requirement: Self-service display-name changes are validated
+The system SHALL reject a blank, whitespace-only, or over-200-character display name and SHALL leave the previously persisted name intact.
+
+#### Scenario: Blank display name is rejected
+- **WHEN** a user submits an empty or whitespace-only display name
+- **THEN** the system returns a clear validation error
+- **AND THEN** the user's previously saved display name remains unchanged
+
+#### Scenario: Overlong display name is rejected
+- **WHEN** a user submits a display name longer than 200 characters
+- **THEN** the system returns a clear validation error
+- **AND THEN** the user's previously saved display name remains unchanged
+
+### Requirement: Self-service display-name changes are restricted to the authenticated user
+The system SHALL derive the target account for a self-service display-name update from the authenticated identity and SHALL NOT allow a client to select another account.
+
+#### Scenario: Standard user updates only their own name
+- **WHEN** an active standard user submits a display-name update
+- **THEN** only that authenticated user's display name is changed
+- **AND THEN** other users' display names remain unchanged
+
+#### Scenario: Self-service request includes another user identifier
+- **WHEN** a client submits a self-service display-name update containing an identifier for another user
+- **THEN** the system does not use that identifier to select the target account
+- **AND THEN** only the authenticated user's account can be changed
+
+### Requirement: Self-service profile updates exclude administrative account controls
+The system SHALL NOT expose self-service changes to email address, Google subject, role, activation status, or user accounts other than the authenticated user's account.
+
+#### Scenario: User settings do not offer administrative fields
+- **WHEN** an active standard user opens user Settings
+- **THEN** the interface does not provide controls for email address, Google subject, role, activation status, or another user's account
+
+#### Scenario: Administrator user management remains separate
+- **WHEN** an administrator manages users through the administrator journey
+- **THEN** the existing administrator account-management controls remain available independently of self-service profile settings

--- a/openspec/changes/archive/2026-08-21-update-own-display-name/tasks.md
+++ b/openspec/changes/archive/2026-08-21-update-own-display-name/tasks.md
@@ -1,0 +1,33 @@
+## 1. Self-Service API
+
+- [x] 1.1 Extend the authenticated user-settings request and response in `AuthEndpoints` with `displayName`, validate a trimmed nonblank value against the existing 200-character limit, and persist it only on the authenticated local user.
+- [x] 1.2 Ensure `/auth/me` continues to return the database-backed saved name and update all existing settings request fixtures for the required display-name contract.
+
+## 2. Settings Interface
+
+- [x] 2.1 Add `displayName` to `AuthUser` settings state, `UserSettingsForm`, and the form conversion/reset helpers.
+- [x] 2.2 Add a pre-populated, required display-name input to `UserSettingsModal` without exposing administrative account fields.
+- [x] 2.3 Include the name in `useUserSettings` save requests and apply the returned name to `AuthUser` after a successful response so the profile menu updates immediately.
+
+## 3. Coverage And Documentation
+
+- [x] 3.1 Add `AuthEndpointsTests` coverage for trimming, persistence, and the refreshed `/auth/me` name.
+- [x] 3.2 Add validation tests for blank and overlong names that verify the previous value remains persisted.
+- [x] 3.3 Add a two-user standard-access test proving a self-service request cannot select or change another user's name.
+- [x] 3.4 Update the enrolment UAT checklist with self-service display-name save, immediate UI update, and refresh/sign-in persistence checks.
+
+## 4. Verification
+
+- [x] 4.1 Run `dotnet test glovelly.sln -m:1`.
+- [x] 4.2 Run `npm --prefix frontend/glovelly-web run lint`.
+- [x] 4.3 Run `npm --prefix frontend/glovelly-web run build`.
+
+## 5. Administrator Cache Synchronization
+
+- [x] 5.1 Synchronize the cached Administrator user entry after a successful self-service display-name save without overwriting unsaved administrator edits.
+- [x] 5.2 Run frontend lint and build after the Administrator cache synchronization change.
+
+## 6. Authenticated Profile Synchronization
+
+- [x] 6.1 Synchronize the authenticated profile state when an administrator saves their own user record.
+- [x] 6.2 Run frontend lint and build after the authenticated-profile synchronization change.

--- a/openspec/specs/self-service-profile/spec.md
+++ b/openspec/specs/self-service-profile/spec.md
@@ -1,0 +1,73 @@
+## Purpose
+
+Allow authenticated users to view and manage their own display name without exposing administrative account controls.
+
+## Requirements
+
+### Requirement: Users can view and update their own display name
+The system SHALL show an active authenticated user's current display name in user Settings and SHALL allow that user to save a new display name for their own account.
+
+#### Scenario: Settings pre-populates the display name
+- **WHEN** an active authenticated user opens user Settings
+- **THEN** the display-name field contains the current name used by the application for that user
+
+#### Scenario: User saves a valid display name
+- **WHEN** an active authenticated user submits a nonblank display name of 200 characters or fewer
+- **THEN** the system trims and persists that name on the authenticated user's account
+- **AND THEN** the response returns the saved name
+
+#### Scenario: Saved name remains available after refresh
+- **WHEN** an active authenticated user has saved a display name and the application loads the current authenticated user again
+- **THEN** the current-user representation contains the saved display name
+
+### Requirement: Display-name changes update the active interface
+The system SHALL update the active client-side user state with the saved display name without requiring a browser reload.
+
+#### Scenario: Profile menu reflects a saved name
+- **WHEN** a user successfully saves a new display name
+- **THEN** user-facing profile menus and headers that render the current user's name show the saved name immediately
+
+#### Scenario: Administrator user list reflects a self-service name change
+- **WHEN** an administrator successfully saves a new display name and opens the Administrator user list
+- **THEN** the matching cached user entry shows the saved name without a browser refresh
+
+#### Scenario: Profile menu reflects an administrator self-edit
+- **WHEN** an administrator saves a display-name update for their own account through the Administrator user list
+- **THEN** the profile menu shows the saved name without a browser refresh
+
+### Requirement: Self-service display-name changes are validated
+The system SHALL reject a blank, whitespace-only, or over-200-character display name and SHALL leave the previously persisted name intact.
+
+#### Scenario: Blank display name is rejected
+- **WHEN** a user submits an empty or whitespace-only display name
+- **THEN** the system returns a clear validation error
+- **AND THEN** the user's previously saved display name remains unchanged
+
+#### Scenario: Overlong display name is rejected
+- **WHEN** a user submits a display name longer than 200 characters
+- **THEN** the system returns a clear validation error
+- **AND THEN** the user's previously saved display name remains unchanged
+
+### Requirement: Self-service display-name changes are restricted to the authenticated user
+The system SHALL derive the target account for a self-service display-name update from the authenticated identity and SHALL NOT allow a client to select another account.
+
+#### Scenario: Standard user updates only their own name
+- **WHEN** an active standard user submits a display-name update
+- **THEN** only that authenticated user's display name is changed
+- **AND THEN** other users' display names remain unchanged
+
+#### Scenario: Self-service request includes another user identifier
+- **WHEN** a client submits a self-service display-name update containing an identifier for another user
+- **THEN** the system does not use that identifier to select the target account
+- **AND THEN** only the authenticated user's account can be changed
+
+### Requirement: Self-service profile updates exclude administrative account controls
+The system SHALL NOT expose self-service changes to email address, Google subject, role, activation status, or user accounts other than the authenticated user's account.
+
+#### Scenario: User settings do not offer administrative fields
+- **WHEN** an active standard user opens user Settings
+- **THEN** the interface does not provide controls for email address, Google subject, role, activation status, or another user's account
+
+#### Scenario: Administrator user management remains separate
+- **WHEN** an administrator manages users through the administrator journey
+- **THEN** the existing administrator account-management controls remain available independently of self-service profile settings

--- a/tests/Glovelly.Uat.Tests/AssemblyInfo.cs
+++ b/tests/Glovelly.Uat.Tests/AssemblyInfo.cs
@@ -1,3 +1,1 @@
-using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.None)]

--- a/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
@@ -401,6 +401,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
     {
         var settingsStatus = await FetchWithSessionAsync("/auth/me/settings", "PUT", new
         {
+            displayName = "Glovelly UAT Regression User",
             mileageRate = 0.45m,
             passengerMileageRate = 0.10m,
             defaultPaymentWindowDays = 14,

--- a/tests/Glovelly.Uat.Tests/README.md
+++ b/tests/Glovelly.Uat.Tests/README.md
@@ -1,6 +1,6 @@
 # Glovelly UAT Tests
 
-This project contains Playwright-based UAT and regression smoke tests. It is intentionally kept outside `glovelly.sln` so `dotnet test glovelly.sln` remains a fast backend test command.
+This project contains Playwright-based UAT and regression smoke tests. It is intentionally kept outside `glovelly.sln` so `dotnet test --solution glovelly.sln` remains a fast backend test command.
 
 ## Install Browsers
 
@@ -29,15 +29,15 @@ The `Glovelly CI/CD` workflow deploys staging and calls the reusable `Glovelly U
 For branch UAT, run the `Glovelly CI/CD` workflow manually on the branch with `target_environment` set to `staging`. The workflow deploys staging and then runs the full Playwright UAT suite against it.
 
 ```bash
-GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net dotnet test --project tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
 ```
 
 To run only the production-safe smoke suite locally:
 
 ```bash
 GLOVELLY_UAT_BASE_URL=https://glovelly.net \
-dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj \
-  --filter "Suite=Smoke"
+dotnet test --project tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj \
+  -- -trait "Suite=Smoke"
 ```
 
 To mirror CI diagnostics locally:
@@ -47,10 +47,9 @@ GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net \
 GLOVELLY_UAT_SECRET=<secret> \
 GLOVELLY_UAT_INVOICE_RECIPIENT_EMAIL=uat-invoices@example.com \
 GLOVELLY_UAT_ARTIFACT_DIR=TestResults/uat \
-dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj \
-  --logger "trx;LogFileName=uat-test-results.trx" \
-  --logger "html;LogFileName=uat-test-report.html" \
-  --results-directory TestResults/uat/test-results
+dotnet tests/Glovelly.Uat.Tests/bin/Debug/net10.0/Glovelly.Uat.Tests.dll \
+  -result-trx TestResults/uat/test-results/uat-test-results.trx \
+  -result-html TestResults/uat/test-results/uat-test-report.html
 ```
 
 On failure, tests write Playwright trace zips to `TestResults/uat/playwright-traces` and screenshots to `TestResults/uat/screenshots`.
@@ -58,5 +57,5 @@ On failure, tests write Playwright trace zips to `TestResults/uat/playwright-tra
 Tests run headless by default. To see the browser:
 
 ```bash
-GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net GLOVELLY_UAT_HEADLESS=false dotnet test tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
+GLOVELLY_UAT_BASE_URL=https://staging.glovelly.net GLOVELLY_UAT_HEADLESS=false dotnet test --project tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj
 ```

--- a/verify.sh
+++ b/verify.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Running backend tests..."
-dotnet test "$ROOT_DIR/glovelly.sln" -m:1
+dotnet test --solution "$ROOT_DIR/glovelly.sln" --max-parallel-test-modules 1
 
 echo
 echo "Running frontend tests..."


### PR DESCRIPTION
## Summary
- allow authenticated users to update their own display name
- apply security and dependency maintenance across .NET, npm, Google, IdentityModel, and Resend packages
- migrate xUnit 4 tests to Microsoft Testing Platform and preserve UAT reports

## Validation
- `./verify.sh`
- targeted authentication, Vertex AI, Google Drive, email, and focused MTP tests
- UAT project build and smoke-trait discovery
- `npm audit --package-lock-only --json` reports zero vulnerabilities