### PR TITLE
chore: restore Gemini review acknowledgement

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
+      issues: 'write'
+      pull-requests: 'write'
     outputs:
       additional_context: '${{ steps.extract_context.outputs.additional_context }}'
     steps:
@@ -46,6 +48,30 @@ jobs:
               ? request.slice(command.length).trim()
               : '';
             core.setOutput('additional_context', additionalContext);
+
+      - name: 'Mint identity token'
+        id: 'mint_identity_token'
+        if: |-
+          ${{ vars.APP_ID }}
+        uses: 'actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf' # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: '${{ vars.APP_ID }}'
+          private-key: '${{ secrets.APP_PRIVATE_KEY }}'
+          permission-contents: 'read'
+          permission-issues: 'write'
+          permission-pull-requests: 'write'
+
+      - name: 'Acknowledge review request'
+        env:
+          GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          MESSAGE: |-
+            🤖 Hi @${{ github.actor }}, I've received your request, and I'm working on it now! You can track my progress [in the logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+          REPOSITORY: '${{ github.repository }}'
+        run: |-
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body "${MESSAGE}" \
+            --repo "${REPOSITORY}"
 
   review:
     needs: 'dispatch'


### PR DESCRIPTION
## Summary

Restores the acknowledgement comment that was removed when the Gemini dispatcher was narrowed to PR reviews.

The acknowledgement is posted for every permitted review run: automatic review on PR open and trusted `@gemini-cli /review` re-reviews.

## Validation

- Preserves the fixed YAML quoting for the request expression.
- Uses the existing GitHub App token flow and write permissions from the prior dispatcher.