### PR TITLE
fix: restore valid Gemini review dispatch workflow

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -37,7 +37,7 @@ jobs:
         id: 'extract_context'
         uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8
         env:
-          REQUEST: '${{ github.event.comment.body || '' }}'
+          REQUEST: "${{ github.event.comment.body || '' }}"
         with:
           script: |-
             const command = '@gemini-cli /review';


### PR DESCRIPTION
## Summary

Fixes the workflow-validation error introduced in #256.

The `REQUEST` environment value is a GitHub expression containing an empty string literal. It was wrapped in YAML single quotes, which caused YAML to consume one level of the expression's quotes and left GitHub Actions with an unterminated expression.

## Change

Uses YAML double quotes around the expression:

```yaml
REQUEST: "${{ github.event.comment.body || '' }}"
```

This preserves both supported review paths: automatic same-repository PR review and trusted `@gemini-cli /review` re-review.