### PR TITLE
Improve workflow failure feedback and notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ dotnet tool run docfx docs/docfx.json --serve  # local handbook
 - `src/App.tsx` coordinates session, active section, initial data loads, modals, and cross-workspace actions. Avoid adding large workflow bodies there when a hook can own them.
 - `src/hooks/` owns stateful workspace logic for clients, gigs, gig imports, invoices, admin, user settings, seller profile, and quick receipts.
 - `src/components/` is presentational sections/modals. Preserve the current plain React/CSS approach; there is no component library.
+- Terminal frontend feedback uses Sonner: mount `NotificationToaster` from `src/NotificationToaster.tsx` in `src/main.tsx` and call the Glovelly policy wrapper in `src/notifications.ts`, rather than importing Sonner in workspace code. Use notifications for completed actions and unexpected failures that close, navigate away from, or outlive their initiating UI; keep validation, progress, durable configuration/health warnings, and terminal feedback for still-open modals inline. The notification viewport must render below modal overlays so persistent notifications cannot block modal controls.
 - Use `buildApiUrl`, `fetchWithSession`, `parseProblemDetails`, and session-expiry helpers from `src/api.ts`; avoid raw `fetch` for authenticated API calls.
 - Update `src/types.ts` whenever backend JSON shapes change.
 - When adding a frontend-consumed API prefix, update both `frontend/glovelly-web/vite.config.ts` proxy and `frontend/glovelly-web/public/sw.js` API bypass list, or local Vite/service-worker responses can hide backend data.
@@ -53,6 +54,7 @@ dotnet tool run docfx docs/docfx.json --serve  # local handbook
 - Use `GlovellyApiFactory.WithConfiguration(...)` for auth/development-style tests that need real auth wiring.
 - Seed IDs live in `Infrastructure/TestData.cs`; default authenticated user claims live in `Infrastructure/TestAuthContext.cs`; email assertions should use `factory.Emails`.
 - When changing a user journey or cross-workspace navigation, update the matching scenario under `docs/uat/`.
+- When changing terminal frontend feedback, update the relevant UAT journey and retain its notification, persistent-error, and mobile-placement coverage.
 
 ## Local And Secrets
 

--- a/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
+++ b/backend/Glovelly.Api.Tests/GigEndpointsTests.cs
@@ -3,7 +3,10 @@ using System.Net.Http.Json;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Glovelly.Api.Data;
+using Glovelly.Api.Services;
 using Glovelly.Api.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -534,6 +537,12 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
         Assert.Equal("application/pdf", downloadResponse.Content.Headers.ContentType?.MediaType);
         Assert.Equal("receipt evidence", await downloadResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        await RemoveAttachmentBlobAsync(attachmentId);
+        var missingBlobResponse = await _client.GetAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, missingBlobResponse.StatusCode);
+        var missingBlobProblem = await missingBlobResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("This attachment file is no longer available.", missingBlobProblem.GetProperty("detail").GetString());
 
         var deleteResponse = await _client.DeleteAsync($"/gigs/{gigId}/expenses/{expenseId}/attachments/{attachmentId}", TestContext.Current.CancellationToken);
 
@@ -1531,10 +1540,28 @@ public sealed class GigEndpointsTests : IClassFixture<GlovellyApiFactory>
         Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
         Assert.Equal("text/markdown", downloadResponse.Content.Headers.ContentType?.MediaType);
 
+        await RemoveAttachmentBlobAsync(attachmentId);
+        var missingBlobResponse = await _client.GetAsync($"/gigs/{gigId}/external-resources/{resourceId}/attachments/{attachmentId}", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, missingBlobResponse.StatusCode);
+        var missingBlobProblem = await missingBlobResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+        Assert.Equal("This attachment file is no longer available.", missingBlobProblem.GetProperty("detail").GetString());
+
         var deleteResponse = await _client.DeleteAsync($"/gigs/{gigId}/external-resources/{resourceId}/attachments/{attachmentId}", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
         var gigAfterDelete = await deleteResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
         Assert.Empty(Assert.Single(gigAfterDelete.GetProperty("externalResources").EnumerateArray()).GetProperty("attachments").EnumerateArray());
+    }
+
+    private async Task RemoveAttachmentBlobAsync(Guid attachmentId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var storageKey = (await db.ExpenseAttachments.FindAsync([attachmentId], TestContext.Current.CancellationToken))?.StorageKey
+            ?? (await db.GigExternalResourceAttachments.FindAsync([attachmentId], TestContext.Current.CancellationToken))?.StorageKey;
+        Assert.NotNull(storageKey);
+
+        var attachmentStore = scope.ServiceProvider.GetRequiredService<IExpenseAttachmentStore>();
+        await attachmentStore.DeleteAsync(storageKey, TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
+++ b/backend/Glovelly.Api.Tests/GoogleCalendarIntegrationModelTests.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Net;
+using System.Net.Http.Json;
 using Xunit;
 
 namespace Glovelly.Api.Tests;
@@ -713,6 +715,140 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
         Assert.Null(syncState.LastSyncError);
     }
 
+    [Theory]
+    [InlineData("{\"error\":{\"code\":403,\"details\":[{\"reason\":\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\"}]}}")]
+    [InlineData("{\"error\":{\"code\":403,\"errors\":[{\"reason\":\"insufficientPermissions\"}]}}")]
+    public void GoogleCalendarApiException_WhenForbiddenScopeIsInsufficient_IsClassified(string responseBody)
+    {
+        var exception = new GoogleCalendarApiException("provider failure", HttpStatusCode.Forbidden, responseBody);
+
+        Assert.True(exception.IsInsufficientScope);
+    }
+
+    [Fact]
+    public void GoogleCalendarApiException_WhenForbiddenReasonIsNotScopeRelated_IsNotClassified()
+    {
+        var exception = new GoogleCalendarApiException(
+            "provider failure",
+            HttpStatusCode.Forbidden,
+            "{\"error\":{\"errors\":[{\"reason\":\"forbidden\"}]}}");
+
+        Assert.False(exception.IsInsufficientScope);
+    }
+
+    [Fact]
+    public void GoogleCalendarApiException_WhenScopeReasonIsOutsideTheCalendarErrorEnvelope_IsNotClassified()
+    {
+        var exception = new GoogleCalendarApiException(
+            "provider failure",
+            HttpStatusCode.Forbidden,
+            "{\"error\":{\"code\":403,\"metadata\":{\"reason\":\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\"}}}");
+
+        Assert.False(exception.IsInsufficientScope);
+    }
+
+    [Fact]
+    public async Task QueueDrainer_WhenGoogleCalendarScopeIsInsufficient_RequiresReconnectionWithoutExposingProviderPayload()
+    {
+        const string responseBody = "{\"error\":{\"code\":403,\"details\":[{\"reason\":\"ACCESS_TOKEN_SCOPE_INSUFFICIENT\"}]}}";
+        var calendarClient = new FakeGoogleCalendarApiClient
+        {
+            CreateEventException = new GoogleCalendarApiException("provider failure", HttpStatusCode.Forbidden, responseBody),
+        };
+        using var factory = CreateFactory(calendarClient);
+        var client = factory.CreateClient();
+        var connectionId = await SeedCalendarConnectionAsync(factory);
+        var gig = CreateGig(GigStatus.Confirmed);
+
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var dbContext = seedScope.ServiceProvider.GetRequiredService<AppDbContext>();
+            dbContext.GoogleCalendarIntegrationSettings.Add(new GoogleCalendarIntegrationSettings
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                GoogleConnectionId = connectionId,
+                IsEnabled = true,
+                GoogleCalendarId = "calendar-id",
+                CalendarName = "Glovelly Gigs",
+                CreatedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            dbContext.Gigs.Add(gig);
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var workItemId = await SeedWorkItemAsync(factory, CalendarSyncWorkItemReason.GigCreated, gig.Id);
+        using (var scope = factory.Services.CreateScope())
+        {
+            var drainer = scope.ServiceProvider.GetRequiredService<ICalendarSyncQueueDrainer>();
+            var result = await drainer.DrainAsync(new CalendarSyncDrainOptions(MaxItems: 5), TestContext.Current.CancellationToken);
+
+            Assert.Equal(new CalendarSyncDrainResult(1, 0, 0, 1, 0, 0), result);
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var workItem = await dbContext.CalendarSyncWorkItems.SingleAsync(item => item.Id == workItemId, TestContext.Current.CancellationToken);
+            var settings = await dbContext.GoogleCalendarIntegrationSettings.SingleAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(CalendarSyncWorkItemStatus.Failed, workItem.Status);
+            Assert.Equal(GoogleCalendarApiException.InsufficientScopeMessage, workItem.LastError);
+            Assert.Contains("provider failure", workItem.LastErrorDetail);
+            Assert.True(settings.RequiresReconnection);
+        }
+
+        var status = await client.GetFromJsonAsync<GoogleCalendarStatusResponse>(
+            "/integrations/google-calendar/status",
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.False(status.IsConnected);
+        Assert.True(status.RequiresReconnection);
+        Assert.Equal(GoogleCalendarApiException.InsufficientScopeMessage, status.LastError);
+        Assert.DoesNotContain("ACCESS_TOKEN_SCOPE_INSUFFICIENT", status.LastError);
+    }
+
+    [Fact]
+    public async Task EnsureCalendarAsync_WhenReconnected_ClearsReconnectionRequirement()
+    {
+        var calendarClient = new FakeGoogleCalendarApiClient();
+        using var factory = CreateFactory(calendarClient);
+        _ = factory.CreateClient();
+        var connectionId = await SeedCalendarConnectionAsync(factory);
+        var failedWorkItemId = await SeedWorkItemAsync(
+            factory,
+            CalendarSyncWorkItemReason.GigUpdated,
+            Guid.NewGuid(),
+            attemptCount: 1,
+            status: CalendarSyncWorkItemStatus.Failed,
+            lastError: GoogleCalendarApiException.InsufficientScopeMessage);
+
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var dbContext = seedScope.ServiceProvider.GetRequiredService<AppDbContext>();
+            dbContext.GoogleCalendarIntegrationSettings.Add(new GoogleCalendarIntegrationSettings
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestAuthContext.UserId,
+                GoogleConnectionId = connectionId,
+                IsEnabled = true,
+                RequiresReconnection = true,
+                GoogleCalendarId = "calendar-id",
+                CalendarName = "Glovelly Gigs",
+                CreatedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow,
+            });
+            await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var scope = factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IGoogleCalendarIntegrationService>();
+        await service.EnsureCalendarAsync(TestAuthContext.UserId, TestContext.Current.CancellationToken);
+
+        var assertionDbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var settings = await assertionDbContext.GoogleCalendarIntegrationSettings.SingleAsync(TestContext.Current.CancellationToken);
+        var failedWorkItem = await assertionDbContext.CalendarSyncWorkItems.SingleAsync(item => item.Id == failedWorkItemId, TestContext.Current.CancellationToken);
+        Assert.False(settings.RequiresReconnection);
+        Assert.Equal(CalendarSyncWorkItemStatus.Failed, failedWorkItem.Status);
+        Assert.Equal(GoogleCalendarApiException.InsufficientScopeMessage, failedWorkItem.LastError);
+    }
+
     [Fact]
     public async Task SyncProcessor_WhenStoredCalendarIsMissing_RecreatesCalendarAndRetriesCreate()
     {
@@ -857,6 +993,122 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
         Assert.Null(workItem.LastError);
         Assert.Null(workItem.LastErrorType);
         Assert.Null(workItem.LastErrorDetail);
+    }
+
+    [Fact]
+    public async Task QueueDrainer_WhenReplacementGigWorkSucceeds_SupersedesHistoricalFailureInStatus()
+    {
+        var processor = new FakeGoogleCalendarSyncProcessor();
+        using var factory = CreateFactory(processor);
+        var client = factory.CreateClient();
+        var gigId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        var failedWorkItemId = await SeedWorkItemAsync(
+            factory,
+            CalendarSyncWorkItemReason.GigUpdated,
+            gigId,
+            attemptCount: 5,
+            status: CalendarSyncWorkItemStatus.Failed,
+            lastError: "Google Calendar is not connected.",
+            createdAtUtc: now.AddMinutes(-2));
+        var replacementWorkItemId = await SeedWorkItemAsync(
+            factory,
+            CalendarSyncWorkItemReason.GigUpdated,
+            gigId,
+            createdAtUtc: now.AddMinutes(-1));
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var drainer = scope.ServiceProvider.GetRequiredService<ICalendarSyncQueueDrainer>();
+            _ = await drainer.DrainAsync(new CalendarSyncDrainOptions(MaxItems: 5), TestContext.Current.CancellationToken);
+
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var failedWorkItem = await dbContext.CalendarSyncWorkItems.SingleAsync(item => item.Id == failedWorkItemId, TestContext.Current.CancellationToken);
+            var replacementWorkItem = await dbContext.CalendarSyncWorkItems.SingleAsync(item => item.Id == replacementWorkItemId, TestContext.Current.CancellationToken);
+            Assert.Equal(CalendarSyncWorkItemStatus.Failed, failedWorkItem.Status);
+            Assert.Equal("Google Calendar is not connected.", failedWorkItem.LastError);
+            Assert.NotNull(failedWorkItem.SupersededAtUtc);
+            Assert.Equal(CalendarSyncWorkItemStatus.Succeeded, replacementWorkItem.Status);
+        }
+
+        var status = await client.GetFromJsonAsync<GoogleCalendarStatusResponse>(
+            "/integrations/google-calendar/status",
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.Equal(0, status.FailedWorkCount);
+        Assert.Null(status.LastError);
+    }
+
+    [Fact]
+    public async Task QueueDrainer_WhenDifferentGigWorkSucceeds_DoesNotSupersedeHistoricalFailure()
+    {
+        var processor = new FakeGoogleCalendarSyncProcessor();
+        using var factory = CreateFactory(processor);
+        var client = factory.CreateClient();
+        var now = DateTimeOffset.UtcNow;
+        var failedWorkItemId = await SeedWorkItemAsync(
+            factory,
+            CalendarSyncWorkItemReason.GigUpdated,
+            Guid.NewGuid(),
+            attemptCount: 5,
+            status: CalendarSyncWorkItemStatus.Failed,
+            lastError: "Google Calendar is not connected.",
+            createdAtUtc: now.AddMinutes(-2));
+        await SeedWorkItemAsync(
+            factory,
+            CalendarSyncWorkItemReason.GigUpdated,
+            Guid.NewGuid(),
+            createdAtUtc: now.AddMinutes(-1));
+
+        using var scope = factory.Services.CreateScope();
+        var drainer = scope.ServiceProvider.GetRequiredService<ICalendarSyncQueueDrainer>();
+        _ = await drainer.DrainAsync(new CalendarSyncDrainOptions(MaxItems: 5), TestContext.Current.CancellationToken);
+
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var failedWorkItem = await dbContext.CalendarSyncWorkItems.SingleAsync(item => item.Id == failedWorkItemId, TestContext.Current.CancellationToken);
+        Assert.Null(failedWorkItem.SupersededAtUtc);
+
+        var status = await client.GetFromJsonAsync<GoogleCalendarStatusResponse>(
+            "/integrations/google-calendar/status",
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.Equal(1, status.FailedWorkCount);
+        Assert.Equal("Google Calendar is not connected.", status.LastError);
+    }
+
+    [Fact]
+    public async Task QueueDrainer_WhenFullSyncSucceeds_DoesNotSupersedeHistoricalGigFailure()
+    {
+        var processor = new FakeGoogleCalendarSyncProcessor();
+        using var factory = CreateFactory(processor);
+        var client = factory.CreateClient();
+        var now = DateTimeOffset.UtcNow;
+        var failedWorkItemId = await SeedWorkItemAsync(
+            factory,
+            CalendarSyncWorkItemReason.GigUpdated,
+            Guid.NewGuid(),
+            attemptCount: 5,
+            status: CalendarSyncWorkItemStatus.Failed,
+            lastError: "Google Calendar is not connected.",
+            createdAtUtc: now.AddMinutes(-2));
+        await SeedWorkItemAsync(
+            factory,
+            CalendarSyncWorkItemReason.ConnectionChanged,
+            createdAtUtc: now.AddMinutes(-1));
+
+        using var scope = factory.Services.CreateScope();
+        var drainer = scope.ServiceProvider.GetRequiredService<ICalendarSyncQueueDrainer>();
+        _ = await drainer.DrainAsync(new CalendarSyncDrainOptions(MaxItems: 5), TestContext.Current.CancellationToken);
+
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var failedWorkItem = await dbContext.CalendarSyncWorkItems.SingleAsync(item => item.Id == failedWorkItemId, TestContext.Current.CancellationToken);
+        Assert.Null(failedWorkItem.SupersededAtUtc);
+
+        var status = await client.GetFromJsonAsync<GoogleCalendarStatusResponse>(
+            "/integrations/google-calendar/status",
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.Equal(1, status.FailedWorkCount);
     }
 
     [Fact]
@@ -1145,12 +1397,14 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
         DateTimeOffset? nextAttemptAtUtc = null,
         CalendarSyncWorkItemStatus status = CalendarSyncWorkItemStatus.Pending,
         string? processingOwnerId = null,
-        DateTimeOffset? processingStartedAtUtc = null)
+        DateTimeOffset? processingStartedAtUtc = null,
+        string? lastError = null,
+        DateTimeOffset? createdAtUtc = null)
     {
         using var scope = factory.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var workItemId = Guid.NewGuid();
-        var now = DateTimeOffset.UtcNow;
+        var now = createdAtUtc ?? DateTimeOffset.UtcNow;
         dbContext.CalendarSyncWorkItems.Add(new CalendarSyncWorkItem
         {
             Id = workItemId,
@@ -1163,6 +1417,7 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
             NextAttemptAtUtc = nextAttemptAtUtc ?? now,
             ProcessingOwnerId = processingOwnerId,
             ProcessingStartedAtUtc = processingStartedAtUtc,
+            LastError = lastError,
             CreatedAtUtc = now,
             UpdatedAtUtc = now,
         });
@@ -1204,6 +1459,7 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
     {
         public bool CreateWasCalled { get; private set; }
         public bool ThrowNotFoundOnNextCreateEvent { get; set; }
+        public Exception? CreateEventException { get; set; }
         public string CreatedCalendarId { get; set; } = "google-calendar-id";
         public string? AccessToken { get; private set; }
         public string? Summary { get; private set; }
@@ -1244,6 +1500,11 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
                     "Not Found");
             }
 
+            if (CreateEventException is not null)
+            {
+                throw CreateEventException;
+            }
+
             return Task.FromResult(new GoogleCalendarEventResult(eventId));
         }
 
@@ -1271,6 +1532,14 @@ public sealed class GoogleCalendarIntegrationModelTests : IClassFixture<Glovelly
             DeletedEventId = eventId;
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class GoogleCalendarStatusResponse
+    {
+        public bool IsConnected { get; set; }
+        public bool RequiresReconnection { get; set; }
+        public int FailedWorkCount { get; set; }
+        public string? LastError { get; set; }
     }
 
     private sealed class FakeGoogleCalendarSyncProcessor : IGoogleCalendarSyncProcessor

--- a/backend/Glovelly.Api/Data/Configuration/CalendarSyncWorkItemConfiguration.cs
+++ b/backend/Glovelly.Api/Data/Configuration/CalendarSyncWorkItemConfiguration.cs
@@ -36,6 +36,7 @@ internal sealed class CalendarSyncWorkItemConfiguration : IEntityTypeConfigurati
         entity.HasIndex(item => new { item.Status, item.ProcessingStartedAtUtc });
         entity.HasIndex(item => item.ProcessingOwnerId);
         entity.HasIndex(item => new { item.UserId, item.Provider });
+        entity.HasIndex(item => new { item.UserId, item.Provider, item.Status, item.SupersededAtUtc, item.UpdatedAtUtc });
         entity.HasIndex(item => new { item.GigId, item.Provider });
         entity.HasOne(item => item.User)
             .WithMany(user => user.CalendarSyncWorkItems)

--- a/backend/Glovelly.Api/Endpoints/GigAttachmentEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigAttachmentEndpoints.cs
@@ -98,7 +98,8 @@ internal static class GigAttachmentEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
-            IExpenseAttachmentStore attachmentStore) =>
+            IExpenseAttachmentStore attachmentStore,
+            ILogger<Program> logger) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var attachment = await GigEndpointSupport.FindVisibleAttachmentAsync(db, userId, gigId, expenseId, attachmentId, asNoTracking: true);
@@ -116,9 +117,16 @@ internal static class GigAttachmentEndpoints
                     attachment.FileName,
                     enableRangeProcessing: true);
             }
-            catch (FileNotFoundException)
+            catch (FileNotFoundException exception)
             {
-                return Results.NotFound();
+                logger.LogWarning(
+                    exception,
+                    "Attachment object was not found: AttachmentId {AttachmentId}, StorageKey {StorageKey}.",
+                    attachment.Id,
+                    attachment.StorageKey);
+                return Results.Problem(
+                    detail: "This attachment file is no longer available.",
+                    statusCode: StatusCodes.Status404NotFound);
             }
         });
 

--- a/backend/Glovelly.Api/Endpoints/GigExternalResourceEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GigExternalResourceEndpoints.cs
@@ -510,7 +510,8 @@ internal static class GigExternalResourceEndpoints
             AppDbContext db,
             ClaimsPrincipal user,
             ICurrentUserAccessor currentUserAccessor,
-            IExpenseAttachmentStore attachmentStore) =>
+            IExpenseAttachmentStore attachmentStore,
+            ILogger<Program> logger) =>
         {
             var userId = currentUserAccessor.TryGetUserId(user);
             var attachment = await GigEndpointSupport.FindVisibleExternalResourceAttachmentAsync(db, userId, gigId, resourceId, attachmentId, asNoTracking: true);
@@ -528,9 +529,16 @@ internal static class GigExternalResourceEndpoints
                     attachment.FileName,
                     enableRangeProcessing: true);
             }
-            catch (FileNotFoundException)
+            catch (FileNotFoundException exception)
             {
-                return Results.NotFound();
+                logger.LogWarning(
+                    exception,
+                    "Attachment object was not found: AttachmentId {AttachmentId}, StorageKey {StorageKey}.",
+                    attachment.Id,
+                    attachment.StorageKey);
+                return Results.Problem(
+                    detail: "This attachment file is no longer available.",
+                    statusCode: StatusCodes.Status404NotFound);
             }
         });
 

--- a/backend/Glovelly.Api/Endpoints/GoogleCalendarIntegrationEndpoints.cs
+++ b/backend/Glovelly.Api/Endpoints/GoogleCalendarIntegrationEndpoints.cs
@@ -181,25 +181,35 @@ internal static class GoogleCalendarIntegrationEndpoints
             var failedWorkCount = await dbContext.CalendarSyncWorkItems.CountAsync(value =>
                 value.UserId == userId.Value &&
                 value.Provider == CalendarProvider.GoogleCalendar &&
-                value.Status == CalendarSyncWorkItemStatus.Failed);
-            var lastError = await dbContext.CalendarSyncWorkItems
+                value.Status == CalendarSyncWorkItemStatus.Failed &&
+                value.SupersededAtUtc == null);
+            var latestError = await dbContext.CalendarSyncWorkItems
                 .AsNoTracking()
                 .Where(value =>
                     value.UserId == userId.Value &&
                     value.Provider == CalendarProvider.GoogleCalendar &&
+                    value.Status == CalendarSyncWorkItemStatus.Failed &&
+                    value.SupersededAtUtc == null &&
                     value.LastError != null)
                 .OrderByDescending(value => value.UpdatedAtUtc)
-                .Select(value => value.LastError)
+                .Select(value => new { value.LastError, value.LastErrorType })
                 .FirstOrDefaultAsync();
+            var lastError = latestError is not null &&
+                latestError.LastErrorType == typeof(GoogleCalendarApiException).FullName &&
+                latestError.LastError != GoogleCalendarApiException.InsufficientScopeMessage
+                ? GoogleCalendarApiException.GenericCalendarErrorMessage
+                : latestError?.LastError;
 
             return Results.Ok(new
             {
                 isConnected = calendarSettings is not null &&
                     calendarSettings.IsEnabled &&
                     calendarSettings.DisconnectedAtUtc == null &&
+                    !calendarSettings.RequiresReconnection &&
                     hasRequiredScope,
                 isEnabled = calendarSettings?.IsEnabled ?? false,
                 hasRequiredScope,
+                requiresReconnection = calendarSettings?.RequiresReconnection ?? false,
                 calendarId = calendarSettings?.GoogleCalendarId,
                 calendarName = calendarSettings?.CalendarName,
                 lastSuccessfulSyncAtUtc = calendarSettings?.LastSuccessfulSyncAtUtc,
@@ -228,6 +238,7 @@ internal static class GoogleCalendarIntegrationEndpoints
             {
                 calendarSettings.IsEnabled = false;
                 calendarSettings.DisconnectedAtUtc = now;
+                calendarSettings.RequiresReconnection = false;
                 calendarSettings.UpdatedAtUtc = now;
             }
 

--- a/backend/Glovelly.Api/Models/CalendarSyncWorkItem.cs
+++ b/backend/Glovelly.Api/Models/CalendarSyncWorkItem.cs
@@ -18,6 +18,7 @@ public sealed class CalendarSyncWorkItem
     public string? LastError { get; set; }
     public string? LastErrorType { get; set; }
     public string? LastErrorDetail { get; set; }
+    public DateTimeOffset? SupersededAtUtc { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset UpdatedAtUtc { get; set; }
 

--- a/backend/Glovelly.Api/Models/GoogleCalendarIntegrationSettings.cs
+++ b/backend/Glovelly.Api/Models/GoogleCalendarIntegrationSettings.cs
@@ -15,6 +15,7 @@ public sealed class GoogleCalendarIntegrationSettings
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset UpdatedAtUtc { get; set; }
     public DateTimeOffset? DisconnectedAtUtc { get; set; }
+    public bool RequiresReconnection { get; set; }
 
     [JsonIgnore]
     public User? User { get; set; }

--- a/backend/Glovelly.Api/Services/CalendarSyncQueueDrainer.cs
+++ b/backend/Glovelly.Api/Services/CalendarSyncQueueDrainer.cs
@@ -140,6 +140,22 @@ public sealed class CalendarSyncQueueDrainer(
             workItem.LastErrorType = null;
             workItem.LastErrorDetail = null;
             workItem.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+            var historicalFailures = await dbContext.CalendarSyncWorkItems
+                .Where(item =>
+                    item.Id != workItem.Id &&
+                    item.UserId == workItem.UserId &&
+                    item.Provider == workItem.Provider &&
+                    item.GigId == workItem.GigId &&
+                    item.Status == CalendarSyncWorkItemStatus.Failed &&
+                    item.SupersededAtUtc == null &&
+                    item.CreatedAtUtc < workItem.CreatedAtUtc)
+                .ToListAsync(cancellationToken);
+            foreach (var historicalFailure in historicalFailures)
+            {
+                historicalFailure.SupersededAtUtc = workItem.UpdatedAtUtc;
+            }
+
             await dbContext.SaveChangesAsync(cancellationToken);
 
             return CalendarSyncDrainItemOutcome.Succeeded;
@@ -147,16 +163,35 @@ public sealed class CalendarSyncQueueDrainer(
         catch (Exception ex)
         {
             workItem.AttemptCount += 1;
-            workItem.LastError = ex.Message;
+            var requiresReconnection = ex is GoogleCalendarApiException { IsInsufficientScope: true };
+            workItem.LastError = requiresReconnection
+                ? GoogleCalendarApiException.InsufficientScopeMessage
+                : ex is GoogleCalendarApiException
+                    ? GoogleCalendarApiException.GenericCalendarErrorMessage
+                    : ex.Message;
             workItem.LastErrorType = ex.GetType().FullName;
             workItem.LastErrorDetail = Truncate(ex.ToString(), MaxErrorDetailLength);
-            workItem.Status = workItem.AttemptCount >= MaxAttempts
+            workItem.Status = requiresReconnection || workItem.AttemptCount >= MaxAttempts
                 ? CalendarSyncWorkItemStatus.Failed
                 : CalendarSyncWorkItemStatus.Pending;
-            workItem.NextAttemptAtUtc = DateTimeOffset.UtcNow.Add(GetRetryDelay(workItem.AttemptCount));
+            workItem.NextAttemptAtUtc = requiresReconnection
+                ? DateTimeOffset.MaxValue
+                : DateTimeOffset.UtcNow.Add(GetRetryDelay(workItem.AttemptCount));
             workItem.ProcessingOwnerId = null;
             workItem.ProcessingStartedAtUtc = null;
             workItem.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+            if (requiresReconnection)
+            {
+                var calendarSettings = await dbContext.GoogleCalendarIntegrationSettings
+                    .SingleOrDefaultAsync(value => value.UserId == workItem.UserId, cancellationToken);
+                if (calendarSettings is not null)
+                {
+                    calendarSettings.RequiresReconnection = true;
+                    calendarSettings.UpdatedAtUtc = workItem.UpdatedAtUtc;
+                }
+            }
+
             await dbContext.SaveChangesAsync(cancellationToken);
 
             logger.LogWarning(

--- a/backend/Glovelly.Api/Services/GcsBlobStore.cs
+++ b/backend/Glovelly.Api/Services/GcsBlobStore.cs
@@ -30,11 +30,25 @@ public sealed class GcsBlobStore(
         CancellationToken cancellationToken = default)
     {
         var memory = new MemoryStream();
-        var obj = await storageClient.DownloadObjectAsync(
-            _bucketName,
-            key,
-            memory,
-            cancellationToken: cancellationToken);
+        Google.Apis.Storage.v1.Data.Object obj;
+        try
+        {
+            obj = await storageClient.DownloadObjectAsync(
+                _bucketName,
+                key,
+                memory,
+                cancellationToken: cancellationToken);
+        }
+        catch (GoogleApiException exception) when (GoogleApiExceptionSupport.IsNotFound(exception))
+        {
+            memory.Dispose();
+            throw new FileNotFoundException("Blob was not found.", key, exception);
+        }
+        catch
+        {
+            memory.Dispose();
+            throw;
+        }
 
         memory.Position = 0;
         return new BlobReadResult(memory, obj.ContentType, (long?)obj.Size);

--- a/backend/Glovelly.Api/Services/GoogleCalendarApiException.cs
+++ b/backend/Glovelly.Api/Services/GoogleCalendarApiException.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Glovelly.Api.Services;
 
@@ -7,6 +9,57 @@ public sealed class GoogleCalendarApiException(
     HttpStatusCode statusCode,
     string responseBody) : InvalidOperationException(message)
 {
+    public const string InsufficientScopeMessage = "Glovelly no longer has permission to add events to this Google Calendar. Reconnect your calendar to grant the required access.";
+    public const string GenericCalendarErrorMessage = "Google Calendar could not be updated. Please try again later.";
+
     public HttpStatusCode StatusCode { get; } = statusCode;
     public string ResponseBody { get; } = responseBody;
+
+    public bool IsInsufficientScope =>
+        StatusCode == HttpStatusCode.Forbidden && ContainsInsufficientScopeReason(ResponseBody);
+
+    private static bool ContainsInsufficientScopeReason(string responseBody)
+    {
+        try
+        {
+            var response = JsonSerializer.Deserialize<GoogleCalendarErrorResponse>(responseBody);
+            var error = response?.Error;
+            if (error is null || (error.Code != 0 && error.Code != (int)HttpStatusCode.Forbidden))
+            {
+                return false;
+            }
+
+            return error.Errors.Concat(error.Details).Any(error =>
+                string.Equals(error.Reason, "ACCESS_TOKEN_SCOPE_INSUFFICIENT", StringComparison.Ordinal) ||
+                string.Equals(error.Reason, "insufficientPermissions", StringComparison.Ordinal));
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private sealed class GoogleCalendarErrorResponse
+    {
+        [JsonPropertyName("error")]
+        public GoogleCalendarError? Error { get; init; }
+    }
+
+    private sealed class GoogleCalendarError
+    {
+        [JsonPropertyName("code")]
+        public int Code { get; init; }
+
+        [JsonPropertyName("errors")]
+        public IReadOnlyList<GoogleCalendarErrorReason> Errors { get; init; } = [];
+
+        [JsonPropertyName("details")]
+        public IReadOnlyList<GoogleCalendarErrorReason> Details { get; init; } = [];
+    }
+
+    private sealed class GoogleCalendarErrorReason
+    {
+        [JsonPropertyName("reason")]
+        public string? Reason { get; init; }
+    }
 }

--- a/backend/Glovelly.Api/Services/GoogleCalendarIntegrationService.cs
+++ b/backend/Glovelly.Api/Services/GoogleCalendarIntegrationService.cs
@@ -44,6 +44,7 @@ public sealed class GoogleCalendarIntegrationService(
             settings.GoogleConnectionId = connection.Id;
             settings.DisconnectedAtUtc = null;
             settings.IsEnabled = true;
+            settings.RequiresReconnection = false;
             settings.UpdatedAtUtc = now;
         }
 

--- a/backend/Glovelly.Migrations/Migrations/20260822214332_AddCalendarSyncFailureSupersession.Designer.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260822214332_AddCalendarSyncFailureSupersession.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Glovelly.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Glovelly.Migrations.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260822214332_AddCalendarSyncFailureSupersession")]
+    partial class AddCalendarSyncFailureSupersession
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Glovelly.Migrations/Migrations/20260822214332_AddCalendarSyncFailureSupersession.cs
+++ b/backend/Glovelly.Migrations/Migrations/20260822214332_AddCalendarSyncFailureSupersession.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Glovelly.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCalendarSyncFailureSupersession : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "RequiresReconnection",
+                table: "GoogleCalendarIntegrationSettings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "SupersededAtUtc",
+                table: "CalendarSyncWorkItems",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CalendarSyncWorkItems_UserId_Provider_Status_SupersededAtUt~",
+                table: "CalendarSyncWorkItems",
+                columns: new[] { "UserId", "Provider", "Status", "SupersededAtUtc", "UpdatedAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CalendarSyncWorkItems_UserId_Provider_Status_SupersededAtUt~",
+                table: "CalendarSyncWorkItems");
+
+            migrationBuilder.DropColumn(
+                name: "RequiresReconnection",
+                table: "GoogleCalendarIntegrationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SupersededAtUtc",
+                table: "CalendarSyncWorkItems");
+        }
+    }
+}

--- a/docs/uat/expenses.md
+++ b/docs/uat/expenses.md
@@ -26,7 +26,7 @@ Use these journeys when a change may affect gig expenses, receipt attachments, q
 
 ### Expected Results
 
-Receipt metadata, storage, download, and deletion all work without changing the expense reimbursement state.
+Receipt metadata, storage, download, and deletion all work without changing the expense reimbursement state. Each completed file action shows a terminal notification; a missing receipt file shows a persistent error notification with a clear unavailable-file message.
 
 ## Receipt Analysis Journey
 
@@ -61,7 +61,7 @@ Receipt analysis augments, but never blocks or silently changes, the manual expe
 
 ### Expected Results
 
-The draft becomes a normal gig expense with its receipt attached. Existing expenses and attachments remain intact.
+The draft becomes a normal gig expense with its receipt attached. Existing expenses and attachments remain intact. Completion feedback remains visible after navigating to the target gig.
 
 ## Expense Reimbursement Journey
 

--- a/docs/uat/gig-external-resources.md
+++ b/docs/uat/gig-external-resources.md
@@ -43,7 +43,7 @@ The attachment is added to the selected gig only, appears without refreshing, pr
 
 ### Expected Results
 
-The quick add journey uses the same gig matching behaviour as quick receipts, supports both uploaded files and URLs, infers Google Doc/Sheet types where possible, and preserves user-facing attachment terminology.
+The quick add journey uses the same gig matching behaviour as quick receipts, supports both uploaded files and URLs, infers Google Doc/Sheet types where possible, and preserves user-facing attachment terminology. Terminal save feedback remains visible after navigating to the target gig and does not obscure the floating mobile actions.
 
 ## File-Only Attachment Journey
 
@@ -60,7 +60,7 @@ The quick add journey uses the same gig matching behaviour as quick receipts, su
 
 ### Expected Results
 
-The app allows an attachment without a URL, stores uploaded file metadata, downloads the same file, and removes the file without deleting the attachment itself.
+The app allows an attachment without a URL, stores uploaded file metadata, downloads the same file, and removes the file without deleting the attachment itself. Completed file actions show terminal notifications; unavailable stored files show a persistent, user-safe error notification.
 
 ## Primary Resource Behaviour
 

--- a/docs/uat/pre-merge-regression.md
+++ b/docs/uat/pre-merge-regression.md
@@ -38,6 +38,23 @@ For local development, engineers usually run:
 
 Navigation, session state, and core reads are healthy.
 
+## Notification Feedback
+
+> **Automation:** Partially automated UAT: invoice, gig, receipt, and attachment browser journeys assert terminal Sonner notifications. Manual checks cover dismissal, modal stacking, and visual placement.
+
+### Steps
+
+1. Complete a terminal action such as saving a client, uploading a receipt, or changing an invoice status.
+2. Confirm a notification appears at the top of the viewport without needing to locate the initiating panel.
+3. Trigger a safe failure, such as an unavailable mileage estimate or attachment download.
+4. Confirm the error notification remains visible until dismissed using its accessible close control.
+5. Open and close a modal after starting an applicable action, then confirm the terminal notification remains visible.
+6. On a phone-sized viewport, confirm notifications do not cover the quick-capture controls or return-to-top button.
+
+### Expected Results
+
+Terminal success and information notifications auto-dismiss. Errors persist until dismissed. Form validation, progress, and durable configuration guidance remain in their original local context.
+
 ## Dashboard Summary
 
 > **Automation:** Automated UAT: `Glovelly.Uat.Tests.DashboardSummaryTests.DashboardHighlightsNextGigOutstandingBalanceAndInvoicePrompt`; manual balance edge-case spot checks remain useful when paid, cancelled, issued, and overdue invoices already exist together.

--- a/frontend/glovelly-web/package-lock.json
+++ b/frontend/glovelly-web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@microsoft/signalr": "^10.0.0",
         "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react-dom": "^19.2.7",
+        "sonner": "^2.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2799,6 +2800,22 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.8.tgz",
+      "integrity": "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/glovelly-web/package.json
+++ b/frontend/glovelly-web/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@microsoft/signalr": "^10.0.0",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "sonner": "^2.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/glovelly-web/src/App.tsx
+++ b/frontend/glovelly-web/src/App.tsx
@@ -50,6 +50,7 @@ import { useSellerProfile } from './hooks/useSellerProfile'
 import { useThemePreference } from './hooks/useThemePreference'
 import { useUserSettings } from './hooks/useUserSettings'
 import { useWorkspaceEvents } from './hooks/useWorkspaceEvents'
+import { notifications } from './notifications'
 import type {
   AppMetadata,
   AppSection,
@@ -114,6 +115,7 @@ function App({ appMetadata }: AppProps) {
   const isAdmin = authUser?.role === 'Admin'
   const accessRequestDeepLinkId = getAccessRequestDeepLinkId(window.location.pathname)
   const clearSession = useCallback(() => {
+    notifications.resetSession()
     setIsAuthenticated(false)
     setAuthUser(null)
     setIsApiConnected(false)
@@ -291,7 +293,7 @@ function App({ appMetadata }: AppProps) {
         ...current.filter((value) => value.id !== invoice.id),
       ])
       setSelectedInvoiceId(invoice.id)
-      setInvoiceStatus(message)
+      notifications.info(message, { dedupeKey: `invoice:${invoice.id}:linked-gig` })
     },
     onOpenSection: (section) => setActiveSection(section),
     onSessionExpired: expireSession,
@@ -311,9 +313,8 @@ function App({ appMetadata }: AppProps) {
     setGigImportDraftStatus,
     updateGigImportDraftField,
   } = useGigImportsWorkspace({
-    onGigsCommitted: (committedGigs, message) => {
+    onGigsCommitted: (committedGigs) => {
       applyGigs(committedGigs)
-      setStatus(message)
     },
     onSessionExpired: expireSession,
   })
@@ -861,10 +862,14 @@ function App({ appMetadata }: AppProps) {
             ? `Imported ${snapshot.chartCount} chart(s). ${impact.autoRelinkedItemCount} chart link(s) were updated automatically.`
             : `Imported ${snapshot.chartCount} chart(s) from ${snapshot.originalFileName}.`
       )
-    } catch (error) {
-      setForScoreLibraryStatus(
-        error instanceof Error ? error.message : 'Unable to import forScore library snapshot.'
+      notifications.success(
+        `Imported ${snapshot.chartCount} chart(s) from ${snapshot.originalFileName}.`,
+        { dedupeKey: 'forscore-library:import' }
       )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to import forScore library snapshot.'
+      setForScoreLibraryStatus(message)
+      notifications.error(message, { dedupeKey: 'forscore-library:import' })
     } finally {
       setIsForScoreLibraryUploading(false)
     }
@@ -1001,7 +1006,10 @@ function App({ appMetadata }: AppProps) {
         ...current.filter((value) => value.id !== invoice.id),
       ])
     } catch (error) {
-      setGigStatus(error instanceof Error ? error.message : 'Unable to open linked invoice.')
+      notifications.error(
+        error instanceof Error ? error.message : 'Unable to open linked invoice.',
+        { dedupeKey: `gig:${selectedGig.id}:linked-invoice` }
+      )
       return
     }
 
@@ -1204,8 +1212,10 @@ function App({ appMetadata }: AppProps) {
       `Mark ${linkedGigLabel} as completed now that invoice ${invoice.invoiceNumber} is issued?`
     )
     if (!shouldComplete) {
-      setGigStatus('Linked gig status left unchanged.')
-      setInvoiceStatus(`Invoice ${invoice.invoiceNumber} issued; linked gig status left unchanged.`)
+      notifications.info(
+        `Invoice ${invoice.invoiceNumber} issued; linked gig status left unchanged.`,
+        { dedupeKey: `invoice:${invoice.id}:linked-gig-status` }
+      )
       return
     }
 
@@ -1243,18 +1253,17 @@ function App({ appMetadata }: AppProps) {
       setGigs((current) =>
         current.map((gig) => completedGigs.find((value) => value.id === gig.id) ?? gig)
       )
-      setGigStatus(
-        completedGigs.length === 1
-          ? `"${completedGigs[0].title}" marked as completed.`
-          : `${completedGigs.length} linked gigs marked as completed.`
-      )
-      setInvoiceStatus(
+      notifications.success(
         completedGigs.length === 1
           ? `Invoice ${invoice.invoiceNumber} issued; linked gig marked as completed.`
-          : `Invoice ${invoice.invoiceNumber} issued; ${completedGigs.length} linked gigs marked as completed.`
+          : `Invoice ${invoice.invoiceNumber} issued; ${completedGigs.length} linked gigs marked as completed.`,
+        { dedupeKey: `invoice:${invoice.id}:linked-gig-status` }
       )
     } catch (error) {
-      setGigStatus(error instanceof Error ? error.message : 'Unable to complete linked gig.')
+      notifications.error(
+        error instanceof Error ? error.message : 'Unable to complete linked gig.',
+        { dedupeKey: `invoice:${invoice.id}:linked-gig-status` }
+      )
     } finally {
       setIsInvoiceLoading(false)
     }
@@ -1281,7 +1290,9 @@ function App({ appMetadata }: AppProps) {
       `Mark delivered draft invoice ${invoice.invoiceNumber} as issued?`
     )
     if (!shouldIssue) {
-      setInvoiceStatus(`Invoice ${invoice.invoiceNumber} delivered and left as Draft.`)
+      notifications.info(`Invoice ${invoice.invoiceNumber} delivered and left as Draft.`, {
+        dedupeKey: `invoice:${invoice.id}:delivery-status`,
+      })
       return invoice
     }
 
@@ -1379,17 +1390,17 @@ function App({ appMetadata }: AppProps) {
           )
         )
         setSelectedGigIds([])
-        setGigStatus(
-          `Invoice ${generatedInvoice.invoiceNumber} generated from ${invoiceGigs.length} selected gig(s).`
-        )
-        setInvoiceStatus(
+        notifications.success(
           sellerProfile.isInvoiceReady
             ? `Invoice ${generatedInvoice.invoiceNumber} is ready for review.`
-            : `Invoice ${generatedInvoice.invoiceNumber} is ready for review. ${sellerProfileNotice}`
+            : `Invoice ${generatedInvoice.invoiceNumber} is ready for review. ${sellerProfileNotice}`,
+          { dedupeKey: `invoice:${generatedInvoice.id}:generation` }
         )
         await openInvoicePreview(generatedInvoice)
       } catch (error) {
-        setGigStatus(error instanceof Error ? error.message : 'Unable to generate invoice.')
+        notifications.error(error instanceof Error ? error.message : 'Unable to generate invoice.', {
+          dedupeKey: 'invoice:generation',
+        })
       } finally {
         setIsInvoiceLoading(false)
       }
@@ -1427,8 +1438,9 @@ function App({ appMetadata }: AppProps) {
           setActiveSection('invoices')
         }
 
-        setGigStatus(conflict.message ?? 'This gig has already been invoiced.')
-        setInvoiceStatus('This gig already has an invoice. Reviewing the existing record.')
+        notifications.info(conflict.message ?? 'This gig has already been invoiced.', {
+          dedupeKey: `gig:${invoiceGig.id}:invoice-generation`,
+        })
         return
       }
 
@@ -1454,15 +1466,17 @@ function App({ appMetadata }: AppProps) {
             : gig
         )
       )
-      setGigStatus('Invoice generated and linked to this gig.')
-      setInvoiceStatus(
+      notifications.success(
         sellerProfile.isInvoiceReady
-          ? 'New invoice generated from the selected gig.'
-          : `New invoice generated from the selected gig. ${sellerProfileNotice}`
+          ? `Invoice ${generatedInvoice.invoiceNumber} is ready for review.`
+          : `Invoice ${generatedInvoice.invoiceNumber} is ready for review. ${sellerProfileNotice}`,
+        { dedupeKey: `invoice:${generatedInvoice.id}:generation` }
       )
       await openInvoicePreview(generatedInvoice)
     } catch (error) {
-      setGigStatus(error instanceof Error ? error.message : 'Unable to generate invoice.')
+      notifications.error(error instanceof Error ? error.message : 'Unable to generate invoice.', {
+        dedupeKey: `gig:${invoiceGig.id}:invoice-generation`,
+      })
     } finally {
       setIsInvoiceLoading(false)
     }
@@ -1607,18 +1621,15 @@ function App({ appMetadata }: AppProps) {
             : gig
         )
       )
-      setGigStatus(
-        `Monthly invoice ${updatedInvoice.invoiceNumber} created for ${gigsToInvoice.length} gig(s).`
+      notifications.success(
+        `Monthly invoice ${updatedInvoice.invoiceNumber} created for ${gigsToInvoice.length} gig(s) and ready for review.`,
+        { dedupeKey: `invoice:${updatedInvoice.id}:monthly-generation` }
       )
-      setMonthlyInvoiceStatus(
-        `Monthly invoice ${updatedInvoice.invoiceNumber} created for ${gigsToInvoice.length} gig(s).`
-      )
-      setInvoiceStatus(`Monthly invoice ${updatedInvoice.invoiceNumber} is ready for review.`)
       await openInvoicePreview(updatedInvoice)
     } catch (error) {
-      setMonthlyInvoiceStatus(
-        error instanceof Error ? error.message : 'Unable to generate monthly invoice.'
-      )
+      notifications.error(error instanceof Error ? error.message : 'Unable to generate monthly invoice.', {
+        dedupeKey: 'invoice:monthly-generation',
+      })
     } finally {
       setIsInvoiceLoading(false)
     }

--- a/frontend/glovelly-web/src/NotificationToaster.tsx
+++ b/frontend/glovelly-web/src/NotificationToaster.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { Toaster } from 'sonner'
+
+export function NotificationToaster() {
+  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width: 601px)').matches)
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 601px)')
+    const updatePosition = () => setIsDesktop(mediaQuery.matches)
+
+    mediaQuery.addEventListener('change', updatePosition)
+    return () => mediaQuery.removeEventListener('change', updatePosition)
+  }, [])
+
+  return (
+    <Toaster
+      closeButton
+      containerAriaLabel="Notifications"
+      hotkey={[]}
+      mobileOffset={{ left: 'max(10px, env(safe-area-inset-left))', right: 'max(10px, env(safe-area-inset-right))', top: 'max(74px, calc(env(safe-area-inset-top) + 64px))' }}
+      offset={{ right: '24px', top: '24px' }}
+      position={isDesktop ? 'top-right' : 'top-center'}
+      richColors
+      style={{ zIndex: 75 }}
+      toastOptions={{ closeButtonAriaLabel: 'Dismiss notification' }}
+      visibleToasts={3}
+    />
+  )
+}

--- a/frontend/glovelly-web/src/components/ConnectedServicesModal.tsx
+++ b/frontend/glovelly-web/src/components/ConnectedServicesModal.tsx
@@ -51,7 +51,9 @@ export function ConnectedServicesModal({
 }: ConnectedServicesModalProps) {
   const calendarConnected = googleCalendarStatus?.isConnected ?? false
   const calendarStatusText = googleCalendarStatus
-    ? calendarConnected
+    ? googleCalendarStatus.requiresReconnection
+      ? 'Calendar reconnect required'
+      : calendarConnected
       ? `Calendar connected${googleCalendarStatus.pendingWorkCount > 0 ? `, ${googleCalendarStatus.pendingWorkCount} pending` : ''}`
       : googleCalendarStatus.hasRequiredScope
         ? 'Calendar not enabled'
@@ -189,7 +191,11 @@ export function ConnectedServicesModal({
               />
             </div>
 
-            {googleCalendarStatus?.lastError ? (
+            {googleCalendarStatus?.requiresReconnection ? (
+              <span className="connected-service-error">
+                Glovelly no longer has permission to add events to this Google Calendar. Reconnect your calendar to grant the required access.
+              </span>
+            ) : googleCalendarStatus?.lastError ? (
               <span className="connected-service-error">{googleCalendarStatus.lastError}</span>
             ) : null}
 
@@ -204,11 +210,13 @@ export function ConnectedServicesModal({
                 onClick={onConnectGoogleCalendar}
                 type="button"
               >
-                {calendarConnected ? 'Reconnect Calendar' : 'Connect Calendar'}
+                {calendarConnected || googleCalendarStatus?.requiresReconnection
+                  ? 'Reconnect Calendar'
+                  : 'Connect Calendar'}
               </button>
               <button
                 className="ghost-button"
-                disabled={!calendarConnected || isGoogleCalendarBusy}
+                disabled={(!calendarConnected && !googleCalendarStatus?.requiresReconnection) || isGoogleCalendarBusy}
                 onClick={onDisconnectGoogleCalendar}
                 type="button"
               >

--- a/frontend/glovelly-web/src/components/GigAttachmentsPanel.tsx
+++ b/frontend/glovelly-web/src/components/GigAttachmentsPanel.tsx
@@ -388,7 +388,13 @@ export function GigAttachmentsPanel({
                 >
                   Cancel
                 </button>
-                <span className="status-pill">{gigStatus}</span>
+                <span
+                  className="status-pill"
+                  data-testid="gig-attachment-status"
+                  role="status"
+                >
+                  {gigStatus}
+                </span>
               </div>
             </form>
           </section>

--- a/frontend/glovelly-web/src/components/InvoicesSection.tsx
+++ b/frontend/glovelly-web/src/components/InvoicesSection.tsx
@@ -158,9 +158,10 @@ export function InvoicesSection({
               <p className="section-label">Billing</p>
               <h2>Invoices</h2>
             </div>
-            <span className="status-pill" data-testid="invoice-status">
-              <span>{invoiceStatus}</span>
-              {googleDrivePublishLink ? (
+            {(invoiceStatus || googleDrivePublishLink) && (
+              <span className="status-pill" data-testid="invoice-status">
+                {invoiceStatus ? <span>{invoiceStatus}</span> : null}
+                {googleDrivePublishLink ? (
                 <a
                   href={googleDrivePublishLink.href}
                   target="_blank"
@@ -173,8 +174,9 @@ export function InvoicesSection({
                 >
                   Open file
                 </a>
-              ) : null}
-            </span>
+                ) : null}
+              </span>
+            )}
           </div>
 
           <div className="gig-summary-grid">

--- a/frontend/glovelly-web/src/components/QuickAttachmentModal.tsx
+++ b/frontend/glovelly-web/src/components/QuickAttachmentModal.tsx
@@ -362,7 +362,6 @@ export function QuickAttachmentModal({
               {isSaving ? 'Saving...' : 'Save attachment draft'}
             </button>
             ) : null}
-            <span className="status-pill">{status}</span>
           </div>
         ) : null}
       </section>

--- a/frontend/glovelly-web/src/components/QuickReceiptModal.tsx
+++ b/frontend/glovelly-web/src/components/QuickReceiptModal.tsx
@@ -175,7 +175,6 @@ export function QuickReceiptModal({
               {isSaving ? 'Saving...' : 'Save receipt draft'}
             </button>
           )}
-          <span className="status-pill">{status}</span>
         </div>
       </section>
       {draft && isAnalysisOpen ? (

--- a/frontend/glovelly-web/src/components/SetListImportModal.tsx
+++ b/frontend/glovelly-web/src/components/SetListImportModal.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
-import { buildApiUrl, downloadResponseBlob, fetchWithSession, getResponseErrorMessage, jsonRequestInit } from '../api'
+import {
+  buildApiUrl,
+  downloadResponseBlob,
+  fetchWithSession,
+  getProblemDetailsMessage,
+  getResponseErrorMessage,
+  jsonRequestInit,
+} from '../api'
 import { useWorkspaceEvents } from '../hooks/useWorkspaceEvents'
+import { notifications } from '../notifications'
 import type {
   Gig,
   GigExternalResource,
@@ -24,9 +32,11 @@ type ChartMatchStage = 'locate' | 'ai'
 type ChartMatchRequestItem = Pick<ManagedSetListItem, 'sourceRowNumber' | 'kind' | 'include' | 'title' | 'padNumber' | 'key'>
 type ActiveChartMatchJob = Pick<SetListChartMatchJobResponse, 'jobId' | 'status' | 'correlationId'>
 type ForScoreExportError = {
+  detail?: string
   message?: string
   missingItems?: { title?: string; sourceRowNumber?: number }[]
   errors?: Record<string, string[]>
+  title?: string
 }
 
 const createClientRequestId = () => {
@@ -47,14 +57,14 @@ async function getExportErrorMessage(response: Response) {
 
   try {
     const payload = (await response.json()) as ForScoreExportError
-    const validationMessage = payload.errors ? Object.values(payload.errors).flat().join(' ') : ''
+    const problemMessage = getProblemDetailsMessage(payload)
     const missingTitles = payload.missingItems
       ?.slice(0, 3)
       .map((item) => item.title || (item.sourceRowNumber ? `row ${item.sourceRowNumber}` : null))
       .filter(Boolean)
       .join(', ')
     const missingSuffix = missingTitles ? ` Remaining rows: ${missingTitles}.` : ''
-    return `${payload.message || validationMessage || 'Select forScore charts for all included song rows before exporting.'}${missingSuffix}`
+    return `${problemMessage || payload.message || 'Select forScore charts for all included song rows before exporting.'}${missingSuffix}`
   } catch {
     return 'Unable to export forScore set list.'
   }
@@ -629,8 +639,13 @@ export function SetListImportModal({ gig, resource, onClose }: SetListImportModa
 
       const fileName = await downloadResponseBlob(response, `${gig.title || 'setlist'}.4ss`)
       setStatus(`Downloaded ${fileName}. Open the .4ss file on your iPad and import it into forScore.`)
+      notifications.success(`Downloaded ${fileName}.`, {
+        dedupeKey: `gig:${gig.id}:forscore-export`,
+      })
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : 'Unable to export forScore set list.')
+      const message = error instanceof Error ? error.message : 'Unable to export forScore set list.'
+      setStatus(message)
+      notifications.error(message, { dedupeKey: `gig:${gig.id}:forscore-export` })
     } finally {
       setIsLoading(false)
     }

--- a/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useAdminWorkspace.ts
@@ -9,6 +9,7 @@ import {
   throwIfSessionExpired,
 } from '../api'
 import { defaultAdminStatus, emptyAdminForm } from '../forms'
+import { notifications } from '../notifications'
 import type { AdminSort, AdminUser, AdminUserForm } from '../types'
 
 type UseAdminWorkspaceOptions = {
@@ -338,16 +339,16 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
             )
           }
 
-          setAdminStatus('User added and invitation sent.')
+          notifications.success('User added and invitation sent.')
         } catch {
-          setAdminStatus('User added, but the invitation email could not be sent.')
+          notifications.info('User added, but the invitation email could not be sent.')
         }
       } else {
-        setAdminStatus(isEdit ? 'User updated.' : 'User added.')
+        notifications.success(isEdit ? 'User updated.' : 'User added.')
       }
     } catch (error) {
-      setAdminStatus(
-        error instanceof Error ? error.message : 'Unable to save right now.'
+      notifications.error(
+        error instanceof Error ? error.message : 'Unable to save user.'
       )
     } finally {
       setIsAdminLoading(false)
@@ -409,9 +410,9 @@ export function useAdminWorkspace({ onSessionExpired }: UseAdminWorkspaceOptions
       setIsAdminEditorOpen(false)
       setAdminMode('create')
       setAdminForm(emptyAdminForm())
-      setAdminStatus('User deleted.')
+      notifications.success('User deleted.')
     } catch (error) {
-      setAdminStatus(error instanceof Error ? error.message : 'Unable to delete user.')
+      notifications.error(error instanceof Error ? error.message : 'Unable to delete user.')
     } finally {
       setIsAdminLoading(false)
     }

--- a/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useClientsWorkspace.ts
@@ -8,6 +8,7 @@ import {
   jsonRequestInit,
 } from '../api'
 import { emptyClientSettingsForm, emptyForm } from '../forms'
+import { notifications } from '../notifications'
 import type { Address, Client, ClientForm, ClientSettingsForm, ClientSort } from '../types'
 
 type UseClientsWorkspaceOptions = {
@@ -317,7 +318,9 @@ export function useClientsWorkspace({
       }
 
       if (!response.ok) {
-        throw new Error('Save failed.')
+        throw new Error(
+          await getResponseErrorMessage(response, 'Unable to save client right now.')
+        )
       }
 
       const savedClient = (await response.json()) as Client
@@ -334,10 +337,12 @@ export function useClientsWorkspace({
 
       setSelectedClientId(savedClient.id)
       setMode('edit')
-      setStatus(isEdit ? 'Client updated.' : 'Client created.')
+      notifications.success(isEdit ? 'Client updated.' : 'Client created.')
       setIsClientEditorOpen(!closeAfterSave)
-    } catch {
-      setStatus('Unable to save right now. Please try again.')
+    } catch (error) {
+      notifications.error(
+        error instanceof Error ? error.message : 'Unable to save client right now.'
+      )
     } finally {
       setIsLoading(false)
     }
@@ -384,11 +389,11 @@ export function useClientsWorkspace({
       setSelectedClientId(nextSelectedClientId)
       setMode('create')
       setForm(emptyForm())
-      setStatus('Client deleted.')
+      notifications.success('Client deleted.')
       setIsClientEditorOpen(false)
     } catch (error) {
-      setStatus(
-        error instanceof Error ? error.message : 'Unable to delete right now.'
+      notifications.error(
+        error instanceof Error ? error.message : 'Unable to delete client right now.'
       )
     } finally {
       setIsLoading(false)

--- a/frontend/glovelly-web/src/hooks/useExpenseStatementWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useExpenseStatementWorkspace.ts
@@ -212,9 +212,8 @@ export function useExpenseStatementWorkspace({
       return previewUrl
     } catch (error) {
       clearExpenseStatementPreviewUrl()
-      setExpenseStatementStatus(
-        error instanceof Error ? error.message : 'Unable to preview the expense statement PDF.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to preview the expense statement PDF.'
+      setExpenseStatementStatus(message)
       return null
     } finally {
       setIsExpenseStatementLoading(false)
@@ -260,13 +259,9 @@ export function useExpenseStatementWorkspace({
 
       const filename = await downloadResponseBlob(response, fallbackFilename)
       setExpenseStatementStatus(`Downloaded ${filename}.`)
-      setGigStatus(`Downloaded ${filename}.`)
     } catch (error) {
-      setExpenseStatementStatus(
-        error instanceof Error
-          ? error.message
-          : 'Unable to download the expense statement PDF.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to download the expense statement PDF.'
+      setExpenseStatementStatus(message)
     } finally {
       setIsExpenseStatementLoading(false)
     }

--- a/frontend/glovelly-web/src/hooks/useGigImportsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigImportsWorkspace.ts
@@ -7,6 +7,7 @@ import {
   jsonRequestInit,
   parseProblemDetails,
 } from '../api'
+import { notifications } from '../notifications'
 import type {
   Gig,
   GigImportBatchDetail,
@@ -458,10 +459,14 @@ export function useGigImportsWorkspace({
       setGigImportStatus(
         `${result.createdCount} gig${result.createdCount === 1 ? '' : 's'} created from import.`
       )
-    } catch (error) {
-      setGigImportStatus(
-        error instanceof Error ? error.message : 'Unable to commit import rows.'
+      notifications.success(
+        `${result.createdCount} gig${result.createdCount === 1 ? '' : 's'} created from import.`,
+        { dedupeKey: `gig-import:${batchDetail.batch.batchId}:commit` }
       )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to commit import rows.'
+      setGigImportStatus(message)
+      notifications.error(message, { dedupeKey: `gig-import:${batchDetail.batch.batchId}:commit` })
     } finally {
       setIsGigImportLoading(false)
     }

--- a/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useGigsWorkspace.ts
@@ -41,6 +41,7 @@ import type {
   Invoice,
 } from '../types'
 import { useExpenseStatementWorkspace } from './useExpenseStatementWorkspace'
+import { notifications } from '../notifications'
 
 type UseGigsWorkspaceOptions = {
   clientNamesById: ReadonlyMap<string, string>
@@ -330,7 +331,7 @@ export function useGigsWorkspace({
       setEditingExternalResourceId('')
       setExternalResourceMode('create')
       setIsExternalResourceEditorOpen(false)
-      setGigStatus(isEdit ? 'Attachment updated.' : 'Attachment added.')
+      notifications.success(isEdit ? 'Attachment updated.' : 'Attachment added.')
     } catch (error) {
       setGigStatus(
         error instanceof Error
@@ -381,9 +382,9 @@ export function useGigsWorkspace({
       if (editingExternalResourceId === resource.id) {
         cancelExternalResourceEdit()
       }
-      setGigStatus('Attachment deleted.')
+      notifications.success('Attachment deleted.')
     } catch (error) {
-      setGigStatus(
+      notifications.error(
         error instanceof Error
           ? error.message
           : 'Unable to delete attachment right now.'
@@ -433,9 +434,9 @@ export function useGigsWorkspace({
 
       const savedGig = (await response.json()) as Gig
       replaceSavedGig(savedGig)
-      setGigStatus('Attachment file uploaded.')
+      notifications.success('Attachment file uploaded.')
     } catch (error) {
-      setGigStatus(
+      notifications.error(
         error instanceof Error
           ? error.message
           : 'Unable to upload attachment file right now.'
@@ -478,9 +479,9 @@ export function useGigsWorkspace({
       }
 
       const fileName = await downloadResponseBlob(response, attachment.fileName)
-      setGigStatus(`Downloaded ${fileName}.`)
+      notifications.success(`Downloaded ${fileName}.`)
     } catch (error) {
-      setGigStatus(
+      notifications.error(
         error instanceof Error
           ? error.message
           : 'Unable to download attachment file right now.'
@@ -529,9 +530,9 @@ export function useGigsWorkspace({
 
       const savedGig = (await response.json()) as Gig
       replaceSavedGig(savedGig)
-      setGigStatus('Attachment file deleted.')
+      notifications.success('Attachment file deleted.')
     } catch (error) {
-      setGigStatus(
+      notifications.error(
         error instanceof Error
           ? error.message
           : 'Unable to delete attachment file right now.'
@@ -644,11 +645,12 @@ export function useGigsWorkspace({
       setSelectedGigIds([])
       setGigMode('edit')
       setGigForm(toEditableGigForm(savedGig))
-      setGigStatus('Gig cloned. Update any details before saving.')
+      notifications.success('Gig cloned.')
+      setGigStatus('Update any details before saving.')
       revealGig(savedGig, nextGigs)
       setIsGigEditorOpen(true)
     } catch (error) {
-      setGigStatus(error instanceof Error ? error.message : 'Unable to clone gig.')
+      notifications.error(error instanceof Error ? error.message : 'Unable to clone gig.')
     } finally {
       setIsGigLoading(false)
     }
@@ -779,11 +781,11 @@ export function useGigsWorkspace({
         wasDriving: true,
         travelMiles: formatEditableNumber(estimate.distanceMiles),
       }))
-      setGigStatus(
+      notifications.success(
         `Estimated ${formatEditableNumber(estimate.distanceMiles)} miles from ${estimate.originLabel} to ${estimate.destinationLabel}.`
       )
     } catch (error) {
-      setGigStatus(
+      notifications.error(
         error instanceof Error
           ? error.message
           : 'Unable to estimate mileage right now.'
@@ -807,7 +809,7 @@ export function useGigsWorkspace({
     }
 
     if (!response.ok) {
-      throw new Error('Unable to refresh gig receipts.')
+      throw new Error(await getResponseErrorMessage(response, 'Unable to refresh gig receipts.'))
     }
 
     const savedGig = (await response.json()) as Gig
@@ -850,24 +852,56 @@ export function useGigsWorkspace({
       }
 
       await refreshGig(selectedGig.id)
-      setGigStatus('Receipt uploaded.')
+      notifications.success('Receipt uploaded.')
     } catch (error) {
-      setGigStatus(error instanceof Error ? error.message : 'Unable to upload receipt.')
+      notifications.error(error instanceof Error ? error.message : 'Unable to upload receipt.')
     } finally {
       setIsGigLoading(false)
     }
   }
 
-  const downloadExpenseAttachment = (expense: GigExpenseForm, attachmentId: string) => {
+  const downloadExpenseAttachment = async (
+    expense: GigExpenseForm,
+    attachmentId: string
+  ) => {
     if (!selectedGig || !expense.id) {
       return
     }
 
-    window.open(
-      buildApiUrl(`/gigs/${selectedGig.id}/expenses/${expense.id}/attachments/${attachmentId}`),
-      '_blank',
-      'noopener,noreferrer'
-    )
+    setIsGigLoading(true)
+
+    try {
+      const response = await fetchWithSession(
+        buildApiUrl(`/gigs/${selectedGig.id}/expenses/${expense.id}/attachments/${attachmentId}`)
+      )
+
+      if (
+        handleSessionExpired(
+          response,
+          onSessionExpired,
+          'Your session expired. Sign in again to keep managing gigs.'
+        )
+      ) {
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          await getResponseErrorMessage(response, 'Unable to download receipt.')
+        )
+      }
+
+      const attachment = expense.attachments.find((value) => value.id === attachmentId)
+      const downloadedFileName = await downloadResponseBlob(
+        response,
+        attachment?.fileName ?? 'receipt'
+      )
+      notifications.success(`Downloaded ${downloadedFileName}.`)
+    } catch (error) {
+      notifications.error(error instanceof Error ? error.message : 'Unable to download receipt.')
+    } finally {
+      setIsGigLoading(false)
+    }
   }
 
   const deleteExpenseAttachment = async (
@@ -899,13 +933,13 @@ export function useGigsWorkspace({
       }
 
       if (!response.ok) {
-        throw new Error('Unable to delete receipt.')
+        throw new Error(await getResponseErrorMessage(response, 'Unable to delete receipt.'))
       }
 
       await refreshGig(selectedGig.id)
-      setGigStatus('Receipt deleted.')
+      notifications.success('Receipt deleted.')
     } catch (error) {
-      setGigStatus(error instanceof Error ? error.message : 'Unable to delete receipt.')
+      notifications.error(error instanceof Error ? error.message : 'Unable to delete receipt.')
     } finally {
       setIsGigLoading(false)
     }
@@ -961,9 +995,9 @@ export function useGigsWorkspace({
       setIsGigEditorOpen(false)
       setGigMode('create')
       setGigForm(toCreateGigForm(clients))
-      setGigStatus('Gig deleted.')
+      notifications.success('Gig deleted.')
     } catch (error) {
-      setGigStatus(error instanceof Error ? error.message : 'Unable to delete gig.')
+      notifications.error(error instanceof Error ? error.message : 'Unable to delete gig.')
     } finally {
       setIsGigLoading(false)
     }
@@ -1039,10 +1073,12 @@ export function useGigsWorkspace({
 
       const savedGig = (await response.json()) as Gig
       mergeSavedGig(savedGig)
-      setGigStatus(`Expense marked as ${formatReimbursementStatus(status).toLowerCase()}.`)
+      notifications.success(
+        `Expense marked as ${formatReimbursementStatus(status).toLowerCase()}.`
+      )
       await handleLinkedInvoiceAfterGigSave(selectedGig, savedGig, true)
     } catch (error) {
-      setGigStatus(
+      notifications.error(
         error instanceof Error ? error.message : 'Unable to update reimbursement.'
       )
     } finally {
@@ -1126,7 +1162,6 @@ export function useGigsWorkspace({
       redraftedInvoice,
       `Draft invoice ${redraftedInvoice.invoiceNumber} regenerated from updated gig details.`
     )
-    setGigStatus(`Gig updated. Draft invoice ${redraftedInvoice.invoiceNumber} regenerated.`)
   }
 
   const promptToCancelLinkedInvoice = async (invoice: Invoice) => {
@@ -1159,7 +1194,6 @@ export function useGigsWorkspace({
       cancelledInvoice,
       `Linked invoice ${cancelledInvoice.invoiceNumber} cancelled.`
     )
-    setGigStatus(`Gig updated. Linked invoice ${cancelledInvoice.invoiceNumber} cancelled.`)
   }
 
   const saveGigForm = async (
@@ -1284,7 +1318,7 @@ export function useGigsWorkspace({
       setGigs(nextGigs)
       setGigMode('edit')
       setGigForm(toEditableGigForm(savedGig))
-      setGigStatus(successMessage ?? (isEdit ? 'Gig updated.' : 'Gig created.'))
+      notifications.success(successMessage ?? (isEdit ? 'Gig updated.' : 'Gig created.'))
       setIsGigEditorOpen(!closeAfterSave)
       revealGig(savedGig, nextGigs)
       if (previousGig) {
@@ -1295,7 +1329,7 @@ export function useGigsWorkspace({
         )
       }
     } catch (error) {
-      setGigStatus(
+      notifications.error(
         error instanceof Error ? error.message : 'Unable to save this gig right now.'
       )
     } finally {

--- a/frontend/glovelly-web/src/hooks/useInvoicePreview.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicePreview.ts
@@ -4,6 +4,7 @@ import {
   createBlobObjectUrl,
   downloadResponseBlob,
   fetchWithSession,
+  getResponseErrorMessage,
 } from '../api'
 import type { Invoice } from '../types'
 
@@ -12,6 +13,8 @@ type UseInvoicePreviewOptions = {
 }
 
 export function useInvoicePreview({ onDownloaded }: UseInvoicePreviewOptions) {
+  // App still provides this callback; downloads now report through notifications instead.
+  void onDownloaded
   const [invoicePreviewInvoice, setInvoicePreviewInvoice] = useState<Invoice | null>(null)
   const [invoicePreviewPdfUrl, setInvoicePreviewPdfUrl] = useState<string | null>(null)
   const [invoicePreviewStatus, setInvoicePreviewStatus] = useState('')
@@ -46,7 +49,9 @@ export function useInvoicePreview({ onDownloaded }: UseInvoicePreviewOptions) {
       const response = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}/pdf`))
 
       if (!response.ok) {
-        throw new Error('Unable to prepare the invoice PDF preview.')
+        throw new Error(
+          await getResponseErrorMessage(response, 'Unable to prepare the invoice PDF preview.')
+        )
       }
 
       const previewUrl = await createBlobObjectUrl(response)
@@ -59,9 +64,8 @@ export function useInvoicePreview({ onDownloaded }: UseInvoicePreviewOptions) {
       })
       setInvoicePreviewStatus(`Invoice ${invoice.invoiceNumber} is ready to review.`)
     } catch (error) {
-      setInvoicePreviewStatus(
-        error instanceof Error ? error.message : 'Unable to prepare the invoice PDF preview.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to prepare the invoice PDF preview.'
+      setInvoicePreviewStatus(message)
     } finally {
       setIsInvoicePreviewLoading(false)
     }
@@ -82,17 +86,15 @@ export function useInvoicePreview({ onDownloaded }: UseInvoicePreviewOptions) {
       )
 
       if (!response.ok) {
-        throw new Error('Unable to download the invoice PDF.')
+        throw new Error(await getResponseErrorMessage(response, 'Unable to download the invoice PDF.'))
       }
 
       const filename = await downloadResponseBlob(response, fallbackFilename)
       const message = `Downloaded ${filename}.`
       setInvoicePreviewStatus(message)
-      onDownloaded(message)
     } catch (error) {
-      setInvoicePreviewStatus(
-        error instanceof Error ? error.message : 'Unable to download the invoice PDF.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to download the invoice PDF.'
+      setInvoicePreviewStatus(message)
     } finally {
       setIsInvoicePreviewLoading(false)
     }

--- a/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
+++ b/frontend/glovelly-web/src/hooks/useInvoicesWorkspace.ts
@@ -4,6 +4,7 @@ import {
   downloadResponseBlob,
   fetchWithSession,
   getProblemDetailsMessage,
+  getResponseErrorMessage,
   jsonRequestInit,
   parseProblemDetails,
 } from '../api'
@@ -18,6 +19,7 @@ import type {
   PaidIncomeSummary,
 } from '../types'
 import type { PaidIncomeSummaryState } from '../dashboardCards'
+import { notifications } from '../notifications'
 
 type GoogleDrivePublishLink = {
   href: string
@@ -256,15 +258,18 @@ export function useInvoicesWorkspace({
     try {
       const response = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}/pdf`))
       if (!response.ok) {
-        throw new Error('Unable to download the invoice PDF.')
+        throw new Error(await getResponseErrorMessage(response, 'Unable to download the invoice PDF.'))
       }
 
       const filename = await downloadResponseBlob(response, fallbackFilename)
-      setInvoiceStatus(`Downloaded ${filename}.`)
+      setInvoiceStatus('')
+      notifications.success(`Downloaded ${filename}.`, {
+        dedupeKey: `invoice:${invoice.id}:pdf-download`,
+      })
     } catch (error) {
-      setInvoiceStatus(
-        error instanceof Error ? error.message : 'Unable to download the invoice PDF.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to download the invoice PDF.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:pdf-download` })
     } finally {
       setIsInvoiceLoading(false)
     }
@@ -296,11 +301,14 @@ export function useInvoicesWorkspace({
       setInvoices((current) =>
         current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
       )
-      setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} is now ${updatedInvoice.status}.`)
+      setInvoiceStatus('')
+      notifications.success(`Invoice ${updatedInvoice.invoiceNumber} is now ${updatedInvoice.status}.`)
       await loadPaidIncomeSummary()
       return updatedInvoice
     } catch (error) {
-      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to update invoice status.')
+      const message = error instanceof Error ? error.message : 'Unable to update invoice status.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:status` })
       return null
     } finally {
       setIsInvoiceLoading(false)
@@ -349,18 +357,19 @@ export function useInvoicesWorkspace({
       )
 
       if (isRedraft) {
-        setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} draft regenerated.`)
+        notifications.success(`Invoice ${updatedInvoice.invoiceNumber} draft regenerated.`)
       } else {
         const reissuedAt = formatDateTime(updatedInvoice.lastReissuedUtc)
-        setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} re-issued at ${reissuedAt}.`)
+        notifications.success(`Invoice ${updatedInvoice.invoiceNumber} re-issued at ${reissuedAt}.`)
       }
+      setInvoiceStatus('')
 
       await loadPaidIncomeSummary()
       return updatedInvoice
     } catch (error) {
-      setInvoiceStatus(
-        error instanceof Error ? error.message : `Unable to ${actionLabel.toLowerCase()} invoice.`
-      )
+      const message = error instanceof Error ? error.message : `Unable to ${actionLabel.toLowerCase()} invoice.`
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:${isRedraft ? 'redraft' : 'reissue'}` })
       return null
     } finally {
       setIsInvoiceLoading(false)
@@ -407,12 +416,16 @@ export function useInvoicesWorkspace({
       setInvoices((current) =>
         current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
       )
-      setInvoiceStatus(
-        `Invoice ${updatedInvoice.invoiceNumber} sent to ${updatedInvoice.lastDeliveryRecipient}.`
+      setInvoiceStatus('')
+      notifications.success(
+        `Invoice ${updatedInvoice.invoiceNumber} sent to ${updatedInvoice.lastDeliveryRecipient}.`,
+        { dedupeKey: `invoice:${invoice.id}:email-delivery` }
       )
       return updatedInvoice
     } catch (error) {
-      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to send invoice email.')
+      const message = error instanceof Error ? error.message : 'Unable to send invoice email.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:email-delivery` })
       return null
     } finally {
       setIsInvoiceLoading(false)
@@ -461,18 +474,21 @@ export function useInvoicesWorkspace({
           href: driveLink,
           fileName: publishResult.fileName,
         })
-        setInvoiceStatus(`Uploaded ${updatedInvoice.invoiceNumber} to Google Drive.`)
+        notifications.success(`Uploaded ${updatedInvoice.invoiceNumber} to Google Drive.`, {
+          dedupeKey: `invoice:${invoice.id}:google-drive`,
+        })
       } else {
-        setInvoiceStatus(`Invoice ${updatedInvoice.invoiceNumber} published to Google Drive.`)
+        notifications.success(`Invoice ${updatedInvoice.invoiceNumber} published to Google Drive.`, {
+          dedupeKey: `invoice:${invoice.id}:google-drive`,
+        })
       }
+      setInvoiceStatus('')
       return updatedInvoice
     } catch (error) {
       setGoogleDrivePublishLink(null)
-      setInvoiceStatus(
-        error instanceof Error
-          ? error.message
-          : 'Unable to publish invoice to Google Drive.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to publish invoice to Google Drive.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:google-drive` })
       return null
     } finally {
       setIsInvoiceLoading(false)
@@ -521,9 +537,14 @@ export function useInvoicesWorkspace({
       )
       setAdjustmentAmount('')
       setAdjustmentReason('')
-      setInvoiceStatus(`Adjustment saved. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`)
+      setInvoiceStatus('')
+      notifications.success(
+        `Adjustment saved. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`
+      )
     } catch (error) {
-      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to add invoice adjustment.')
+      const message = error instanceof Error ? error.message : 'Unable to add invoice adjustment.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:adjustment` })
     } finally {
       setIsInvoiceLoading(false)
     }
@@ -555,9 +576,14 @@ export function useInvoicesWorkspace({
         current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
       )
       setInvoiceDescription(updatedInvoice.description ?? '')
-      setInvoiceStatus(`Description saved for ${updatedInvoice.invoiceNumber}. Redraft the invoice to update its PDF.`)
+      setInvoiceStatus('')
+      notifications.success(
+        `Description saved for ${updatedInvoice.invoiceNumber}. Redraft the invoice to update its PDF.`
+      )
     } catch (error) {
-      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to save invoice description.')
+      const message = error instanceof Error ? error.message : 'Unable to save invoice description.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:description` })
     } finally {
       setIsInvoiceLoading(false)
     }
@@ -583,21 +609,31 @@ export function useInvoicesWorkspace({
       )
 
       if (!deleteResponse.ok) {
-        throw new Error('Unable to remove invoice adjustment.')
+        throw new Error(await getResponseErrorMessage(deleteResponse, 'Unable to remove invoice adjustment.'))
       }
 
       const invoiceResponse = await fetchWithSession(buildApiUrl(`/invoices/${invoice.id}`))
       if (!invoiceResponse.ok) {
-        throw new Error('Adjustment removed, but the invoice could not be refreshed.')
+        throw new Error(
+          await getResponseErrorMessage(
+            invoiceResponse,
+            'Adjustment removed, but the invoice could not be refreshed.'
+          )
+        )
       }
 
       const updatedInvoice = (await invoiceResponse.json()) as Invoice
       setInvoices((current) =>
         current.map((value) => (value.id === updatedInvoice.id ? updatedInvoice : value))
       )
-      setInvoiceStatus(`Adjustment removed. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`)
+      setInvoiceStatus('')
+      notifications.success(
+        `Adjustment removed. ${updatedInvoice.invoiceNumber} now totals ${formatCurrency(updatedInvoice.total)}.`
+      )
     } catch (error) {
-      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to remove invoice adjustment.')
+      const message = error instanceof Error ? error.message : 'Unable to remove invoice adjustment.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:adjustment` })
     } finally {
       setIsInvoiceLoading(false)
     }
@@ -637,10 +673,15 @@ export function useInvoicesWorkspace({
       setInvoices((current) => current.filter((value) => value.id !== invoice.id))
       onInvoiceDeleted(invoice)
       setSelectedInvoiceId((current) => (current === invoice.id ? '' : current))
-      setInvoiceStatus(`Invoice ${invoice.invoiceNumber} deleted.`)
+      setInvoiceStatus('')
+      notifications.success(`Invoice ${invoice.invoiceNumber} deleted.`, {
+        dedupeKey: `invoice:${invoice.id}:delete`,
+      })
       setIsInvoiceEditorOpen(false)
     } catch (error) {
-      setInvoiceStatus(error instanceof Error ? error.message : 'Unable to delete invoice.')
+      const message = error instanceof Error ? error.message : 'Unable to delete invoice.'
+      setInvoiceStatus(message)
+      notifications.error(message, { dedupeKey: `invoice:${invoice.id}:delete` })
     } finally {
       setIsInvoiceLoading(false)
     }

--- a/frontend/glovelly-web/src/hooks/useQuickAttachment.ts
+++ b/frontend/glovelly-web/src/hooks/useQuickAttachment.ts
@@ -34,7 +34,6 @@ export function useQuickAttachment({
   onOpenAttachmentDraft,
   onSelectGig,
   onSessionExpired,
-  setGigStatus,
 }: UseQuickAttachmentOptions) {
   const [quickAttachmentMode, setQuickAttachmentMode] = useState<QuickAttachmentMode>('choose')
   const [pendingAttachmentFile, setPendingAttachmentFile] = useState<File | null>(null)
@@ -182,15 +181,9 @@ export function useQuickAttachment({
           ? 'Attachment saved. There are other nearby gigs, so please check the selected gig.'
           : 'Attachment saved. Add details now or come back later.'
       )
-      setGigStatus(
-        draft.inferredGig
-          ? 'Attachment draft saved to the nearest matching gig.'
-          : 'Attachment draft saved.'
-      )
     } catch (error) {
-      setQuickAttachmentStatus(
-        error instanceof Error ? error.message : 'Unable to save attachment draft.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to save attachment draft.'
+      setQuickAttachmentStatus(message)
     } finally {
       setIsQuickAttachmentSaving(false)
     }
@@ -267,15 +260,9 @@ export function useQuickAttachment({
           ? 'Attachment saved. There are other nearby gigs, so please check the selected gig.'
           : 'Attachment saved. Add details now or come back later.'
       )
-      setGigStatus(
-        draft.inferredGig
-          ? 'Attachment draft saved to the nearest matching gig.'
-          : 'Attachment draft saved.'
-      )
     } catch (error) {
-      setQuickAttachmentStatus(
-        error instanceof Error ? error.message : 'Unable to save attachment draft.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to save attachment draft.'
+      setQuickAttachmentStatus(message)
     } finally {
       setIsQuickAttachmentSaving(false)
     }
@@ -367,16 +354,14 @@ export function useQuickAttachment({
       )
       onSelectGig(update.gig.id)
       setQuickAttachmentSelectedGigId(update.gig.id)
-      setGigStatus('Attachment details saved.')
       setQuickAttachmentStatus(
         update.moved
-          ? 'Attachment moved and details saved.'
-          : 'Attachment details saved.'
+          ? 'Attachment moved and details saved. You can continue editing or go to the gig.'
+          : 'Attachment details saved. You can continue editing or go to the gig.'
       )
     } catch (error) {
-      setQuickAttachmentStatus(
-        error instanceof Error ? error.message : 'Unable to save attachment details.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to save attachment details.'
+      setQuickAttachmentStatus(message)
     } finally {
       setIsQuickAttachmentSaving(false)
     }

--- a/frontend/glovelly-web/src/hooks/useQuickReceipt.ts
+++ b/frontend/glovelly-web/src/hooks/useQuickReceipt.ts
@@ -28,7 +28,6 @@ export function useQuickReceipt({
   onOpenReceiptDraft,
   onSelectGig,
   onSessionExpired,
-  setGigStatus,
 }: UseQuickReceiptOptions) {
   const [pendingReceiptFile, setPendingReceiptFile] = useState<File | null>(null)
   const [quickReceiptDraft, setQuickReceiptDraft] =
@@ -131,15 +130,9 @@ export function useQuickReceipt({
           ? 'Receipt saved. There are other nearby gigs, so please check the selected gig.'
           : 'Receipt saved. Add details now or come back later.'
       )
-      setGigStatus(
-        receiptDraft.inferredGig
-          ? 'Receipt draft saved to the nearest matching gig.'
-          : 'Receipt draft saved. Add the amount and description when you are ready.'
-      )
     } catch (error) {
-      setQuickReceiptStatus(
-        error instanceof Error ? error.message : 'Unable to save receipt draft.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to save receipt draft.'
+      setQuickReceiptStatus(message)
     } finally {
       setIsQuickReceiptSaving(false)
     }
@@ -224,16 +217,14 @@ export function useQuickReceipt({
       )
       onSelectGig(update.gig.id)
       setQuickReceiptSelectedGigId(update.gig.id)
-      setGigStatus('Receipt details saved.')
       setQuickReceiptStatus(
         update.moved
-          ? 'Receipt moved and details saved.'
-          : 'Receipt details saved.'
+          ? 'Receipt moved and details saved. You can continue editing or go to the gig.'
+          : 'Receipt details saved. You can continue editing or go to the gig.'
       )
     } catch (error) {
-      setQuickReceiptStatus(
-        error instanceof Error ? error.message : 'Unable to save receipt details.'
-      )
+      const message = error instanceof Error ? error.message : 'Unable to save receipt details.'
+      setQuickReceiptStatus(message)
     } finally {
       setIsQuickReceiptSaving(false)
     }

--- a/frontend/glovelly-web/src/hooks/useSellerProfile.ts
+++ b/frontend/glovelly-web/src/hooks/useSellerProfile.ts
@@ -152,8 +152,8 @@ export function useSellerProfile({
       applySellerProfile(savedProfile)
       setSellerProfileStatus(
         savedProfile.isInvoiceReady
-          ? 'Seller profile updated and ready for invoice generation.'
-          : `Seller profile saved. Missing: ${savedProfile.missingFields.join(', ')}.`
+          ? 'Seller profile updated.'
+          : `Seller profile updated. Invoice-ready fields still missing: ${savedProfile.missingFields.join(', ')}.`
       )
     } catch (error) {
       setSellerProfileStatus(

--- a/frontend/glovelly-web/src/index.css
+++ b/frontend/glovelly-web/src/index.css
@@ -495,6 +495,44 @@ body::before {
   min-height: 100vh;
 }
 
+[data-sonner-toaster] {
+  --normal-bg: var(--surface-elevated);
+  --normal-border: var(--surface-border);
+  --normal-text: var(--text);
+  --success-bg: color-mix(in srgb, #3f8c68 16%, var(--surface-elevated));
+  --success-border: color-mix(in srgb, #3f8c68 42%, var(--surface-border));
+  --success-text: var(--text);
+  --info-bg: color-mix(in srgb, #326b99 16%, var(--surface-elevated));
+  --info-border: color-mix(in srgb, #326b99 42%, var(--surface-border));
+  --info-text: var(--text);
+  --error-bg: color-mix(in srgb, #b54b4b 18%, var(--surface-elevated));
+  --error-border: color-mix(in srgb, #b54b4b 48%, var(--surface-border));
+  --error-text: var(--text);
+  --border-radius: 16px;
+  font-family: var(--body);
+}
+
+[data-sonner-toast][data-styled='true'] {
+  box-shadow: var(--surface-shadow-strong);
+  font-size: 0.9rem;
+}
+
+[data-sonner-toast][data-styled='true'] [data-close-button] {
+  color: inherit;
+}
+
+[data-sonner-toast]:focus-visible,
+[data-sonner-toast][data-styled='true'] [data-close-button]:focus-visible {
+  box-shadow: var(--surface-shadow-strong), var(--focus-ring);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-sonner-toast],
+  [data-sonner-toast] > * {
+    transition: none !important;
+  }
+}
+
 h1,
 h2 {
   margin: 0;

--- a/frontend/glovelly-web/src/main.tsx
+++ b/frontend/glovelly-web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { loadAppMetadata } from './api'
+import { NotificationToaster } from './NotificationToaster'
 import { isThemePreference, themeStorageKey } from './theme'
 
 const applyInitialTheme = () => {
@@ -28,6 +29,7 @@ async function bootstrap() {
   root.render(
     <StrictMode>
       <App appMetadata={appMetadata} />
+      <NotificationToaster />
     </StrictMode>,
   )
 }

--- a/frontend/glovelly-web/src/notifications.test.ts
+++ b/frontend/glovelly-web/src/notifications.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  dismiss: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({ toast }))
+
+import { notifications } from './notifications'
+
+describe('notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses a semantic key to replace repeated success feedback', () => {
+    notifications.success('Receipt uploaded.', { dedupeKey: 'gig:receipt-upload' })
+
+    expect(toast.success).toHaveBeenCalledWith('Receipt uploaded.', {
+      duration: 5000,
+      id: 'gig:receipt-upload',
+    })
+  })
+
+  it('uses the standard information timeout', () => {
+    notifications.info('Invoice is ready for review.')
+
+    expect(toast.info).toHaveBeenCalledWith('Invoice is ready for review.', { duration: 6000 })
+  })
+
+  it('keeps errors visible until dismissed', () => {
+    notifications.error('Unable to download attachment file.', { dedupeKey: 'gig:attachment-download' })
+
+    expect(toast.error).toHaveBeenCalledWith('Unable to download attachment file.', {
+      duration: Infinity,
+      id: 'gig:attachment-download',
+    })
+  })
+
+  it('supports individual dismissal and session reset', () => {
+    notifications.dismiss('gig:attachment-download')
+    notifications.resetSession()
+
+    expect(toast.dismiss).toHaveBeenNthCalledWith(1, 'gig:attachment-download')
+    expect(toast.dismiss).toHaveBeenNthCalledWith(2)
+  })
+})

--- a/frontend/glovelly-web/src/notifications.ts
+++ b/frontend/glovelly-web/src/notifications.ts
@@ -1,0 +1,35 @@
+import { toast } from 'sonner'
+
+type NotificationOptions = {
+  dedupeKey?: string
+}
+
+const successDuration = 5000
+const infoDuration = 6000
+
+function getToastOptions(duration: number, options?: NotificationOptions) {
+  return {
+    duration,
+    ...(options?.dedupeKey ? { id: options.dedupeKey } : {}),
+  }
+}
+
+// Use notifications for terminal outcomes that outlive their initiating UI. Keep validation,
+// progress, durable warnings, and terminal feedback in still-open modals inline.
+export const notifications = {
+  success(message: string, options?: NotificationOptions) {
+    return toast.success(message, getToastOptions(successDuration, options))
+  },
+  info(message: string, options?: NotificationOptions) {
+    return toast.info(message, getToastOptions(infoDuration, options))
+  },
+  error(message: string, options?: NotificationOptions) {
+    return toast.error(message, getToastOptions(Infinity, options))
+  },
+  dismiss(dedupeKey?: string) {
+    toast.dismiss(dedupeKey)
+  },
+  resetSession() {
+    toast.dismiss()
+  },
+}

--- a/frontend/glovelly-web/src/types.ts
+++ b/frontend/glovelly-web/src/types.ts
@@ -55,6 +55,7 @@ export type GoogleCalendarStatus = {
   isConnected: boolean
   isEnabled: boolean
   hasRequiredScope: boolean
+  requiresReconnection: boolean
   calendarId: string | null
   calendarName: string | null
   lastSuccessfulSyncAtUtc: string | null

--- a/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/design.md
+++ b/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/design.md
@@ -1,0 +1,92 @@
+## Context
+
+Glovelly has no shared notification system. Workspace hooks and `App.tsx` maintain local mutable status strings that components render as `status-pill` elements. This is useful for validation, progress, and modal workflows, but terminal results are easily missed after navigation or modal dismissal and can be overwritten by another action.
+
+The change spans the React application shell, workspace hooks, presentational components, shared API error handling, browser UAT scenarios, and agent orientation guidance. The application uses plain React and CSS with no component library or state-management dependency. Existing modal overlays use `z-index: 80`; mobile fixed controls occupy the bottom of the viewport.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a single in-session notification mechanism for applicable terminal success, information, and error outcomes.
+- Migrate the full current set of applicable terminal outcomes across clients, gigs, invoices, quick capture, settings, seller profile, integrations, and admin workflows.
+- Keep errors visible until explicitly dismissed and make routine success/information messages self-clearing.
+- Preserve contextual inline validation, progress, multi-step workflow, and durable health/configuration feedback.
+- Make notifications accessible, mobile-safe, and available across workspace navigation and modal closure.
+- Update browser UAT documentation and agent orientation so future work applies the feedback policy consistently.
+
+**Non-Goals:**
+
+- Replacing form validation, progress displays, or persistent configuration/health warnings with toasts.
+- Persisting notifications through a browser reload, sign-out, or new session.
+- Introducing a general-purpose component library or state-management library beyond the focused Sonner notification dependency.
+- Retrofitting every existing API endpoint or adding an application-wide error boundary.
+- Adding retry behaviour where an existing operation does not already have a safe retry path.
+
+## Decisions
+
+### Use Sonner with a thin Glovelly policy wrapper
+
+Add the MIT-licensed, React 19-compatible `sonner` package. Mount its `Toaster` once at the frontend root beside `App`, configured for the global desktop and mobile placement, three visible notifications, a close button, and the Glovelly visual theme.
+
+Create a small Glovelly notification-policy wrapper around Sonner's `toast` API. It exposes success, information, error, dismissal, and session-reset operations to workspace hooks and components. The wrapper applies standard durations, uses `Infinity` for errors, and maps caller-provided semantic deduplication keys to Sonner toast IDs.
+
+Sonner supplies the presentation, visible-item limit, timeout handling, hover/focus pause, dismissal controls, interaction handling, and mobile offsets. The wrapper keeps Glovelly policy and library-specific calls out of business-workflow code, avoiding a bespoke context, queue, timer, portal, and event-store implementation.
+
+### Separate notification policy from local workflow state
+
+Use notifications for terminal outcomes only:
+
+- Success: completed create, save, delete, upload, download, delivery, or integration action.
+- Information: an important terminal outcome that is neither success nor failure.
+- Error: unexpected request failure or an error whose initiating view may close or change.
+
+Keep field validation, eligibility guidance, in-progress work, multi-step modal outcomes, and durable warnings in their current contextual UI. A migrated terminal outcome must not be announced both as a new toast and a redundant local status pill. Some operations can retain a local result where it remains materially useful, but the notification is the primary completion feedback.
+
+This is deliberately a policy-driven migration rather than a mechanical replacement of every `set*Status` call.
+
+### Queueing, deduplication, and lifetime
+
+Sonner is configured to show at most three notifications in its collapsed viewport while retaining additional notifications. Errors are never silently discarded.
+
+Callers can provide semantic deduplication keys such as `gig:<id>:attachment-download`. A matching notification replaces the prior notification and resets its timeout, preventing repeated operation feedback from stacking.
+
+Success notifications auto-dismiss after approximately five seconds; information notifications after approximately six seconds. Errors have no timeout and require explicit dismissal. Timed notifications pause while hovered or keyboard-focused. Notification state is cleared for a new unauthenticated session and is never stored in browser persistence.
+
+### Accessible, non-modal presentation
+
+Sonner provides a fixed non-modal notification viewport with a polite live region for all notification types. Persistent error notifications provide durable visual feedback without interrupting the user's current screen-reader task. Notifications never take focus; each has a keyboard-accessible dismiss button. The visible notification content is announced once rather than duplicated in a hidden live region.
+
+Desktop placement is top-right. Mobile placement is top-centre with safe-area insets and sufficient top offset to avoid the app header; bottom placement is avoided because of the existing fixed quick-action and return-to-top controls. The viewport itself does not intercept pointer events outside its notification cards. Motion respects `prefers-reduced-motion`.
+
+### Normalize error messages as each action is migrated
+
+Migrated actions use the existing authenticated fetch and Problem Details helpers where applicable. They show a user-safe server `detail`, validation message, or title when available, with an action-specific fallback. This includes converting expense-receipt downloads from a new-window navigation to the existing authenticated blob-download pattern, allowing the explicit missing-attachment response from issue #207 to reach the notification system.
+
+Avoid a broad unrelated API-error refactor. Correct error-message handling only at action paths included in the migration.
+
+### Treat UAT and agent orientation as delivery work
+
+Update the relevant `docs/uat/` scenarios to cover terminal notifications, persistent errors, contextual feedback that remains inline, modal/navigation continuity, and mobile placement. Update `AGENTS.md` with the Sonner configuration and Glovelly notification-wrapper locations and the toast-versus-inline policy so future agents add feedback consistently.
+
+## Risks / Trade-offs
+
+- [Notification fatigue from full migration] -> Limit messages to terminal outcomes, deduplicate repeated operations, and retain local feedback for guidance and progress.
+- [Duplicate or conflicting feedback during migration] -> Review each status call by category and remove redundant terminal status-pill rendering only after its toast path is in place.
+- [Screen-reader announcement noise] -> Use Sonner's single polite live region, announce visible content once, and retain important recovery guidance in contextual UI.
+- [Toasts obscure modal or mobile controls] -> Use a dedicated layer above overlays, a top-based responsive layout, safe-area spacing, and manual browser UAT verification.
+- [Concurrent operations overwrite feedback] -> Queue independent notifications rather than reuse one mutable workspace status string.
+- [Generic errors hide useful server detail] -> Migrate calls through the shared Problem Details helpers and test representative failure paths.
+- [UAT churn] -> Update scenarios alongside each workflow migration and run the browser suite iteratively rather than treating documentation as a final cleanup.
+
+## Migration Plan
+
+1. Add and verify Sonner, the Glovelly notification-policy wrapper, root toaster configuration, styles, accessibility, and focused wrapper tests.
+2. Migrate terminal feedback by workflow domain, removing only redundant status pills while retaining local progress, validation, and durable warnings.
+3. Convert browser attachment downloads to authenticated response handling and notify missing-file failures using the backend response from issue #207.
+4. Update UAT scenarios and `AGENTS.md`, then run frontend lint/build and the affected browser UAT coverage.
+5. Rollback is limited to reverting the frontend change; no server schema, persisted state, or API contract is introduced. Local contextual status remains available during incremental migration, reducing rollback risk.
+
+## Open Questions
+
+- None. The initial policy is to migrate all currently applicable terminal outcomes and extend the system for future suitable actions.

--- a/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/proposal.md
+++ b/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Glovelly currently reports many completed actions and failures through local, mutable status pills. Those messages can be difficult to find after navigation or a modal closes, and later operations can overwrite them. A global snackbar system will make applicable feedback consistently visible while retaining local feedback where the user needs context to act.
+
+## What Changes
+
+- Add a global, accessible snackbar notification system for in-session success, information, and error feedback using Sonner.
+- Show terminal outcomes for applicable create, save, delete, upload, download, delivery, and integration actions as snackbars across clients, gigs, invoices, quick capture, settings, seller profile, and admin workflows.
+- Keep errors visible until dismissed; auto-dismiss success and informational notifications.
+- Retain contextual inline feedback for validation, progress, multi-step modal workflows, and durable configuration or health warnings.
+- Standardize migrated API-error handling so user-safe Problem Details messages are shown when available.
+- Update browser UAT scenarios for the notification behaviour and update agent orientation guidance so future changes use the system consistently.
+
+## Capabilities
+
+### New Capabilities
+
+- `global-snackbar-notifications`: Provides accessible global notifications for applicable terminal user-action outcomes while preserving contextual feedback where required.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Frontend React application: Sonner integration, a Glovelly notification-policy wrapper, styling, and workspace action feedback.
+- Frontend dependency graph: add the MIT-licensed, React 19-compatible `sonner` package.
+- Frontend browser download handling for attachment failures, including missing attachment objects addressed by issue #207.
+- Existing frontend API error-message call sites as they are migrated.
+- UAT documentation and agent orientation files, especially `AGENTS.md`.

--- a/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/specs/global-snackbar-notifications/spec.md
+++ b/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/specs/global-snackbar-notifications/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Global terminal notifications
+The application SHALL provide an in-session global notification viewport for applicable terminal outcomes from authenticated workspace actions. The viewport SHALL remain available when the user changes workspace section or closes the modal that initiated the action.
+
+#### Scenario: Completed action after navigation
+- **WHEN** an applicable workspace action completes successfully and the user changes section before viewing its original status area
+- **THEN** the application SHALL show the completion notification in the global viewport
+
+#### Scenario: Completed action after modal closure
+- **WHEN** an applicable action initiated from a modal completes and the modal is closed
+- **THEN** the application SHALL retain the notification in the global viewport for its configured lifetime
+
+### Requirement: Notification severity and lifetime
+The application SHALL classify applicable terminal outcomes as success, information, or error. Success and information notifications SHALL auto-dismiss after a finite timeout. Error notifications SHALL remain visible until the user dismisses them.
+
+#### Scenario: Successful upload
+- **WHEN** an attachment upload completes successfully
+- **THEN** the application SHALL show a success notification that auto-dismisses
+
+#### Scenario: Failed download
+- **WHEN** an attachment download fails
+- **THEN** the application SHALL show an error notification that remains visible until dismissed
+
+### Requirement: Notification visibility and deduplication
+The application SHALL show no more than three notifications in its collapsed global viewport. It SHALL NOT silently discard an error notification when additional notifications exist. The application SHALL replace a prior notification when an action supplies the same semantic deduplication key.
+
+#### Scenario: Collapsed viewport receives an error
+- **WHEN** three notifications are visible and an action produces an error notification
+- **THEN** the application SHALL retain the error notification without silently discarding it
+
+#### Scenario: Repeated action feedback
+- **WHEN** an action emits a notification with the same semantic deduplication key as a visible notification
+- **THEN** the application SHALL update the existing notification instead of adding a duplicate
+
+### Requirement: Contextual feedback remains local
+The application SHALL retain contextual UI feedback for field validation, action progress, multi-step modal workflows, and durable configuration or health warnings. It SHALL NOT use a global notification as the sole feedback for those states.
+
+#### Scenario: Invalid form submission
+- **WHEN** a user submits a form with invalid or missing required values
+- **THEN** the application SHALL show the validation feedback in the relevant form context
+
+#### Scenario: Long-running modal workflow
+- **WHEN** a multi-step modal workflow is in progress
+- **THEN** the application SHALL show progress in the modal context
+
+### Requirement: Accessible and responsive notifications
+The application SHALL announce notifications through a polite live region. Notifications SHALL NOT move keyboard focus, SHALL provide an accessible dismiss control, SHALL respect reduced-motion preferences, and SHALL avoid obscuring fixed mobile controls.
+
+#### Scenario: Keyboard dismissal
+- **WHEN** a keyboard user reaches a visible notification
+- **THEN** the user SHALL be able to dismiss it through an accessible dismiss control without focus having been moved automatically
+
+#### Scenario: Mobile notification placement
+- **WHEN** the application is viewed on a mobile-width viewport
+- **THEN** the notification viewport SHALL be positioned so it does not obscure the fixed quick-action or return-to-top controls
+
+### Requirement: User-safe action failures
+For each migrated action, the application SHALL show the user-safe Problem Details message when the server provides one, otherwise it SHALL show an action-specific fallback. It SHALL NOT expose storage keys, internal exception details, or other implementation-sensitive information in a notification.
+
+#### Scenario: Missing attachment object
+- **WHEN** a user downloads an attachment whose metadata exists but whose stored object is unavailable
+- **THEN** the application SHALL show the server-provided missing-attachment message as an error notification
+
+#### Scenario: Generic request failure
+- **WHEN** a migrated action fails without a parseable user-safe server message
+- **THEN** the application SHALL show that action's fallback error notification

--- a/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/tasks.md
+++ b/openspec/changes/archive/2026-08-24-add-global-snackbar-notifications/tasks.md
@@ -1,0 +1,32 @@
+## 1. Sonner Integration
+
+- [x] 1.1 Add the `sonner` dependency and create a thin Glovelly notification-policy wrapper for success, information, error, dismissal, session reset, semantic deduplication, and standard durations.
+- [x] 1.2 Mount and configure Sonner's root `Toaster` with three visible notifications, polite announcements, close controls, and the Glovelly desktop/mobile placement.
+- [x] 1.3 Add responsive Sonner theme overrides, including reduced-motion support and safe placement above existing modal and fixed-control layers.
+- [x] 1.4 Add focused frontend tests for notification-policy deduplication, error persistence configuration, dismissal, and timeout selection using the existing Vitest setup.
+
+## 2. Shared Feedback Migration
+
+- [x] 2.1 Document the frontend Sonner toast-versus-inline feedback policy in the notification wrapper and identify redundant terminal `status-pill` rendering that can be removed without affecting validation, progress, or durable warnings.
+- [x] 2.2 Migrate client, client-settings, user-settings, seller-profile, connected-service, and admin terminal success/error outcomes to notifications, preserving contextual validation and configuration feedback.
+- [x] 2.3 Migrate gig create, update, delete, clone, expense, reimbursement, mileage, receipt, and external-resource attachment terminal outcomes to notifications while preserving editing and validation feedback.
+- [x] 2.4 Migrate invoice workflow, invoice generation, monthly invoice, preview, delivery, Drive, and adjustment terminal outcomes to notifications, keeping compound delivery and issue results distinct.
+- [x] 2.5 Migrate quick receipt, quick attachment, expense statement, forScore library, and other applicable modal terminal outcomes to notifications without replacing modal-local progress or recovery guidance.
+
+## 3. Error And Download Handling
+
+- [x] 3.1 Update each migrated request path to use user-safe Problem Details messages with action-specific fallbacks, without exposing internal implementation details.
+- [x] 3.2 Replace expense-receipt new-window downloads with authenticated response/blob downloads and send both receipt and external-resource attachment terminal outcomes through notifications.
+- [x] 3.3 Verify missing attachment objects return the issue #207 message in a persistent error notification and preserve existing session-expiry handling.
+
+## 4. UAT And Agent Guidance
+
+- [x] 4.1 Update affected `docs/uat/` scenarios to assert discoverable terminal notifications, persistent errors, navigation/modal continuity, and the retained inline validation/progress behaviour.
+- [x] 4.2 Add mobile UAT coverage confirming notifications do not obscure fixed quick-action or return-to-top controls.
+- [x] 4.3 Update `AGENTS.md` with the Sonner configuration and Glovelly notification-wrapper locations, the toast-versus-inline policy, and UAT expectations for future frontend changes.
+
+## 5. Verification
+
+- [x] 5.1 Run frontend unit tests, lint, and build; resolve any migration regressions.
+- [x] 5.2 Run the affected browser UAT coverage iteratively and resolve notification-related expectation or interaction failures.
+- [x] 5.3 Run `./verify.sh` and perform desktop/mobile manual accessibility checks for notification announcement, keyboard dismissal, modal stacking, and reduced motion.

--- a/openspec/specs/global-snackbar-notifications/spec.md
+++ b/openspec/specs/global-snackbar-notifications/spec.md
@@ -1,0 +1,79 @@
+## Purpose
+
+Provide global, accessible terminal notifications for authenticated workspace actions while preserving contextual feedback where it is needed.
+
+## Requirements
+
+### Requirement: Global terminal notifications
+The application SHALL provide an in-session global notification viewport for applicable terminal outcomes from authenticated workspace actions. The viewport SHALL remain available when the user changes workspace section or closes the modal that initiated the action.
+
+#### Scenario: Completed action after navigation
+- **WHEN** an applicable workspace action completes successfully and the user changes section before viewing its original status area
+- **THEN** the application SHALL show the completion notification in the global viewport
+
+#### Scenario: Completed action after modal closure
+- **WHEN** an applicable action initiated from a modal completes and the modal is closed
+- **THEN** the application SHALL retain the notification in the global viewport for its configured lifetime
+
+### Requirement: Notification severity and lifetime
+The application SHALL classify applicable terminal outcomes as success, information, or error. Success and information notifications SHALL auto-dismiss after a finite timeout. Error notifications SHALL remain visible until the user dismisses them.
+
+#### Scenario: Successful upload
+- **WHEN** an attachment upload completes successfully
+- **THEN** the application SHALL show a success notification that auto-dismisses
+
+#### Scenario: Failed download
+- **WHEN** an attachment download fails
+- **THEN** the application SHALL show an error notification that remains visible until dismissed
+
+### Requirement: Notification visibility and deduplication
+The application SHALL show no more than three notifications in its collapsed global viewport. It SHALL NOT silently discard an error notification when additional notifications exist. The application SHALL replace a prior notification when an action supplies the same semantic deduplication key.
+
+#### Scenario: Collapsed viewport receives an error
+- **WHEN** three notifications are visible and an action produces an error notification
+- **THEN** the application SHALL retain the error notification without silently discarding it
+
+#### Scenario: Repeated action feedback
+- **WHEN** an action emits a notification with the same semantic deduplication key as a visible notification
+- **THEN** the application SHALL update the existing notification instead of adding a duplicate
+
+### Requirement: Contextual feedback remains local
+The application SHALL retain contextual UI feedback for field validation, action progress, multi-step modal workflows, durable configuration or health warnings, and terminal outcomes from actions whose initiating modal remains open. It SHALL NOT use a global notification as the sole feedback for those states.
+
+#### Scenario: Invalid form submission
+- **WHEN** a user submits a form with invalid or missing required values
+- **THEN** the application SHALL show the validation feedback in the relevant form context
+
+#### Scenario: Long-running modal workflow
+- **WHEN** a multi-step modal workflow is in progress
+- **THEN** the application SHALL show progress in the modal context
+
+#### Scenario: Completed action in an open modal
+- **WHEN** an action completes and its initiating modal remains open
+- **THEN** the application SHALL show its terminal outcome in the modal context without a competing global notification
+
+### Requirement: Accessible and responsive notifications
+The application SHALL announce notifications through a polite live region. Notifications SHALL NOT move keyboard focus, SHALL provide an accessible dismiss control, SHALL respect reduced-motion preferences, and SHALL avoid obscuring fixed mobile controls.
+
+#### Scenario: Keyboard dismissal
+- **WHEN** a keyboard user reaches a visible notification
+- **THEN** the user SHALL be able to dismiss it through an accessible dismiss control without focus having been moved automatically
+
+#### Scenario: Mobile notification placement
+- **WHEN** the application is viewed on a mobile-width viewport
+- **THEN** the notification viewport SHALL be positioned so it does not obscure the fixed quick-action or return-to-top controls
+
+#### Scenario: Open modal with a persistent notification
+- **WHEN** a global notification remains active while the user opens a modal
+- **THEN** the modal overlay SHALL render above the notification viewport so the notification cannot block modal controls
+
+### Requirement: User-safe action failures
+For each migrated action, the application SHALL show the user-safe Problem Details message when the server provides one, otherwise it SHALL show an action-specific fallback. It SHALL NOT expose storage keys, internal exception details, or other implementation-sensitive information in a notification.
+
+#### Scenario: Missing attachment object
+- **WHEN** a user downloads an attachment whose metadata exists but whose stored object is unavailable
+- **THEN** the application SHALL show the server-provided missing-attachment message as an error notification
+
+#### Scenario: Generic request failure
+- **WHEN** a migrated action fails without a parseable user-safe server message
+- **THEN** the application SHALL show that action's fallback error notification

--- a/tests/Glovelly.Uat.Tests/CoreInvoiceWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/CoreInvoiceWorkflowTests.cs
@@ -46,7 +46,7 @@ public sealed class CoreInvoiceWorkflowTests : InvoiceUatTestBase
         try
         {
             await Page.GetByTestId("invoice-send-button").ClickAsync();
-            await ExpectContainsAsync(Page.GetByTestId("invoice-status"), "delivered and left as Draft");
+            await ExpectNotificationAsync("delivered and left as Draft", "info");
         }
         finally
         {

--- a/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoiceLineRefreshWorkflowTests.cs
@@ -169,6 +169,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                 await OpenInvoiceLinesAsync();
                 await AssertInvoiceLineTypeCountAsync("Mileage", 1);
 
+                await ExpectNotificationAsync("address not found", "error");
                 await SaveUserMileageSettingsViaUiAsync(mileageRate: string.Empty, passengerMileageRate: string.Empty, travelOriginPostcode: string.Empty);
                 await PutSellerProfileAsync(postcode: string.Empty);
                 await CreateGigAsync(
@@ -181,11 +182,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                 await Page.GetByTestId("gig-driving-checkbox").CheckAsync();
                 await Page.GetByTestId("gig-travel-miles-input").FillAsync("12");
                 await Page.GetByTestId("gig-estimate-mileage-button").ClickAsync();
-                await Assertions.Expect(Page.GetByTestId("gig-status")).ToContainTextAsync("travel origin postcode", new LocatorAssertionsToContainTextOptions
-                {
-                    Timeout = 30_000,
-                    IgnoreCase = true,
-                });
+                await ExpectNotificationAsync("travel origin postcode", "error");
                 await Assertions.Expect(Page.GetByTestId("gig-travel-miles-input")).ToHaveValueAsync("12");
             }
             finally
@@ -218,10 +215,15 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
 
         while (DateTime.UtcNow < deadline)
         {
-            lastStatus = await Page.GetByTestId("gig-status").InnerTextAsync();
-            if (expectedFragments.Any(fragment => lastStatus.Contains(fragment, StringComparison.OrdinalIgnoreCase)))
+            var notifications = Page.Locator("[data-sonner-toast][data-type='error']");
+            var count = await notifications.CountAsync();
+            if (count > 0)
             {
-                return;
+                lastStatus = await notifications.Last.InnerTextAsync();
+                if (expectedFragments.Any(fragment => lastStatus.Contains(fragment, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
             }
 
             await Task.Delay(500, TestContext.Current.CancellationToken);
@@ -259,7 +261,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
 
             AssertRedraftSucceeded(redraftResponse);
             await AssertRedraftedInvoiceLinePresenceAsync(redraftResponse, expenseDescription, status != "Reimbursed");
-            await ExpectContainsAsync(Page.GetByTestId("gig-status"), "regenerated");
+            await ExpectNotificationAsync("regenerated", "info");
         }
         finally
         {
@@ -310,7 +312,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
                 async () => await Page.GetByTestId("gig-save-close-button").ClickAsync());
 
             AssertRedraftSucceeded(redraftResponse);
-            await ExpectContainsAsync(Page.GetByTestId("gig-status"), "regenerated");
+            await ExpectNotificationAsync("regenerated", "info");
         }
         finally
         {
@@ -389,11 +391,7 @@ public sealed class InvoiceLineRefreshWorkflowTests : InvoiceUatTestBase
         await Page.GetByTestId("user-settings-passenger-mileage-rate-input").FillAsync(passengerMileageRate);
         await Page.GetByTestId("user-settings-travel-origin-postcode-input").FillAsync(travelOriginPostcode);
         await Page.GetByTestId("user-settings-save-button").ClickAsync();
-        await Assertions.Expect(Page.GetByTestId("user-settings-status")).ToContainTextAsync("updated", new LocatorAssertionsToContainTextOptions
-        {
-            IgnoreCase = true,
-            Timeout = 30_000,
-        });
+        await Assertions.Expect(Page.GetByTestId("user-settings-status")).ToContainTextAsync("Settings updated.");
         await Page.GetByRole(AriaRole.Button, new() { Name = "Close" }).ClickAsync();
     }
 

--- a/tests/Glovelly.Uat.Tests/InvoicePreviewWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoicePreviewWorkflowTests.cs
@@ -42,11 +42,7 @@ public sealed class InvoicePreviewWorkflowTests : InvoiceUatTestBase
         try
         {
             await Page.GetByTestId("invoice-status-select").SelectOptionAsync(new[] { "Issued" });
-            await Assertions.Expect(Page.GetByTestId("invoice-status")).ToContainTextAsync("issued", new LocatorAssertionsToContainTextOptions
-            {
-                IgnoreCase = true,
-                Timeout = 30_000,
-            });
+            await ExpectNotificationAsync("issued", "success");
         }
         finally
         {

--- a/tests/Glovelly.Uat.Tests/InvoicePromptChoiceTests.cs
+++ b/tests/Glovelly.Uat.Tests/InvoicePromptChoiceTests.cs
@@ -31,11 +31,7 @@ public sealed class InvoicePromptChoiceTests : InvoiceUatTestBase
                 await DismissNextDialogAsync(async () => await Page.GetByTestId("invoice-status-select").SelectOptionAsync("Issued"));
             }
 
-            await Assertions.Expect(Page.GetByTestId("invoice-status")).ToContainTextAsync("issued", new LocatorAssertionsToContainTextOptions
-            {
-                IgnoreCase = true,
-                Timeout = 30_000,
-            });
+            await ExpectNotificationAsync("issued", "success");
             await OpenGigAsync(gigTitle);
             await Assertions.Expect(Page.GetByTestId("selected-gig-status")).ToContainTextAsync(expectedGigStatus, new LocatorAssertionsToContainTextOptions
             {

--- a/tests/Glovelly.Uat.Tests/UatTestBase.cs
+++ b/tests/Glovelly.Uat.Tests/UatTestBase.cs
@@ -14,6 +14,17 @@ public abstract class UatTestBase : IAsyncLifetime
 
     protected IPage Page => page ?? throw new InvalidOperationException("The Playwright page has not been initialized.");
 
+    protected Task ExpectNotificationAsync(string message, string type)
+    {
+        return Assertions.Expect(Page.Locator($"[data-sonner-toast][data-type='{type}']").Filter(new LocatorFilterOptions
+        {
+            HasText = message,
+        })).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions
+        {
+            Timeout = 30_000,
+        });
+    }
+
     public async ValueTask InitializeAsync()
     {
         playwright = await Playwright.CreateAsync();

--- a/tests/Glovelly.Uat.Tests/UploadAndQuickCaptureWorkflowTests.cs
+++ b/tests/Glovelly.Uat.Tests/UploadAndQuickCaptureWorkflowTests.cs
@@ -45,8 +45,15 @@ public sealed class UploadAndQuickCaptureWorkflowTests : InvoiceUatTestBase
             await Assertions.Expect(expenseRow.GetByTestId("gig-expense-reimbursement-select")).ToHaveValueAsync("Unreimbursed");
 
             await Page.GetByTestId("add-gig-attachment-button").ClickAsync();
-            await Page.GetByTestId("gig-attachment-type-select").SelectOptionAsync("File");
+            await Page.GetByTestId("gig-attachment-type-select").SelectOptionAsync("Url");
             await Page.GetByTestId("gig-attachment-title-input").FillAsync(attachmentTitle);
+            await Page.GetByTestId("gig-attachment-url-input").FillAsync("ftp://example.com/contract");
+            await Page.GetByText("Add attachment", new PageGetByTextOptions { Exact = true }).Last.ClickAsync();
+            await Assertions.Expect(Page.GetByTestId("gig-attachment-status")).ToContainTextAsync(
+                "URL must be an absolute http or https URL.",
+                new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+            await Assertions.Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
+            await Page.GetByTestId("gig-attachment-url-input").FillAsync("https://example.com/contract");
             await Page.GetByText("Add attachment", new PageGetByTextOptions { Exact = true }).Last.ClickAsync();
 
             var attachmentRow = Page.GetByTestId("gig-attachment-item").Filter(new LocatorFilterOptions


### PR DESCRIPTION
## Summary
- make Google Calendar permission failures recoverable and supersede stale sync failures
- return and log safe 404s for attachment metadata whose backing blob is missing
- add Sonner notifications for terminal frontend outcomes, including persistent errors and authenticated receipt downloads
- update UAT coverage and agent guidance for notification behaviour

## Verification
- `./verify.sh`
- `dotnet build tests/Glovelly.Uat.Tests/Glovelly.Uat.Tests.csproj`
- `npm audit --omit=dev --audit-level=moderate`

## Follow-up Verification
- Playwright UAT execution and desktop/mobile manual accessibility checks require staging UAT credentials, which were unavailable locally.